### PR TITLE
Unify multiple clients into one

### DIFF
--- a/cmd/traffic/main.go
+++ b/cmd/traffic/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	log "github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	"github.com/zalando-incubator/stackset-controller/pkg/traffic"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -37,9 +38,9 @@ func main() {
 		log.Fatalf("Failed to setup Kubernetes client: %v.", err)
 	}
 
-	client, err := traffic.NewForConfig(kubeconfig)
+	client, err := clientset.NewForConfig(kubeconfig)
 	if err != nil {
-		log.Fatalf("Failed to setup Traffic client: %v.", err)
+		log.Fatalf("Failed to initialize Kubernetes client: %v.", err)
 	}
 
 	trafficSwitcher := traffic.NewSwitcher(client)

--- a/main.go
+++ b/main.go
@@ -13,9 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/stackset-controller/controller"
-	clientset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 )
@@ -61,19 +60,13 @@ func main() {
 		log.Fatalf("Failed to setup Kubernetes config: %v", err)
 	}
 
-	client, err := kubernetes.NewForConfig(kubeConfig)
+	client, err := clientset.NewForConfig(kubeConfig)
 	if err != nil {
-		log.Fatalf("Failed to setup Kubernetes client: %v", err)
-	}
-
-	stacksetClient, err := clientset.NewForConfig(kubeConfig)
-	if err != nil {
-		log.Fatalf("Failed to setup Kubernetes CRD client: %v", err)
+		log.Fatalf("Failed to initialize Kubernetes client: %v.", err)
 	}
 
 	controller := controller.NewStackSetController(
 		client,
-		stacksetClient,
 		config.ControllerID,
 		config.StackMinGCAge,
 		config.NoTrafficScaledownTTL,

--- a/pkg/clientset/unified.go
+++ b/pkg/clientset/unified.go
@@ -1,14 +1,20 @@
-package traffic
+package clientset
 
 import (
 	stackset "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned"
 	zalandov1 "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned/typed/zalando/v1"
 	"k8s.io/client-go/kubernetes"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	autoscalingv2beta1 "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	extensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	rest "k8s.io/client-go/rest"
 )
 
 type Interface interface {
+	AppsV1() appsv1.AppsV1Interface
+	AutoscalingV2beta1() autoscalingv2beta1.AutoscalingV2beta1Interface
+	CoreV1() corev1.CoreV1Interface
 	ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface
 	ZalandoV1() zalandov1.ZalandoV1Interface
 }
@@ -30,6 +36,18 @@ func NewForConfig(kubeconfig *rest.Config) (*Clientset, error) {
 	}
 
 	return &Clientset{kubernetes: kubeClient, stackset: stacksetClient}, nil
+}
+
+func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
+	return c.kubernetes.AppsV1()
+}
+
+func (c *Clientset) AutoscalingV2beta1() autoscalingv2beta1.AutoscalingV2beta1Interface {
+	return c.kubernetes.AutoscalingV2beta1()
+}
+
+func (c *Clientset) CoreV1() corev1.CoreV1Interface {
+	return c.kubernetes.CoreV1()
 }
 
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,11 +19,11 @@ const (
 
 // Switcher is able to switch traffic between stacks.
 type Switcher struct {
-	client Interface
+	client clientset.Interface
 }
 
 // NewSwitcher initializes a new traffic switcher.
-func NewSwitcher(client Interface) *Switcher {
+func NewSwitcher(client clientset.Interface) *Switcher {
 	return &Switcher{client: client}
 }
 


### PR DESCRIPTION
Unifies both core Kubernetes as well as Zalando's Stackset client into one.

Not sure if it's good but it simplifies the setup a bit since we don't have to deal with multiple clients.