### PR TITLE
reconcile should not create a new event recorder

### DIFF
--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
-	"github.com/zalando-incubator/stackset-controller/pkg/recorder"
 	apiv1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -41,7 +40,7 @@ type ingressReconciler struct {
 // ReconcileIngress brings Ingresses of a StackSet to the desired state.
 func (c *StackSetController) ReconcileIngress(sc StackSetContainer) error {
 	ir := &ingressReconciler{
-		logger: log.WithFields(
+		logger: c.logger.WithFields(
 			log.Fields{
 				"controller": "ingress",
 				"stackset":   sc.StackSet.Name,
@@ -49,7 +48,7 @@ func (c *StackSetController) ReconcileIngress(sc StackSetContainer) error {
 			},
 		),
 		client:   c.client,
-		recorder: recorder.CreateEventRecorder(c.client),
+		recorder: c.recorder,
 	}
 	return ir.reconcile(sc)
 }

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -9,7 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
-	"github.com/zalando-incubator/stackset-controller/pkg/recorder"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
@@ -37,7 +36,7 @@ type stacksReconciler struct {
 // ReconcileStacks brings a set of Stacks of a StackSet to the desired state.
 func (c *StackSetController) ReconcileStacks(ssc StackSetContainer) error {
 	sr := &stacksReconciler{
-		logger: log.WithFields(
+		logger: c.logger.WithFields(
 			log.Fields{
 				"controller": "stacks",
 				"stackset":   ssc.StackSet.Name,
@@ -45,7 +44,7 @@ func (c *StackSetController) ReconcileStacks(ssc StackSetContainer) error {
 			},
 		),
 		client:   c.client,
-		recorder: recorder.CreateEventRecorder(c.client),
+		recorder: c.recorder,
 	}
 	return sr.reconcile(ssc)
 }


### PR DESCRIPTION
stackset-controller crashes due to OOM. because of initialising eventrecorder in each reconcile loop

![screen shot 2018-09-20 at 14 39 35](https://user-images.githubusercontent.com/1936982/45818785-073f7f00-bce3-11e8-9db2-332ff16dfe7d.png)

![screen shot 2018-09-20 at 14 39 01](https://user-images.githubusercontent.com/1936982/45818760-f55ddc00-bce2-11e8-849a-6d39f9326454.png)
