### PR TITLE
#8 support stackLifecycle to make autocleanup work

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -253,8 +253,8 @@ func (c *StackController) manageDeployment(stack zv1.Stack, traffic map[string]T
 						)
 					}
 				}
+				return nil
 			}
-			return nil
 
 		} else {
 			deployment.Annotations[noTrafficSinceAnnotationKey] = time.Now().UTC().Format(time.RFC3339)

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -97,7 +97,7 @@ func (c *StackSetController) Run(ctx context.Context) {
 
 			noTrafficScaledownTTL := c.noTrafficScaledownTTL
 			if ttlSec := stackset.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
-				noTrafficScaledownTTL = ttlSec
+				noTrafficScaledownTTL = time.Second * time.Duration(*ttlSec)
 			}
 
 			// set default ingress backend port if not specified.

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -99,6 +99,11 @@ func (c *StackSetController) Run(ctx context.Context) {
 			stackset.APIVersion = "zalando.org/v1"
 			stackset.Kind = "StackSet"
 
+			noTrafficScaledownTTL := c.noTrafficScaledownTTL
+			if ttlSec := stackset.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
+				noTrafficScaledownTTL = ttlSec
+			}
+
 			// set default ingress backend port if not specified.
 			if stackset.Spec.Ingress != nil && intOrStrIsEmpty(stackset.Spec.Ingress.BackendPort) {
 				stackset.Spec.Ingress.BackendPort = defaultBackendPort
@@ -139,7 +144,7 @@ func (c *StackSetController) Run(ctx context.Context) {
 
 			stackControllerDone := make(chan struct{}, 1)
 			entry.Done = append(entry.Done, stackControllerDone)
-			stackController := NewStackController(c.kube, c.appClient, stackset, stackControllerDone, c.noTrafficScaledownTTL, c.noTrafficTerminationTTL, c.interval)
+			stackController := NewStackController(c.kube, c.appClient, stackset, stackControllerDone, noTrafficScaledownTTL, c.interval)
 			go stackController.Run(ctx)
 
 			ingressControllerDone := make(chan struct{}, 1)


### PR DESCRIPTION
#8 support stackLifecycle to make autocleanup work

Instead of using a fixed scaledownTTLSeconds for all stackset get the value if defined from the stackLifecycle spec. The `limit`was already used correctly.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>