### PR TITLE
Validate targetValue quantity values

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -93,9 +93,15 @@ spec:
                                   type: string
                                 type: object
                           targetAverageValue:
-                            type: string
+                            # quantity type is string or int
+                            oneOf:
+                            - type: string
+                            - type: integer
                           targetValue:
-                            type: string
+                            # quantity type is string or int
+                            oneOf:
+                            - type: string
+                            - type: integer
                       object:
                         properties:
                           metricName:
@@ -109,13 +115,19 @@ spec:
                               name:
                                 type: string
                           targetValue:
-                            type: string
+                            # quantity type is string or int
+                            oneOf:
+                            - type: string
+                            - type: integer
                       pods:
                         properties:
                           metricName:
                             type: string
                           targetAverageValue:
-                            type: string
+                            # quantity type is string or int
+                            oneOf:
+                            - type: string
+                            - type: integer
                       resource:
                         properties:
                           name:
@@ -124,7 +136,10 @@ spec:
                             format: int32
                             type: integer
                           targetAverageValue:
-                            type: string
+                            # quantity type is string or int
+                            oneOf:
+                            - type: string
+                            - type: integer
                       type:
                         type: string
                   type: array

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -121,9 +121,15 @@ spec:
                                           type: string
                                         type: object
                                   targetAverageValue:
-                                    type: string
+                                    # quantity type is string or int
+                                    oneOf:
+                                    - type: string
+                                    - type: integer
                                   targetValue:
-                                    type: string
+                                    # quantity type is string or int
+                                    oneOf:
+                                    - type: string
+                                    - type: integer
                               object:
                                 properties:
                                   metricName:
@@ -137,13 +143,19 @@ spec:
                                       name:
                                         type: string
                                   targetValue:
-                                    type: string
+                                    # quantity type is string or int
+                                    oneOf:
+                                    - type: string
+                                    - type: integer
                               pods:
                                 properties:
                                   metricName:
                                     type: string
                                   targetAverageValue:
-                                    type: string
+                                    # quantity type is string or int
+                                    oneOf:
+                                    - type: string
+                                    - type: integer
                               resource:
                                 properties:
                                   name:
@@ -152,7 +164,10 @@ spec:
                                     format: int32
                                     type: integer
                                   targetAverageValue:
-                                    type: string
+                                    # quantity type is string or int
+                                    oneOf:
+                                    - type: string
+                                    - type: integer
                               type:
                                 type: string
                           type: array


### PR DESCRIPTION
Validate `targetValue` and `targetAverageValue` values as either string
or integer. This allows defining HPAs like this:

```yaml
horizontalPodAutoscaler:
  minReplicas: 3
  maxReplicas: 10
  metrics:
  - type: Object
    object:
      metricName: requests-per-second
      target:
        apiVersion: extensions/v1beta1
        kind: Ingress
        name: my-app
      targetValue: 100 # this would not be allowed before
```

This is similar to the fix done in #57