### PR TITLE
Adding the first draft for a per StackSet service

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -18,7 +18,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,6 +107,11 @@ func (c *StackSetController) Run(ctx context.Context) {
 						}
 
 						err = c.ReconcileIngress(container)
+						if err != nil {
+							c.logger.Error(err)
+						}
+
+						err = c.ReconcileService(container)
 						if err != nil {
 							c.logger.Error(err)
 						}
@@ -200,6 +205,12 @@ type StackSetContainer struct {
 	// `StackSet.Spec.Ingress` defines the ingress configuration specified
 	// by the user on the StackSet.
 	Ingress *v1beta1.Ingress
+
+	// Service defines the current Service resource belonging to the
+	// StackSet. This is a reference to the actual resource while
+	// `StackSet.Spec.Service` defines the ingress configuration specified
+	// by the user on the StackSet.
+	Service *v1.Service
 
 	// Traffic is the current traffic distribution across stacks of the
 	// StackSet. The values of this are derived from the related Ingress
@@ -399,6 +410,21 @@ func (c *StackSetController) collectServices(stacksets map[types.UID]*StackSetCo
 	if err != nil {
 		return fmt.Errorf("failed to list Services: %v", err)
 	}
+
+
+	for _, s := range services.Items {
+		service := s
+		if uid, ok := getOwnerUID(service.ObjectMeta); ok {
+			for _, stackset := range stacksets {
+				if service.Name == stackset.StackSet.Name &&
+					service.Namespace == stackset.StackSet.Namespace &&
+					stackset.StackSet.UID == uid {
+					stackset.Service = &service
+				}
+			}
+		}
+	}
+
 
 	for _, s := range services.Items {
 		service := s


### PR DESCRIPTION
Service endpoints are typically stable in k8s. StackSet controller changes
that because while traffic switching a StackSet may have different Services
that point to different versions of an application.

Trying to add a per StackSet service, so it's endpoint would serve as a stable
endpoint to the application

ref: https://github.com/zalando-incubator/stackset-controller/issues/26