### PR TITLE
Make it possible to run multiple controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ After the CRDs are install the controller can be deployed:
 $ kubectl apply -f docs/deployment.yaml
 ```
 
+### Custom configuration
+
+## controller-id
+
+There are cases where it might be desirable to run multiple instances of the
+stackset-controller in the same cluster, e.g. for development.
+
+To prevent the controllers from fighting over the same `StackSet` resources
+they can be configured with the flag `--controller-id=<some-id>` which
+indicates that the controller should only manage the `StackSets` which has an
+annotation `stackset-controller.zalando.org/controller=<some-id>` defined.
+If the controller-id is not configured, the controller will manage all
+`StackSets` which does not have the annotation defined.
+
 ## Quick intro
 
 Once you have deployed the controller you can create your first `StackSet`

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -109,9 +109,8 @@ func (c *StackSetController) Run(ctx context.Context) {
 				continue
 			}
 
-			// check if stackset should be managed by the
-			// controller
-			if !c.shouldManage(&stackset) {
+			// check if stackset should be managed by the controller
+			if !c.hasOwnership(&stackset) {
 				continue
 			}
 
@@ -162,12 +161,12 @@ func (c *StackSetController) Run(ctx context.Context) {
 	}
 }
 
-// shouldManage returns true if the controller should manage the stackset.
-// Whether it should manage is determined by the value of the
+// hasOwnership returns true if the controller is the "owner" of the stackset.
+// Whether it's owner is determined by the value of the
 // 'stackset-controller.zalando.org/controller' annotation. If the value
-// matches the controllerID then it should manage it, or if the controllerID is
+// matches the controllerID then it owns it, or if the controllerID is
 // "" and there's no annotation set.
-func (c *StackSetController) shouldManage(stackset *zv1.StackSet) bool {
+func (c *StackSetController) hasOwnership(stackset *zv1.StackSet) bool {
 	if stackset.Annotations != nil {
 		if owner, ok := stackset.Annotations[stacksetControllerControllerAnnotationKey]; ok {
 			return owner == c.controllerID

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 		StackMinGCAge           time.Duration
 		NoTrafficScaledownTTL   time.Duration
 		NoTrafficTerminationTTL time.Duration
+		ControllerID            string
 	}
 )
 
@@ -50,6 +51,7 @@ func main() {
 	kingpin.Flag("no-traffic-scaledown-ttl", "Default TTL for scaling down deployments not getting any traffic.").Default(defaultNoTrafficScaledownTTL.String()).DurationVar(&config.NoTrafficScaledownTTL)
 	kingpin.Flag("no-traffic-termination-ttl", "Default TTL for terminating deployments after they are not getting any traffic.").Default(defaultNoTrafficTerminationTTL.String()).DurationVar(&config.NoTrafficTerminationTTL)
 	kingpin.Flag("metrics-address", "defines where to serve metrics").Default(defaultMetricsAddress).StringVar(&config.MetricsAddress)
+	kingpin.Flag("controller-id", "ID of the controller used to determine ownership of StackSet resources").StringVar(&config.ControllerID)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -75,6 +77,7 @@ func main() {
 	controller := controller.NewStackSetController(
 		client,
 		stacksetClient,
+		config.ControllerID,
 		config.StackMinGCAge,
 		config.NoTrafficScaledownTTL,
 		config.NoTrafficTerminationTTL,


### PR DESCRIPTION
This makes it possible to run multiple controllers in a single cluster.

This is possible by defining a `controller-id` for the stackset-controller which means it will only manage `StackSets` where the annotation `stackset-controller.zalando.org/controller` is defined with a value matching the `controller-id`.

Fix #28