### PR TITLE
Validate resource quantity values

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -661,11 +661,17 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  # quantity type is string or int
+                                  oneOf:
+                                  - type: string
+                                  - type: integer
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  # quantity type is string or int
+                                  oneOf:
+                                  - type: string
+                                  - type: integer
                                 type: object
                           securityContext:
                             properties:
@@ -1061,11 +1067,17 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  # quantity type is string or int
+                                  oneOf:
+                                  - type: string
+                                  - type: integer
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  # quantity type is string or int
+                                  oneOf:
+                                  - type: string
+                                  - type: integer
                                 type: object
                           securityContext:
                             properties:

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -689,11 +689,17 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          type: string
+                                          # quantity type is string or int
+                                          oneOf:
+                                          - type: string
+                                          - type: integer
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          type: string
+                                          # quantity type is string or int
+                                          oneOf:
+                                          - type: string
+                                          - type: integer
                                         type: object
                                   securityContext:
                                     properties:
@@ -1089,11 +1095,17 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          type: string
+                                          # quantity type is string or int
+                                          oneOf:
+                                          - type: string
+                                          - type: integer
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          type: string
+                                          # quantity type is string or int
+                                          oneOf:
+                                          - type: string
+                                          - type: integer
                                         type: object
                                   securityContext:
                                     properties:


### PR DESCRIPTION
Validate resource quantity values as either `string` or `integer`. This allows defining resources like this:

```yaml
resources:
  requests:
    cpu: 1 # this would not work before
    memory: 2Gi
  limits:
    cpu: 1000m
    memory: 2Gi
```