### PR TITLE
Use equality.Semantic.DeepEqual for resource comparison

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,33 +53,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:db2e37856e0f3e8ad322792ca2ede9bcf821f4d482ca0ef300e6a9d85776a99a"
-  name = "github.com/go-kit/kit"
-  packages = [
-    "log",
-    "log/level",
-  ]
-  pruneopts = "UT"
-  revision = "ca4112baa34cb55091301bdc13b1420a122b1b9e"
-  version = "v0.7.0"
-
-[[projects]]
-  digest = "1:31a18dae27a29aa074515e43a443abfd2ba6deb6d69309d8d7ce789c45f34659"
-  name = "github.com/go-logfmt/logfmt"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
-  version = "v0.3.0"
-
-[[projects]]
-  digest = "1:c4a2528ccbcabf90f9f3c464a5fc9e302d592861bbfd0b7135a7de8a943d0406"
-  name = "github.com/go-stack/stack"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
-
-[[projects]]
   digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
   name = "github.com/gogo/protobuf"
   packages = [
@@ -92,12 +65,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:21313498d530ee0767fca8e8e9f27782d713b38a695e1cc81c1d194ddc3d896a"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6267c4c0b15dec7005db4ba9d428d39237c442bc"
-  source = "github.com/kubermatic/glog-gokit"
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
@@ -191,14 +163,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
-
-[[projects]]
-  branch = "master"
-  digest = "1:a64e323dc06b73892e5bb5d040ced475c4645d456038333883f58934abbf6f72"
-  name = "github.com/kr/logfmt"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -435,9 +399,10 @@
   revision = "183f3326a9353bd6d41430fc80f96259331d029c"
 
 [[projects]]
-  digest = "1:b7a7277a24d4ca275a5c8d45dcfd90847fbbfdcd6b0bf43f23777a628cd9515c"
+  digest = "1:02a0c216426652d43d2692b7e363b22198597022a05bc780f08db157e1a9705e"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
@@ -573,6 +538,7 @@
     "k8s.io/api/autoscaling/v2beta1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -588,6 +554,10 @@
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/typed/apps/v1",
+    "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -107,7 +107,7 @@ func (c *ingressReconciler) reconcile(sc StackSetContainer) error {
 		}
 	} else {
 		sc.Ingress.Status = v1beta1.IngressStatus{}
-		if !reflect.DeepEqual(sc.Ingress, ingress) {
+		if !equality.Semantic.DeepEqual(sc.Ingress, ingress) {
 			c.logger.Debugf("Ingress %s/%s changed: %s", ingress.Namespace, ingress.Name, cmp.Diff(sc.Ingress, ingress))
 			c.logger.Infof("Updating Ingress %s/%s with %d service backend(s).", ingress.Namespace, ingress.Name, len(stacks))
 			_, err := c.client.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
@@ -203,7 +203,7 @@ func (c *ingressReconciler) stackIngress(stackset zv1.StackSet, stack zv1.Stack)
 		ingress.ResourceVersion = ing.ResourceVersion
 		ing.Status = v1beta1.IngressStatus{}
 
-		if !reflect.DeepEqual(ing, ingress) {
+		if !equality.Semantic.DeepEqual(ing, ingress) {
 			c.logger.Debugf("Ingress %s/%s changed: %s", ingress.Namespace, ingress.Name, cmp.Diff(ing, ingress))
 			c.logger.Infof("Updating Ingress %s/%s.", ingress.Namespace, ingress.Name)
 			_, err := c.client.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -173,7 +173,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		// only update the resource if there are changes
 		// TODO: still if we add just the annotation it could mess with
 		// the HPA.
-		if !reflect.DeepEqual(origDeployment, deployment) {
+		if !equality.Semantic.DeepEqual(origDeployment, deployment) {
 			c.logger.Debugf("Deployment %s/%s changed: %s",
 				deployment.Namespace, deployment.Name,
 				cmp.Diff(
@@ -227,7 +227,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		newStatus.DesiredReplicas = hpa.Status.DesiredReplicas
 	}
 
-	if !reflect.DeepEqual(newStatus, stack.Status) {
+	if !equality.Semantic.DeepEqual(newStatus, stack.Status) {
 		c.logger.Infof(
 			"Status changed for Stack %s/%s: %#v -> %#v",
 			stack.Namespace,
@@ -320,7 +320,7 @@ func (c *stacksReconciler) manageAutoscaling(sc StackContainer, deployment *apps
 			return nil, err
 		}
 	} else {
-		if !reflect.DeepEqual(origHPA, hpa) {
+		if !equality.Semantic.DeepEqual(origHPA, hpa) {
 			c.logger.Debugf("HPA %s/%s changed: %s", hpa.Namespace, hpa.Name, cmp.Diff(origHPA, hpa))
 			c.logger.Infof(
 				"Updating HPA %s/%s for Deployment %s/%s",
@@ -394,7 +394,7 @@ func (c *stacksReconciler) manageService(sc StackContainer, deployment *appsv1.D
 			return err
 		}
 	} else {
-		if !reflect.DeepEqual(origService, service) {
+		if !equality.Semantic.DeepEqual(origService, service) {
 			c.logger.Debugf("Service %s/%s changed: %s", service.Namespace, service.Name, cmp.Diff(origService, service))
 			c.logger.Infof(
 				"Updating Service %s/%s for StackSet stack %s/%s",

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -20,6 +19,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -559,7 +559,7 @@ func (c *StackSetController) ReconcileStackSetStatus(ssc StackSetContainer) erro
 		ReadyStacks:       readyStacks(stacks),
 	}
 
-	if !reflect.DeepEqual(newStatus, stackset.Status) {
+	if !equality.Semantic.DeepEqual(newStatus, stackset.Status) {
 		c.logger.Infof(
 			"Status changed for StackSet %s/%s: %#v -> %#v",
 			stackset.Namespace,
@@ -731,7 +731,7 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 		}
 	} else {
 		// only update the resource if there are changes
-		if !reflect.DeepEqual(origStack, stack) {
+		if !equality.Semantic.DeepEqual(origStack, stack) {
 			c.logger.Debugf("Stack %s/%s changed: %s",
 				stack.Namespace, stack.Name,
 				cmp.Diff(


### PR DESCRIPTION
Use `equality.Semantic.DeepEqual` instead of `reflect.DeepEqual` for correct comparison of special Kubernetes types like `resource.Quantity`.

The `resource.Quantity` type can represent the same value in different representations i.e. `2000m` is equal to `2`. In that case the internal fields of the struct will look differently and therefore it's not possible to compare just with `reflect.DeepEqual`.