### PR TITLE
ignore update events for now

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -189,15 +189,16 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 					cmpopts.IgnoreUnexported(resource.Quantity{}),
 				),
 			)
-			c.recorder.Eventf(&stack,
-				apiv1.EventTypeNormal,
-				"UpdateDeployment",
-				"Updating Deployment %s/%s for StackSet stack %s/%s",
-				deployment.Namespace,
-				deployment.Name,
-				stack.Namespace,
-				stack.Name,
-			)
+			// depends on https://github.com/zalando-incubator/stackset-controller/issues/49
+			// c.recorder.Eventf(&stack,
+			// 	apiv1.EventTypeNormal,
+			// 	"UpdateDeployment",
+			// 	"Updating Deployment %s/%s for StackSet stack %s/%s",
+			// 	deployment.Namespace,
+			// 	deployment.Name,
+			// 	stack.Namespace,
+			// 	stack.Name,
+			// )
 			deployment, err = c.client.AppsV1().Deployments(deployment.Namespace).Update(deployment)
 			if err != nil {
 				return err


### PR DESCRIPTION
currently we got to many events due to some changes which are not covered in
```code 
if !equality.Semantic.DeepEqual(origDeployment, deployment) {
...
}
```

see issue https://github.com/zalando-incubator/stackset-controller/issues/49

<img width="615" alt="screen shot 2018-09-19 at 17 43 52" src="https://user-images.githubusercontent.com/1936982/45765001-3b0f9b80-bc34-11e8-9787-4e508d80014d.png">
