### PR TITLE
refactor: Improve controller performance

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,240 +2,347 @@
 
 
 [[projects]]
+  digest = "1:c06d9e11d955af78ac3bbb26bd02e01d2f61f689e1a3bce2ef6fb683ef8a7f2d"
   name = "github.com/alecthomas/kingpin"
   packages = ["."]
+  pruneopts = "UT"
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = "UT"
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c198fdc381e898e8fb62b8eb62758195091c313ad18e52a3067366e1dda2fb3c"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:db2e37856e0f3e8ad322792ca2ede9bcf821f4d482ca0ef300e6a9d85776a99a"
+  name = "github.com/go-kit/kit"
+  packages = [
+    "log",
+    "log/level",
+  ]
+  pruneopts = "UT"
+  revision = "ca4112baa34cb55091301bdc13b1420a122b1b9e"
+  version = "v0.7.0"
+
+[[projects]]
+  digest = "1:31a18dae27a29aa074515e43a443abfd2ba6deb6d69309d8d7ce789c45f34659"
+  name = "github.com/go-logfmt/logfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
+  version = "v0.3.0"
+
+[[projects]]
+  digest = "1:c4a2528ccbcabf90f9f3c464a5fc9e302d592861bbfd0b7135a7de8a943d0406"
+  name = "github.com/go-stack/stack"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
+  version = "v1.7.0"
+
+[[projects]]
+  digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "UT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:21313498d530ee0767fca8e8e9f27782d713b38a695e1cc81c1d194ddc3d896a"
   name = "github.com/golang/glog"
   packages = ["."]
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+  pruneopts = "UT"
+  revision = "6267c4c0b15dec7005db4ba9d428d39237c442bc"
+  source = "github.com/kubermatic/glog-gokit"
 
 [[projects]]
+  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9887333bbef17574b1db5f9893ea137ac44107235d624408a3ac9e0b98fbb2cb"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
+  digest = "1:d2754cafcab0d22c13541618a8029a70a8959eb3525ff201fe971637e2274cd0"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/cmpopts",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "UT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:86c1210529e69d69860f2bb3ee9ccce0b595aa3f9165e7dd1388e5c612915888"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "UT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
+  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "UT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  digest = "1:3e260afa138eab6492b531a3b3d10ab4cb70512d423faa78b8949dec76e66a21"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "UT"
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
+  digest = "1:bb3cc4c1b21ea18cfa4e3e47440fc74d316ab25b0cf42927e8c1274917bd9891"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a64e323dc06b73892e5bb5d040ced475c4645d456038333883f58934abbf6f72"
+  name = "github.com/kr/logfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "UT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:0e7775ebbcf00d8dd28ac663614af924411c868dca3d5aa762af0fae3808d852"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "UT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:e469cd65badf7694aeb44874518606d93c1d59e7735d3754ad442782437d3cc3"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "UT"
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:20d9bb50dbee172242f9bcd6ec24a917dd7a5bb17421bf16a79c33111dea7db1"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "UT"
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:6825aeffd9e88e2da7fe95bf767528e0c813d81dab2423d2a4e16ab3acdf05bf"
   name = "golang.org/x/net"
   packages = [
     "context",
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = "UT"
   revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
 
 [[projects]]
   branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  pruneopts = "UT"
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3364d01296ce7eeca363e3d530ae63a2092d6f8efb85fb3d101e8f6d7de83452"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -251,37 +358,47 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "UT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
+  digest = "1:c06d9e11d955af78ac3bbb26bd02e01d2f61f689e1a3bce2ef6fb683ef8a7f2d"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3b4f29485072d6af75536e5dd9d5480400e083a4ff685638d6793c27eab8dcd3"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -312,11 +429,13 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "UT"
   revision = "183f3326a9353bd6d41430fc80f96259331d029c"
 
 [[projects]]
+  digest = "1:b7a7277a24d4ca275a5c8d45dcfd90847fbbfdcd6b0bf43f23777a628cd9515c"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -359,11 +478,13 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "UT"
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
 
 [[projects]]
+  digest = "1:b8509f91be64147570516a1da9f16f30addebae75744064a7bc0b52afe82f20c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -423,20 +544,56 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/retry"
+    "util/retry",
   ]
+  pruneopts = "UT"
   revision = "7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65"
   version = "v8.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
+  pruneopts = "UT"
   revision = "d8ea2fe547a448256204cfc68dfee7b26c720acb"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3d0eb779292e54a39dae0d5a7dc175947a06b7b9d6043dde0e3ac94cd8914d45"
