### PR TITLE
Unify multiple clients into one

### DIFF
--- a/cmd/traffic/main.go
+++ b/cmd/traffic/main.go
@@ -5,12 +5,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	clientset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
-	"github.com/zalando-incubator/stackset-controller/pkg/traffic"
 	"github.com/alecthomas/kingpin"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"github.com/zalando-incubator/stackset-controller/pkg/traffic"
+	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -39,17 +37,12 @@ func main() {
 		log.Fatalf("Failed to setup Kubernetes client: %v.", err)
 	}
 
-	client, err := kubernetes.NewForConfig(kubeconfig)
+	client, err := traffic.NewForConfig(kubeconfig)
 	if err != nil {
-		log.Fatalf("Failed to setup Kubernetes client: %v", err)
+		log.Fatalf("Failed to setup Traffic client: %v.", err)
 	}
 
-	appClient, err := clientset.NewForConfig(kubeconfig)
-	if err != nil {
-		log.Fatalf("Failed to setup Kubernetes CRD client: %v", err)
-	}
-
-	trafficSwitcher := traffic.NewSwitcher(client, appClient)
+	trafficSwitcher := traffic.NewSwitcher(client)
 
 	if config.Stack != "" && config.Traffic != -1 {
 		weight := config.Traffic

--- a/pkg/traffic/clientset.go
+++ b/pkg/traffic/clientset.go
@@ -1,0 +1,41 @@
+package traffic
+
+import (
+	stackset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
+	zalandov1 "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned/typed/zalando/v1"
+	"k8s.io/client-go/kubernetes"
+	extensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	rest "k8s.io/client-go/rest"
+)
+
+type Interface interface {
+	ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface
+	ZalandoV1() zalandov1.ZalandoV1Interface
+}
+
+type Clientset struct {
+	kubernetes kubernetes.Interface
+	stackset   stackset.Interface
+}
+
+func NewForConfig(kubeconfig *rest.Config) (*Clientset, error) {
+	kubeClient, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	stacksetClient, err := stackset.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Clientset{kubernetes: kubeClient, stackset: stacksetClient}, nil
+}
+
+func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
+	return c.kubernetes.ExtensionsV1beta1()
+}
+
+func (c *Clientset) ZalandoV1() zalandov1.ZalandoV1Interface {
+	return c.stackset.ZalandoV1()
+}

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
-	clientset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -20,16 +18,12 @@ const (
 
 // Switcher is able to switch traffic between stacks.
 type Switcher struct {
-	kube      kubernetes.Interface
-	appClient clientset.Interface
+	client Interface
 }
 
 // NewSwitcher initializes a new traffic switcher.
-func NewSwitcher(kube kubernetes.Interface, client clientset.Interface) *Switcher {
-	return &Switcher{
-		kube:      kube,
-		appClient: client,
-	}
+func NewSwitcher(client Interface) *Switcher {
+	return &Switcher{client: client}
 }
 
 // Switch changes traffic weight for a stack.
@@ -73,7 +67,7 @@ func (t *Switcher) Switch(stackset, stack, namespace string, weight float64) ([]
 			return nil, err
 		}
 
-		_, err = t.kube.ExtensionsV1beta1().Ingresses(namespace).Patch(stackset, types.StrategicMergePatchType, annotationData)
+		_, err = t.client.ExtensionsV1beta1().Ingresses(namespace).Patch(stackset, types.StrategicMergePatchType, annotationData)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +100,7 @@ func (t *Switcher) getStacks(stackset, namespace string) ([]StackTrafficWeight, 
 		LabelSelector: labels.Set(heritageLabels).String(),
 	}
 
-	stacks, err := t.appClient.ZalandoV1().Stacks(namespace).List(opts)
+	stacks, err := t.client.ZalandoV1().Stacks(namespace).List(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list stacks of stackset %s/%s: %v", namespace, stackset, err)
 	}
@@ -134,7 +128,7 @@ func (t *Switcher) getIngressTraffic(name, namespace string, stacks []zv1.Stack)
 		return map[string]float64{}, map[string]float64{}, nil
 	}
 
-	ingress, err := t.kube.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
+	ingress, err := t.client.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Unifies both core Kubernetes as well as Zalando's Stackset client into one.

Not sure if it's good but it simplifies the setup a bit since we don't have to deal with multiple clients.