### PR TITLE
Fix docker image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY        ?= stackset-controller
 VERSION       ?= $(shell git describe --tags --always --dirty)
-IMAGE         ?= teapot/$(BINARY)
+IMAGE         ?= registry-write.opensource.zalan.do/teapot/$(BINARY)
 TAG           ?= $(VERSION)
 SOURCES       = $(shell find . -name '*.go')
 GENERATED     = pkg/client pkg/apis/zalando/v1/zz_generated.deepcopy.go

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -9,9 +9,11 @@ pipeline:
   commands:
   - desc: install deps
     cmd: |
+      go get -u golang.org/x/lint/golint
       dep ensure -v -vendor-only
   - desc: test
     cmd: |
+      export PATH=$GOPATH/bin:$PATH
       make check
       make test
   - desc: build


### PR DESCRIPTION
Uses the full name for the docker image.

(This is mostly to validate that the CDP build is in fact working, and procrastination for finishing my KubeCon proposal :P)