+  input-imports = [
+    "github.com/alecthomas/kingpin",
+    "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/sirupsen/logrus",
+    "golang.org/x/sync/errgroup",
+    "gopkg.in/alecthomas/kingpin.v2",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/autoscaling/v2beta1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/fields",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/transport",
+    "k8s.io/client-go/util/flowcontrol",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
+[[override]]
+  name = "github.com/golang/glog"
+  source = "github.com/kubermatic/glog-gokit"
+
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "0.8.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,3 @@
-[[override]]
-  name = "github.com/golang/glog"
-  source = "github.com/kubermatic/glog-gokit"
-
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "0.8.0"

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -151,7 +151,7 @@ func (c *ingressReconciler) getStackStatuses(stacks map[types.UID]*StackContaine
 
 		// check that service has at least one endpoint, otherwise it
 		// should not get traffic.
-		endpoints := stack.Deployment.Endpoints
+		endpoints := stack.Resources.Endpoints
 		if endpoints == nil {
 			status.Available = false
 		} else {

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -231,8 +231,15 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 	}
 
 	if !reflect.DeepEqual(newStatus, stack.Status) {
+		c.logger.Infof(
+			"Status changed for Stack %s/%s: %#v -> %#v",
+			stack.Namespace,
+			stack.Name,
+			stack.Status,
+			newStatus,
+		)
 		stack.Status = newStatus
-		// TODO: log the change in status
+
 		// update status of stack
 		_, err = c.appClient.ZalandoV1().Stacks(stack.Namespace).UpdateStatus(&stack)
 		if err != nil {

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -499,6 +499,40 @@ func applyPodTemplateSpecDefaults(template v1.PodTemplateSpec) v1.PodTemplateSpe
 		if container.ImagePullPolicy == "" {
 			newTemplate.Spec.Containers[i].ImagePullPolicy = v1.PullIfNotPresent
 		}
+		if container.ReadinessProbe != nil {
+			if container.ReadinessProbe.Handler.HTTPGet != nil && container.ReadinessProbe.Handler.HTTPGet.Scheme == "" {
+				newTemplate.Spec.Containers[i].ReadinessProbe.Handler.HTTPGet.Scheme = v1.URISchemeHTTP
+			}
+			if container.ReadinessProbe.TimeoutSeconds == 0 {
+				newTemplate.Spec.Containers[i].ReadinessProbe.TimeoutSeconds = 1
+			}
+			if container.ReadinessProbe.PeriodSeconds == 0 {
+				newTemplate.Spec.Containers[i].ReadinessProbe.PeriodSeconds = 10
+			}
+			if container.ReadinessProbe.SuccessThreshold == 0 {
+				newTemplate.Spec.Containers[i].ReadinessProbe.SuccessThreshold = 1
+			}
+			if container.ReadinessProbe.FailureThreshold == 0 {
+				newTemplate.Spec.Containers[i].ReadinessProbe.FailureThreshold = 3
+			}
+		}
+		if container.LivenessProbe != nil {
+			if container.LivenessProbe.Handler.HTTPGet != nil && container.LivenessProbe.Handler.HTTPGet.Scheme == "" {
+				newTemplate.Spec.Containers[i].LivenessProbe.Handler.HTTPGet.Scheme = v1.URISchemeHTTP
+			}
+			if container.LivenessProbe.TimeoutSeconds == 0 {
+				newTemplate.Spec.Containers[i].LivenessProbe.TimeoutSeconds = 1
+			}
+			if container.LivenessProbe.PeriodSeconds == 0 {
+				newTemplate.Spec.Containers[i].LivenessProbe.PeriodSeconds = 10
+			}
+			if container.LivenessProbe.SuccessThreshold == 0 {
+				newTemplate.Spec.Containers[i].LivenessProbe.SuccessThreshold = 1
+			}
+			if container.LivenessProbe.FailureThreshold == 0 {
+				newTemplate.Spec.Containers[i].LivenessProbe.FailureThreshold = 3
+			}
+		}
 	}
 	if newTemplate.Spec.RestartPolicy == "" {
 		newTemplate.Spec.RestartPolicy = v1.RestartPolicyAlways

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -1,10 +1,7 @@
 package controller
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"math"
 	"reflect"
 	"time"
 
@@ -16,10 +13,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 )
@@ -28,81 +23,36 @@ const (
 	noTrafficSinceAnnotationKey = "stacksetstacks.zalando.org/no-traffic-since"
 )
 
-// StackController is a controller for managing StackSet Stack
-// resources like Deployment and Service.
-type StackController struct {
-	logger                *log.Entry
-	kube                  kubernetes.Interface
-	appClient             clientset.Interface
-	stackset              zv1.StackSet
-	noTrafficScaledownTTL time.Duration
-	interval              time.Duration
-	done                  chan<- struct{}
+// stacksReconciler is able to bring a set of Stacks of a StackSet to the
+// desired state. This includes managing, Deployment, Service and HPA resources
+// of the Stacks.
+type stacksReconciler struct {
+	logger    *log.Entry
+	kube      kubernetes.Interface
+	appClient clientset.Interface
 }
 
-// NewStackController initializes a new StackController.
-func NewStackController(client kubernetes.Interface, appClient clientset.Interface, stackset zv1.StackSet, done chan<- struct{}, noTrafficScaledownTTL, interval time.Duration) *StackController {
-	return &StackController{
+// ReconcileStacks brings a set of Stacks of a StackSet to the desired state.
+func (c *StackSetController) ReconcileStacks(ssc StackSetContainer) error {
+	sr := &stacksReconciler{
 		logger: log.WithFields(
 			log.Fields{
-				"controller": "stack",
-				"stackset":   stackset.Name,
-				"namespace":  stackset.Namespace,
+				"controller": "stacks",
+				"stackset":   ssc.StackSet.Name,
+				"namespace":  ssc.StackSet.Namespace,
 			},
 		),
-		kube:                  client,
-		appClient:             appClient,
-		stackset:              stackset,
-		noTrafficScaledownTTL: noTrafficScaledownTTL,
-		done:     done,
-		interval: interval,
+		kube:      c.kube,
+		appClient: c.appClient,
 	}
+	return sr.reconcile(ssc)
 }
 
-// Run runs the Stack Controller control loop.
-func (c *StackController) Run(ctx context.Context) {
-	for {
-		err := c.runOnce()
+func (c *stacksReconciler) reconcile(ssc StackSetContainer) error {
+	for _, sc := range ssc.StackContainers {
+		err := c.manageStack(*sc, ssc)
 		if err != nil {
-			c.logger.Error(err)
-		}
-
-		select {
-		case <-time.After(c.interval):
-		case <-ctx.Done():
-			c.logger.Info("Terminating Stack Controller.")
-			c.done <- struct{}{}
-			return
-		}
-	}
-}
-
-// runOnce runs one loop of the Stack Controller.
-func (c *StackController) runOnce() error {
-	heritageLabels := map[string]string{
-		stacksetHeritageLabelKey: c.stackset.Name,
-	}
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Set(heritageLabels).String(),
-	}
-
-	stacks, err := c.appClient.ZalandoV1().Stacks(c.stackset.Namespace).List(opts)
-	if err != nil {
-		return fmt.Errorf("failed to list Stacks of StackSet %s/%s: %v", c.stackset.Namespace, c.stackset.Name, err)
-	}
-
-	var traffic map[string]TrafficStatus
-	if c.stackset.Spec.Ingress != nil && len(stacks.Items) > 0 {
-		traffic, err = getIngressTraffic(c.kube, &c.stackset)
-		if err != nil {
-			return fmt.Errorf("failed to get Ingress traffic for StackSet %s/%s: %v", c.stackset.Namespace, c.stackset.Name, err)
-		}
-	}
-
-	for _, stack := range stacks.Items {
-		err = c.manageStack(stack, traffic)
-		if err != nil {
-			log.Errorf("Failed to manage Stack %s/%s: %v", stack.Namespace, stack.Name, err)
+			log.Errorf("Failed to manage Stack %s/%s: %v", sc.Stack.Namespace, sc.Stack.Name, err)
 			continue
 		}
 	}
@@ -110,44 +60,10 @@ func (c *StackController) runOnce() error {
 	return nil
 }
 
-func getIngressTraffic(client kubernetes.Interface, stackset *zv1.StackSet) (map[string]TrafficStatus, error) {
-	ingress, err := getIngress(client, stackset)
-	if err != nil {
-		return nil, err
-	}
-
-	desiredTraffic := make(map[string]float64)
-	if weights, ok := ingress.Annotations[stackTrafficWeightsAnnotationKey]; ok {
-		err := json.Unmarshal([]byte(weights), &desiredTraffic)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current desired Stack traffic weights: %v", err)
-		}
-	}
-
-	actualTraffic := make(map[string]float64)
-	if weights, ok := ingress.Annotations[backendWeightsAnnotationKey]; ok {
-		err := json.Unmarshal([]byte(weights), &actualTraffic)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current actual Stack traffic weights: %v", err)
-		}
-	}
-
-	traffic := make(map[string]TrafficStatus, len(desiredTraffic))
-
-	for stackName, weight := range desiredTraffic {
-		traffic[stackName] = TrafficStatus{
-			ActualWeight:  actualTraffic[stackName],
-			DesiredWeight: weight,
-		}
-	}
-
-	return traffic, nil
-}
-
 // manageStack manages the stack by managing the related Deployment and Service
 // resources.
-func (c *StackController) manageStack(stack zv1.Stack, traffic map[string]TrafficStatus) error {
-	err := c.manageDeployment(stack, traffic)
+func (c *stacksReconciler) manageStack(sc StackContainer, ssc StackSetContainer) error {
+	err := c.manageDeployment(sc, ssc)
 	if err != nil {
 		return err
 	}
@@ -156,13 +72,9 @@ func (c *StackController) manageStack(stack zv1.Stack, traffic map[string]Traffi
 }
 
 // manageDeployment manages the deployment owned by the stack.
-func (c *StackController) manageDeployment(stack zv1.Stack, traffic map[string]TrafficStatus) error {
-	deployment, err := getDeployment(c.kube, stack)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
+func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetContainer) error {
+	deployment := sc.Deployment.Deployment
+	stack := sc.Stack
 
 	var origDeployment *appsv1.Deployment
 	if deployment != nil {
@@ -225,37 +137,17 @@ func (c *StackController) manageDeployment(stack zv1.Stack, traffic map[string]T
 		deployment.Spec.Replicas = stack.Spec.Replicas
 	}
 
-	if traffic != nil && traffic[stack.Name].Weight() <= 0 {
+	if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0 {
 		if ttl, ok := deployment.Annotations[noTrafficSinceAnnotationKey]; ok {
 			noTrafficSince, err := time.Parse(time.RFC3339, ttl)
 			if err != nil {
 				return fmt.Errorf("failed to parse no-traffic-since timestamp '%s': %v", ttl, err)
 			}
 
-			// TODO: make ttl configurable per app/stack
-			if !noTrafficSince.IsZero() && time.Since(noTrafficSince) > c.noTrafficScaledownTTL {
+			if !noTrafficSince.IsZero() && time.Since(noTrafficSince) > ssc.ScaledownTTLSeconds() {
 				replicas := int32(0)
 				deployment.Spec.Replicas = &replicas
 			}
-
-			if !noTrafficSince.IsZero() && time.Since(noTrafficSince) > c.noTrafficScaledownTTL {
-				// delete deployment
-				if !createDeployment {
-					c.logger.Infof("Deleting Deployment %s/%s no longer needed", deployment.Namespace, deployment.Name)
-					err = c.kube.AppsV1().Deployments(deployment.Namespace).Delete(deployment.Name, nil)
-					if err != nil {
-						return fmt.Errorf(
-							"failed to delete Deployment %s/%s owned by Stack %s/%s",
-							deployment.Namespace,
-							deployment.Name,
-							stack.Namespace,
-							stack.Name,
-						)
-					}
-				}
-				return nil
-			}
-
 		} else {
 			deployment.Annotations[noTrafficSinceAnnotationKey] = time.Now().UTC().Format(time.RFC3339)
 		}
@@ -267,6 +159,7 @@ func (c *StackController) manageDeployment(stack zv1.Stack, traffic map[string]T
 		}
 	}
 
+	var err error
 	if createDeployment {
 		c.logger.Infof(
 			"Creating Deployment %s/%s for StackSet stack %s/%s",
@@ -311,57 +204,49 @@ func (c *StackController) manageDeployment(stack zv1.Stack, traffic map[string]T
 	deployment.APIVersion = "apps/v1"
 	deployment.Kind = "Deployment"
 
-	hpa, err := c.manageAutoscaling(stack, deployment, traffic)
+	hpa, err := c.manageAutoscaling(sc, deployment, ssc)
 	if err != nil {
 		return err
 	}
 
-	err = c.manageService(stack, deployment)
+	err = c.manageService(sc, deployment, ssc)
 	if err != nil {
 		return err
 	}
 
 	// update stack status
-	stack.Status.Replicas = deployment.Status.Replicas
-	stack.Status.ReadyReplicas = deployment.Status.ReadyReplicas
-	stack.Status.UpdatedReplicas = deployment.Status.UpdatedReplicas
+	newStatus := zv1.StackStatus{
+		Replicas:        deployment.Status.Replicas,
+		ReadyReplicas:   deployment.Status.ReadyReplicas,
+		UpdatedReplicas: deployment.Status.UpdatedReplicas,
+	}
 
-	if traffic != nil {
-		stack.Status.ActualTrafficWeight = traffic[stack.Name].ActualWeight
-		stack.Status.DesiredTrafficWeight = traffic[stack.Name].DesiredWeight
+	if ssc.Traffic != nil {
+		newStatus.ActualTrafficWeight = ssc.Traffic[stack.Name].ActualWeight
+		newStatus.DesiredTrafficWeight = ssc.Traffic[stack.Name].DesiredWeight
 	}
 
 	if hpa != nil {
-		stack.Status.DesiredReplicas = hpa.Status.DesiredReplicas
+		newStatus.DesiredReplicas = hpa.Status.DesiredReplicas
 	}
 
-	// TODO: log the change in status
-	// update status of stackset
-	_, err = c.appClient.ZalandoV1().Stacks(stack.Namespace).UpdateStatus(&stack)
-	if err != nil {
-		return err
+	if !reflect.DeepEqual(newStatus, stack.Status) {
+		stack.Status = newStatus
+		// TODO: log the change in status
+		// update status of stack
+		_, err = c.appClient.ZalandoV1().Stacks(stack.Namespace).UpdateStatus(&stack)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-type TrafficStatus struct {
-	ActualWeight  float64
-	DesiredWeight float64
-}
-
-func (t TrafficStatus) Weight() float64 {
-	return math.Max(t.ActualWeight, t.DesiredWeight)
-}
-
 // manageAutoscaling manages the HPA defined for the stack.
-func (c *StackController) manageAutoscaling(stack zv1.Stack, deployment *appsv1.Deployment, traffic map[string]TrafficStatus) (*autoscaling.HorizontalPodAutoscaler, error) {
-	hpa, err := c.getHPA(deployment)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-	}
+func (c *stacksReconciler) manageAutoscaling(sc StackContainer, deployment *appsv1.Deployment, ssc StackSetContainer) (*autoscaling.HorizontalPodAutoscaler, error) {
+	hpa := sc.Deployment.HPA
+	stack := sc.Stack
 
 	var origHPA *autoscaling.HorizontalPodAutoscaler
 	if hpa != nil {
@@ -370,7 +255,7 @@ func (c *StackController) manageAutoscaling(stack zv1.Stack, deployment *appsv1.
 	}
 
 	// cleanup HPA if autoscaling is disabled or the stack has 0 traffic.
-	if stack.Spec.HorizontalPodAutoscaler == nil || (traffic != nil && traffic[stack.Name].Weight() <= 0) {
+	if stack.Spec.HorizontalPodAutoscaler == nil || (ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0) {
 		if hpa != nil {
 			c.logger.Infof(
 				"Deleting obsolete HPA %s/%s for Deployment %s/%s",
@@ -417,6 +302,7 @@ func (c *StackController) manageAutoscaling(stack zv1.Stack, deployment *appsv1.
 	hpa.Spec.MaxReplicas = stack.Spec.HorizontalPodAutoscaler.MaxReplicas
 	hpa.Spec.Metrics = stack.Spec.HorizontalPodAutoscaler.Metrics
 
+	var err error
 	if createHPA {
 		c.logger.Infof(
 			"Creating HPA %s/%s for Deployment %s/%s",
@@ -449,36 +335,10 @@ func (c *StackController) manageAutoscaling(stack zv1.Stack, deployment *appsv1.
 	return hpa, nil
 }
 
-// getHPA gets HPA owned by the Deployment.
-func (c *StackController) getHPA(deployment *appsv1.Deployment) (*autoscaling.HorizontalPodAutoscaler, error) {
-	// check for existing object
-	hpa, err := c.kube.AutoscalingV2beta1().HorizontalPodAutoscalers(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// check if object is owned by the deployment resource
-	if !isOwnedReference(deployment.TypeMeta, deployment.ObjectMeta, hpa.ObjectMeta) {
-		return nil, fmt.Errorf(
-			"found HPA '%s/%s' not managed by the Deployment %s/%s",
-			hpa.Namespace,
-			hpa.Name,
-			deployment.Namespace,
-			deployment.Name,
-		)
-	}
-
-	return hpa, nil
-}
-
 // manageService manages the service for a given stack.
-func (c *StackController) manageService(stack zv1.Stack, deployment *appsv1.Deployment) error {
-	service, err := getStackService(c.kube, *deployment)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
+func (c *stacksReconciler) manageService(sc StackContainer, deployment *appsv1.Deployment, ssc StackSetContainer) error {
+	service := sc.Deployment.Service
+	stack := sc.Stack
 
 	var origService *v1.Service
 	if service != nil {
@@ -511,7 +371,7 @@ func (c *StackController) manageService(stack zv1.Stack, deployment *appsv1.Depl
 	service.Labels = stack.Labels
 	service.Spec.Selector = stack.Labels
 	// get service ports to be used for the service
-	servicePorts, err := getServicePorts(c.stackset.Spec.Ingress.BackendPort, stack)
+	servicePorts, err := getServicePorts(ssc.StackSet.Spec.Ingress.BackendPort, stack)
 	if err != nil {
 		return err
 	}
@@ -547,50 +407,6 @@ func (c *StackController) manageService(stack zv1.Stack, deployment *appsv1.Depl
 	}
 
 	return nil
-}
-
-// getDeployment gets Deployment owned by StackSet stack.
-func getDeployment(kube kubernetes.Interface, stack zv1.Stack) (*appsv1.Deployment, error) {
-	// check for existing object
-	deployment, err := kube.AppsV1().Deployments(stack.Namespace).Get(stack.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// check if object is owned by the stack resource
-	if !isOwnedReference(stack.TypeMeta, stack.ObjectMeta, deployment.ObjectMeta) {
-		return nil, fmt.Errorf(
-			"found Deployment '%s/%s' not managed by the StackSet stack %s/%s",
-			deployment.Namespace,
-			deployment.Name,
-			stack.Namespace,
-			stack.Name,
-		)
-	}
-
-	return deployment, nil
-}
-
-// getStackService gets service owned by StackSet stack.
-func getStackService(kube kubernetes.Interface, deployment appsv1.Deployment) (*v1.Service, error) {
-	// check for existing object
-	service, err := kube.CoreV1().Services(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// check if object is owned by the deployment resource
-	if !isOwnedReference(deployment.TypeMeta, deployment.ObjectMeta, service.ObjectMeta) {
-		return nil, fmt.Errorf(
-			"found Service '%s/%s' not managed by the Deployment %s/%s",
-			service.Namespace,
-			service.Name,
-			deployment.Namespace,
-			deployment.Name,
-		)
-	}
-
-	return service, nil
 }
 
 // getServicePorts gets the service ports to be used for the stack service.

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -73,7 +73,7 @@ func (c *stacksReconciler) manageStack(sc StackContainer, ssc StackSetContainer)
 
 // manageDeployment manages the deployment owned by the stack.
 func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetContainer) error {
-	deployment := sc.Deployment.Deployment
+	deployment := sc.Resources.Deployment
 	stack := sc.Stack
 
 	var origDeployment *appsv1.Deployment
@@ -144,7 +144,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 				return fmt.Errorf("failed to parse no-traffic-since timestamp '%s': %v", ttl, err)
 			}
 
-			if !noTrafficSince.IsZero() && time.Since(noTrafficSince) > ssc.ScaledownTTLSeconds() {
+			if !noTrafficSince.IsZero() && time.Since(noTrafficSince) > ssc.ScaledownTTL() {
 				replicas := int32(0)
 				deployment.Spec.Replicas = &replicas
 			}
@@ -245,7 +245,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 
 // manageAutoscaling manages the HPA defined for the stack.
 func (c *stacksReconciler) manageAutoscaling(sc StackContainer, deployment *appsv1.Deployment, ssc StackSetContainer) (*autoscaling.HorizontalPodAutoscaler, error) {
-	hpa := sc.Deployment.HPA
+	hpa := sc.Resources.HPA
 	stack := sc.Stack
 
 	var origHPA *autoscaling.HorizontalPodAutoscaler
@@ -337,7 +337,7 @@ func (c *stacksReconciler) manageAutoscaling(sc StackContainer, deployment *apps
 
 // manageService manages the service for a given stack.
 func (c *stacksReconciler) manageService(sc StackContainer, deployment *appsv1.Deployment, ssc StackSetContainer) error {
-	service := sc.Deployment.Service
+	service := sc.Resources.Service
 	stack := sc.Stack
 
 	var origService *v1.Service

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -181,10 +181,22 @@ func (c *StackSetController) Run(ctx context.Context) {
 // also contains a set of StackContainers which respresents the full state of
 // the individual Stacks part of the StackSet.
 type StackSetContainer struct {
-	StackSet        zv1.StackSet
+	StackSet zv1.StackSet
+
+	// StackContainers is a set of stacks belonging to the StackSet
+	// including the Stack sub resources like Deployments and Services.
 	StackContainers map[types.UID]*StackContainer
-	Ingress         *v1beta1.Ingress
-	Traffic         map[string]TrafficStatus
+
+	// Ingress defines the current Ingress resource belonging to the
+	// StackSet. This is a reference to the actual resource while
+	// `StackSet.Spec.Ingress` defines the ingress configuration specified
+	// by the user on the StackSet.
+	Ingress *v1beta1.Ingress
+
+	// Traffic is the current traffic distribution across stacks of the
+	// StackSet. The values of this are derived from the related Ingress
+	// resource. The key of the map is the Stack name.
+	Traffic map[string]TrafficStatus
 }
 
 // Stacks returns a slice of Stack resources.

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -14,11 +15,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	clientset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -41,17 +45,27 @@ var (
 // stackset resources and starts and maintains other controllers per
 // stackset resource.
 type StackSetController struct {
-	logger                  *log.Entry
-	kube                    kubernetes.Interface
-	appClient               clientset.Interface
-	controllerID            string
-	interval                time.Duration
-	stacksetStackMinGCAge   time.Duration
-	noTrafficScaledownTTL   time.Duration
-	noTrafficTerminationTTL time.Duration
-	controllerTable         map[types.UID]controllerEntry
-	stacksetEvents          chan stacksetEvent
+	logger                *log.Entry
+	kube                  kubernetes.Interface
+	appClient             clientset.Interface
+	controllerID          string
+	interval              time.Duration
+	stacksetStackMinGCAge time.Duration
+	noTrafficScaledownTTL time.Duration
+	stacksetEvents        chan stacksetEvent
+	stacksetStore         map[types.UID]zv1.StackSet
 	sync.Mutex
+}
+
+type controllerEntryV2 struct {
+	StackSet       zv1.StackSet
+	Cancel         context.CancelFunc
+	ControllerRefs []controllerRef
+}
+
+type controllerRef struct {
+	ResourceUpdate chan<- StackSetContainer
+	Done           <-chan struct{}
 }
 
 type stacksetEvent struct {
@@ -65,18 +79,17 @@ type controllerEntry struct {
 }
 
 // NewStackSetController initializes a new StackSetController.
-func NewStackSetController(client kubernetes.Interface, appClient clientset.Interface, controllerID string, stacksetStackMinGCAge, noTrafficScaledownTTL, noTrafficTerminationTTL, interval time.Duration) *StackSetController {
+func NewStackSetController(client kubernetes.Interface, appClient clientset.Interface, controllerID string, stacksetStackMinGCAge, noTrafficScaledownTTL, interval time.Duration) *StackSetController {
 	return &StackSetController{
-		logger:                  log.WithFields(log.Fields{"controller": "stackset"}),
-		kube:                    client,
-		appClient:               appClient,
-		controllerID:            controllerID,
-		stacksetStackMinGCAge:   stacksetStackMinGCAge,
-		noTrafficScaledownTTL:   noTrafficScaledownTTL,
-		noTrafficTerminationTTL: noTrafficTerminationTTL,
-		stacksetEvents:          make(chan stacksetEvent, 1),
-		controllerTable:         map[types.UID]controllerEntry{},
-		interval:                interval,
+		logger:                log.WithFields(log.Fields{"controller": "stackset"}),
+		kube:                  client,
+		appClient:             appClient,
+		controllerID:          controllerID,
+		stacksetStackMinGCAge: stacksetStackMinGCAge,
+		noTrafficScaledownTTL: noTrafficScaledownTTL,
+		stacksetEvents:        make(chan stacksetEvent, 1),
+		stacksetStore:         make(map[types.UID]zv1.StackSet),
+		interval:              interval,
 	}
 }
 
@@ -86,8 +99,73 @@ func NewStackSetController(client kubernetes.Interface, appClient clientset.Inte
 func (c *StackSetController) Run(ctx context.Context) {
 	c.startWatch(ctx)
 
+	nextCheck := time.Now().Add(-c.interval)
+
 	for {
 		select {
+		case <-time.After(time.Until(nextCheck)):
+			nextCheck = time.Now().Add(c.interval)
+
+			start := time.Now()
+			stackContainers, err := c.collectResources()
+			if err != nil {
+				c.logger.Errorf("Failed to collect resources: %v", err)
+				continue
+			}
+			c.logger.Infof("Collecting resources time: %s", time.Since(start))
+
+			startRecon := time.Now()
+			var reconcileGroup errgroup.Group
+			for stackset, container := range stackContainers {
+				container := *container
+
+				reconcileGroup.Go(func() error {
+					if _, ok := c.stacksetStore[stackset]; ok {
+						start := time.Now()
+						err = c.ReconcileStack(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+						fmt.Printf("%s: ReconcileStack took: %s\n", container.StackSet.Name, time.Since(start))
+
+						start = time.Now()
+						err := c.ReconcileStacks(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+						fmt.Printf("%s: ReconcileStacks took: %s\n", container.StackSet.Name, time.Since(start))
+
+						start = time.Now()
+						err = c.ReconcileIngress(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+						fmt.Printf("%s: ReconcileIngress took: %s\n", container.StackSet.Name, time.Since(start))
+
+						start = time.Now()
+						err = c.ReconcileStackSetStatus(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+						fmt.Printf("%s: ReconcileStackSetStatus took: %s\n", container.StackSet.Name, time.Since(start))
+
+						start = time.Now()
+						err = c.StackSetGC(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+						fmt.Printf("%s: StackSetGC took: %s\n", container.StackSet.Name, time.Since(start))
+					}
+					return nil
+				})
+			}
+
+			err = reconcileGroup.Wait()
+			if err != nil {
+				c.logger.Errorf("failed to wait?: %v", err)
+			}
+			c.logger.Infof("Reconcile time: %s", time.Since(startRecon))
+			c.logger.Infof("Total Reconcile time: %s", time.Since(start))
 		case e := <-c.stacksetEvents:
 			stackset := *e.StackSet
 			// set TypeMeta manually because of this bug:
@@ -95,28 +173,21 @@ func (c *StackSetController) Run(ctx context.Context) {
 			stackset.APIVersion = "zalando.org/v1"
 			stackset.Kind = "StackSet"
 
-			noTrafficScaledownTTL := c.noTrafficScaledownTTL
-			if ttlSec := stackset.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
-				noTrafficScaledownTTL = time.Second * time.Duration(*ttlSec)
-			}
-
 			// set default ingress backend port if not specified.
 			if stackset.Spec.Ingress != nil && intOrStrIsEmpty(stackset.Spec.Ingress.BackendPort) {
 				stackset.Spec.Ingress.BackendPort = defaultBackendPort
 			}
 
-			// clear existing entry
-			if entry, ok := c.controllerTable[stackset.UID]; ok {
-				c.logger.Infof("Stopping controllers for StackSet %s/%s", stackset.Namespace, stackset.Name)
-				entry.Cancel()
-				for _, d := range entry.Done {
-					<-d
+			// update/delete existing entry
+			if _, ok := c.stacksetStore[stackset.UID]; ok {
+				if e.Deleted || !c.hasOwnership(&stackset) {
+					c.logger.Infof("StackSet '%s/%s' deleted, removing references", stackset.Namespace, stackset.Name)
+					delete(c.stacksetStore, stackset.UID)
+					continue
 				}
-				delete(c.controllerTable, stackset.UID)
-				c.logger.Infof("Controllers stopped for StackSet %s/%s", stackset.Namespace, stackset.Name)
-			}
 
-			if e.Deleted {
+				// update stackset entry
+				c.stacksetStore[stackset.UID] = stackset
 				continue
 			}
 
@@ -125,51 +196,262 @@ func (c *StackSetController) Run(ctx context.Context) {
 				continue
 			}
 
-			err := c.manageStackSet(&stackset)
-			if err != nil {
-				c.logger.Error(err)
-				continue
-			}
-
-			c.logger.Infof("Starting controllers for StackSet %s/%s", stackset.Namespace, stackset.Name)
-			ctx, cancel := context.WithCancel(ctx)
-			entry := controllerEntry{
-				Cancel: cancel,
-				Done:   []<-chan struct{}{},
-			}
-
-			stackControllerDone := make(chan struct{}, 1)
-			entry.Done = append(entry.Done, stackControllerDone)
-			stackController := NewStackController(c.kube, c.appClient, stackset, stackControllerDone, noTrafficScaledownTTL, c.interval)
-			go stackController.Run(ctx)
-
-			ingressControllerDone := make(chan struct{}, 1)
-			entry.Done = append(entry.Done, ingressControllerDone)
-			ingressController := NewIngressController(c.kube, c.appClient, stackset, ingressControllerDone, c.interval)
-			go ingressController.Run(ctx)
-
-			stackGCDone := make(chan struct{}, 1)
-			entry.Done = append(entry.Done, stackGCDone)
-			go c.runStackGC(ctx, stackset, stackGCDone)
-
-			updateStatusDone := make(chan struct{}, 1)
-			entry.Done = append(entry.Done, updateStatusDone)
-			go c.runUpdateStatus(ctx, stackset, updateStatusDone)
-
-			c.controllerTable[stackset.UID] = entry
+			c.logger.Infof("Adding entry for StackSet %s/%s", stackset.Namespace, stackset.Name)
+			c.stacksetStore[stackset.UID] = stackset
 		case <-ctx.Done():
 			c.logger.Info("Terminating main controller loop.")
-			// wait for all controllers
-			for uid, entry := range c.controllerTable {
-				entry.Cancel()
-				for _, d := range entry.Done {
-					<-d
-				}
-				delete(c.controllerTable, uid)
-			}
 			return
 		}
 	}
+}
+
+type StackSetContainer struct {
+	StackSet        zv1.StackSet
+	StackContainers map[types.UID]*StackContainer
+	Ingress         *v1beta1.Ingress
+	Traffic         map[string]TrafficStatus
+}
+
+func (sc StackSetContainer) Stacks() []zv1.Stack {
+	stacks := make([]zv1.Stack, 0, len(sc.StackContainers))
+	for _, stackContainer := range sc.StackContainers {
+		stacks = append(stacks, stackContainer.Stack)
+	}
+	return stacks
+}
+
+func (sc StackSetContainer) ScaledownTTLSeconds() time.Duration {
+	if ttlSec := sc.StackSet.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
+		return time.Second * time.Duration(*ttlSec)
+	}
+	return 0
+}
+
+type StackContainer struct {
+	Stack      zv1.Stack
+	Deployment DeploymentContainer
+}
+
+type DeploymentContainer struct {
+	Deployment *appsv1.Deployment
+	HPA        *autoscaling.HorizontalPodAutoscaler
+	Service    *v1.Service
+	Endpoints  *v1.Endpoints
+}
+
+type TrafficStatus struct {
+	ActualWeight  float64
+	DesiredWeight float64
+}
+
+func (t TrafficStatus) Weight() float64 {
+	return math.Max(t.ActualWeight, t.DesiredWeight)
+}
+
+func getIngressTraffic(ingress *v1beta1.Ingress) (map[string]TrafficStatus, error) {
+	desiredTraffic := make(map[string]float64)
+	if weights, ok := ingress.Annotations[stackTrafficWeightsAnnotationKey]; ok {
+		err := json.Unmarshal([]byte(weights), &desiredTraffic)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current desired Stack traffic weights: %v", err)
+		}
+	}
+
+	actualTraffic := make(map[string]float64)
+	if weights, ok := ingress.Annotations[backendWeightsAnnotationKey]; ok {
+		err := json.Unmarshal([]byte(weights), &actualTraffic)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current actual Stack traffic weights: %v", err)
+		}
+	}
+
+	traffic := make(map[string]TrafficStatus, len(desiredTraffic))
+
+	for stackName, weight := range desiredTraffic {
+		traffic[stackName] = TrafficStatus{
+			ActualWeight:  actualTraffic[stackName],
+			DesiredWeight: weight,
+		}
+	}
+
+	return traffic, nil
+}
+
+func (c *StackSetController) collectResources() (map[types.UID]*StackSetContainer, error) {
+	stacksets := make(map[types.UID]*StackSetContainer, len(c.stacksetStore))
+	for uid, stackset := range c.stacksetStore {
+		stackset := stackset
+		stacksets[uid] = &StackSetContainer{
+			StackSet:        stackset,
+			StackContainers: map[types.UID]*StackContainer{},
+		}
+	}
+
+	err := c.collectIngresses(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.collectStacks(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.collectDeployments(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.collectServices(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.collectEndpoints(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.collectHPAs(stacksets)
+	if err != nil {
+		return nil, err
+	}
+
+	// add traffic settings
+	for _, ssc := range stacksets {
+		if ssc.StackSet.Spec.Ingress != nil && len(ssc.StackContainers) > 0 && ssc.Ingress != nil {
+			traffic, err := getIngressTraffic(ssc.Ingress)
+			if err != nil {
+				// TODO: can fail for all!!!
+				return nil, fmt.Errorf("failed to get Ingress traffic for StackSet %s/%s: %v", ssc.StackSet.Namespace, ssc.StackSet.Name, err)
+			}
+			ssc.Traffic = traffic
+		}
+	}
+
+	return stacksets, nil
+}
+
+func (c *StackSetController) collectIngresses(stacksets map[types.UID]*StackSetContainer) error {
+	ingresses, err := c.kube.ExtensionsV1beta1().Ingresses(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Ingresses: %v", err)
+	}
+
+	for _, i := range ingresses.Items {
+		ingress := i
+		if uid, ok := getOwnerUID(ingress.ObjectMeta); ok {
+			if s, ok := stacksets[uid]; ok {
+				s.Ingress = &ingress
+			}
+		}
+	}
+	return nil
+}
+
+func (c *StackSetController) collectStacks(stacksets map[types.UID]*StackSetContainer) error {
+	stacks, err := c.appClient.ZalandoV1().Stacks(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Stacks: %v", err)
+	}
+
+	for _, stack := range stacks.Items {
+		if uid, ok := getOwnerUID(stack.ObjectMeta); ok {
+			if s, ok := stacksets[uid]; ok {
+				s.StackContainers[stack.UID] = &StackContainer{Stack: stack}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *StackSetController) collectDeployments(stacksets map[types.UID]*StackSetContainer) error {
+	deployments, err := c.kube.AppsV1().Deployments(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Deployments: %v", err)
+	}
+
+	for _, d := range deployments.Items {
+		deployment := d
+		if uid, ok := getOwnerUID(deployment.ObjectMeta); ok {
+			for _, stackset := range stacksets {
+				if s, ok := stackset.StackContainers[uid]; ok {
+					s.Deployment = DeploymentContainer{
+						Deployment: &deployment,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *StackSetController) collectServices(stacksets map[types.UID]*StackSetContainer) error {
+	services, err := c.kube.CoreV1().Services(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Services: %v", err)
+	}
+
+	for _, s := range services.Items {
+		service := s
+		if uid, ok := getOwnerUID(service.ObjectMeta); ok {
+			for _, stackset := range stacksets {
+				for _, stack := range stackset.StackContainers {
+					if stack.Deployment.Deployment != nil && stack.Deployment.Deployment.UID == uid {
+						stack.Deployment.Service = &service
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *StackSetController) collectEndpoints(stacksets map[types.UID]*StackSetContainer) error {
+	endpoints, err := c.kube.CoreV1().Endpoints(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Endpoints: %v", err)
+	}
+
+	for _, endpoint := range endpoints.Items {
+		endpoint := endpoint
+		for _, stackset := range stacksets {
+			for _, stack := range stackset.StackContainers {
+				if stack.Stack.Name == endpoint.Name && stack.Stack.Namespace == endpoint.Namespace {
+					stack.Deployment.Endpoints = &endpoint
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *StackSetController) collectHPAs(stacksets map[types.UID]*StackSetContainer) error {
+	hpas, err := c.kube.AutoscalingV2beta1().HorizontalPodAutoscalers(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list HPAs: %v", err)
+	}
+
+	for _, h := range hpas.Items {
+		hpa := h
+		if uid, ok := getOwnerUID(hpa.ObjectMeta); ok {
+			for _, stackset := range stacksets {
+				for _, stack := range stackset.StackContainers {
+					if stack.Deployment.Deployment != nil && stack.Deployment.Deployment.UID == uid {
+						stack.Deployment.HPA = &hpa
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getOwnerUID(objectMeta metav1.ObjectMeta) (types.UID, bool) {
+	if len(objectMeta.OwnerReferences) == 1 {
+		return objectMeta.OwnerReferences[0].UID, true
+	}
+	return "", false
 }
 
 // hasOwnership returns true if the controller is the "owner" of the stackset.
@@ -262,62 +544,28 @@ func (c *StackSetController) del(obj interface{}) {
 	}
 }
 
-func (c *StackSetController) runUpdateStatus(ctx context.Context, stackset zv1.StackSet, done chan<- struct{}) {
-	for {
-		err := c.updateStatus(stackset)
-		if err != nil {
-			c.logger.Error(err)
-		}
-
-		select {
-		case <-time.After(c.interval):
-		case <-ctx.Done():
-			c.logger.Info("Terminating update status loop.")
-			done <- struct{}{}
-			return
-		}
-	}
-}
-
-func (c *StackSetController) updateStatus(stackset zv1.StackSet) error {
-	heritageLabels := map[string]string{
-		stacksetHeritageLabelKey: stackset.Name,
-	}
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Set(heritageLabels).String(),
-	}
-
-	stacks, err := c.appClient.ZalandoV1().Stacks(stackset.Namespace).List(opts)
-	if err != nil {
-		return fmt.Errorf("failed to list Stacks of StackSet %s/%s: %v", stackset.Namespace, stackset.Name, err)
-	}
-
-	var traffic map[string]TrafficStatus
-	if stackset.Spec.Ingress != nil && len(stacks.Items) > 0 {
-		traffic, err = getIngressTraffic(c.kube, &stackset)
-		if err != nil {
-			return fmt.Errorf("failed to get Ingress traffic for StackSet %s/%s: %v", stackset.Namespace, stackset.Name, err)
-		}
-	}
+func (c *StackSetController) ReconcileStackSetStatus(ssc StackSetContainer) error {
+	stackset := ssc.StackSet
+	stacks := ssc.Stacks()
 
 	stacksWithTraffic := int32(0)
-	for _, stack := range stacks.Items {
-		if traffic != nil && traffic[stack.Name].Weight() > 0 {
+	for _, stack := range stacks {
+		if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() > 0 {
 			stacksWithTraffic++
 		}
 	}
 
 	newStatus := zv1.StackSetStatus{
-		Stacks:            int32(len(stacks.Items)),
+		Stacks:            int32(len(stacks)),
 		StacksWithTraffic: stacksWithTraffic,
-		ReadyStacks:       readyStacks(stacks.Items),
+		ReadyStacks:       readyStacks(stacks),
 	}
 
 	if !reflect.DeepEqual(newStatus, stackset.Status) {
 		stackset.Status = newStatus
 		// TODO: log the change in status
 		// update status of stackset
-		_, err = c.appClient.ZalandoV1().StackSets(stackset.Namespace).UpdateStatus(&stackset)
+		_, err := c.appClient.ZalandoV1().StackSets(stackset.Namespace).UpdateStatus(&stackset)
 		if err != nil {
 			return err
 		}
@@ -337,54 +585,19 @@ func readyStacks(stacks []zv1.Stack) int32 {
 	return readyStacks
 }
 
-func (c *StackSetController) runStackGC(ctx context.Context, stackset zv1.StackSet, done chan<- struct{}) {
-	for {
-		err := c.gcStacks(stackset)
-		if err != nil {
-			c.logger.Error(err)
-		}
-
-		select {
-		// TODO: change GC interval
-		case <-time.After(c.interval):
-		case <-ctx.Done():
-			c.logger.Info("Terminating stack Garbage collector.")
-			done <- struct{}{}
-			return
-		}
-	}
-}
-
-func (c *StackSetController) gcStacks(stackset zv1.StackSet) error {
-	heritageLabels := map[string]string{
-		stacksetHeritageLabelKey: stackset.Name,
-	}
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Set(heritageLabels).String(),
-	}
-
-	stacks, err := c.appClient.ZalandoV1().Stacks(stackset.Namespace).List(opts)
-	if err != nil {
-		return fmt.Errorf("failed to list Stacks of StackSet %s/%s: %v", stackset.Namespace, stackset.Name, err)
-	}
-
-	var traffic map[string]TrafficStatus
-	if stackset.Spec.Ingress != nil && len(stacks.Items) > 0 {
-		traffic, err = getIngressTraffic(c.kube, &stackset)
-		if err != nil {
-			return fmt.Errorf("failed to get Ingress traffic for StackSet %s/%s: %v", stackset.Namespace, stackset.Name, err)
-		}
-	}
+func (c *StackSetController) StackSetGC(ssc StackSetContainer) error {
+	stackset := ssc.StackSet
+	stacks := ssc.Stacks()
 
 	historyLimit := defaultStackLifecycleLimit
 	if stackset.Spec.StackLifecycle != nil && stackset.Spec.StackLifecycle.Limit != nil {
 		historyLimit = int(*stackset.Spec.StackLifecycle.Limit)
 	}
 
-	gcCandidates := make([]zv1.Stack, 0, len(stacks.Items))
-	for _, stack := range stacks.Items {
+	gcCandidates := make([]zv1.Stack, 0, len(stacks))
+	for _, stack := range stacks {
 		// never garbage collect stacks with traffic
-		if traffic != nil && traffic[stack.Name].Weight() > 0 {
+		if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() > 0 {
 			continue
 		}
 
@@ -394,8 +607,8 @@ func (c *StackSetController) gcStacks(stackset zv1.StackSet) error {
 	}
 
 	// only garbage collect if history limit is reached
-	if len(stacks.Items) <= historyLimit {
-		c.logger.Debugf("No Stacks to clean up for StackSet %s/%s (limit: %d/%d)", stackset.Namespace, stackset.Name, len(stacks.Items), historyLimit)
+	if len(stacks) <= historyLimit {
+		c.logger.Debugf("No Stacks to clean up for StackSet %s/%s (limit: %d/%d)", stackset.Namespace, stackset.Name, len(stacks), historyLimit)
 		return nil
 	}
 
@@ -404,7 +617,7 @@ func (c *StackSetController) gcStacks(stackset zv1.StackSet) error {
 		return gcCandidates[i].CreationTimestamp.Time.Before(gcCandidates[j].CreationTimestamp.Time)
 	})
 
-	excessStacks := len(stacks.Items) - historyLimit
+	excessStacks := len(stacks) - historyLimit
 	c.logger.Infof(
 		"Found %d Stack(s) exeeding the StackHistoryLimit (%d) for StackSet %s/%s. %d candidate(s) for GC",
 		excessStacks,
@@ -433,21 +646,10 @@ func (c *StackSetController) gcStacks(stackset zv1.StackSet) error {
 	return nil
 }
 
-func strInSlice(str string, slice []string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *StackSetController) manageStackSet(stackset *zv1.StackSet) error {
+func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
+	stackset := ssc.StackSet
 	heritageLabels := map[string]string{
 		stacksetHeritageLabelKey: stackset.Name,
-	}
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Set(heritageLabels).String(),
 	}
 
 	version := stackset.Spec.StackTemplate.Spec.Version
@@ -457,17 +659,19 @@ func (c *StackSetController) manageStackSet(stackset *zv1.StackSet) error {
 
 	stackName := stackset.Name + "-" + version
 
-	stacks, err := c.appClient.ZalandoV1().Stacks(stackset.Namespace).List(opts)
-	if err != nil {
-		return fmt.Errorf("failed to list stacks of StackSet %s/%s: %v", stackset.Namespace, stackset.Name, err)
-	}
+	stacks := ssc.Stacks()
 
 	var stack *zv1.Stack
-	for _, s := range stacks.Items {
+	for _, s := range stacks {
 		if s.Name == stackName {
 			stack = &s
 			break
 		}
+	}
+
+	var origStack *zv1.Stack
+	if stack != nil {
+		origStack = stack.DeepCopy()
 	}
 
 	stackLabels := mergeLabels(
@@ -483,7 +687,7 @@ func (c *StackSetController) manageStackSet(stackset *zv1.StackSet) error {
 		stack = &zv1.Stack{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      stackName,
-				Namespace: stackset.Namespace,
+				Namespace: ssc.StackSet.Namespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion: stackset.APIVersion,
@@ -516,16 +720,27 @@ func (c *StackSetController) manageStackSet(stackset *zv1.StackSet) error {
 			return err
 		}
 	} else {
-		c.logger.Infof(
-			"Updating StackSet stack %s/%s for StackSet %s/%s",
-			stack.Namespace,
-			stack.Name,
-			stackset.Namespace,
-			stackset.Name,
-		)
-		_, err := c.appClient.ZalandoV1().Stacks(stack.Namespace).Update(stack)
-		if err != nil {
-			return err
+		// only update the resource if there are changes
+		if !reflect.DeepEqual(origStack, stack) {
+			c.logger.Debugf("Stack %s/%s changed: %s",
+				stack.Namespace, stack.Name,
+				cmp.Diff(
+					origStack,
+					stack,
+					cmpopts.IgnoreUnexported(resource.Quantity{}),
+				),
+			)
+			c.logger.Infof(
+				"Updating StackSet stack %s/%s for StackSet %s/%s",
+				stack.Namespace,
+				stack.Name,
+				stackset.Namespace,
+				stackset.Name,
+			)
+			_, err := c.appClient.ZalandoV1().Stacks(stack.Namespace).Update(stack)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This refactors the controller code to improve the performance and
optimize the number of calls made to the API server.

In the original implementation it created several goroutines per
`StackSet`. Each goroutine would poll the same resources resulting in a
lot of unessesary Get calls to the API server. The number of calls
increased with the number of `StackSets` managed by the controller.
The following calls were made:

    n x [Get Endpoints]
    n x [Get Ingress] x 3
    n x [List Stacks] x 5
    n x [Get Deployment]
    n x [Get Service]
    n x [Get HPA]

Where `n` is the number of `StackSets`. This sums up to `12 x n` `Get`
calls for each iteration of the control loops.

The new implementation fetches all the resources in the main loop and
organizes them in `StackSetContainers` which is a struct storing all the
resources related to a single StackSet. The `StackContainers` are then
passed to individual reconciler loops which works the same as before
except the read from the in memory representation instead of fetching
reasources from the API server. This reduces the number of `Get` calls
from `12 x n` to `6` for each iteration of the control loop.