### PR TITLE
Allow stacks to play nice with kube-downscaler.

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -139,13 +139,13 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 	}
 
 	// If the deployment is scaled down by the downscaler then scale it back up again
-	if *deployment.Spec.Replicas == 0 && *stack.Spec.Replicas != 0 {
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 && *stack.Spec.Replicas != 0 {
 		replicas := int32(*stack.Spec.Replicas)
 		deployment.Spec.Replicas = &replicas
 	}
 
 	// The deployment has to be scaled down because the stack has been scaled down then set the replica count
-	if *deployment.Spec.Replicas != 0 && *stack.Spec.Replicas == 0 {
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas != 0 && *stack.Spec.Replicas == 0 {
 		replicas := int32(0)
 		deployment.Spec.Replicas = &replicas
 	}

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -138,6 +138,18 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		deployment.Spec.Replicas = stack.Spec.Replicas
 	}
 
+	// If the deployment is scaled down by the downscaler then scale it back up again
+	if *deployment.Spec.Replicas == 0 && *stack.Spec.Replicas != 0 {
+		replicas := int32(*stack.Spec.Replicas)
+		deployment.Spec.Replicas = &replicas
+	}
+
+	// The deployment has to be scaled down because the stack has been scaled down then set the replica count
+	if *deployment.Spec.Replicas != 0 && *stack.Spec.Replicas == 0 {
+		replicas := int32(0)
+		deployment.Spec.Replicas = &replicas
+	}
+
 	if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0 {
 		if ttl, ok := deployment.Annotations[noTrafficSinceAnnotationKey]; ok {
 			noTrafficSince, err := time.Parse(time.RFC3339, ttl)

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -139,15 +139,19 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 	}
 
 	// If the deployment is scaled down by the downscaler then scale it back up again
-	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 && *stack.Spec.Replicas != 0 {
-		replicas := int32(*stack.Spec.Replicas)
-		deployment.Spec.Replicas = &replicas
+	if stack.Spec.Replicas != nil && *stack.Spec.Replicas != 0 {
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas == 0 {
+			replicas := int32(*stack.Spec.Replicas)
+			deployment.Spec.Replicas = &replicas
+		}
 	}
 
 	// The deployment has to be scaled down because the stack has been scaled down then set the replica count
-	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas != 0 && *stack.Spec.Replicas == 0 {
-		replicas := int32(0)
-		deployment.Spec.Replicas = &replicas
+	if stack.Spec.Replicas != nil && *stack.Spec.Replicas == 0 {
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+			replicas := int32(0)
+			deployment.Spec.Replicas = &replicas
+		}
 	}
 
 	if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0 {


### PR DESCRIPTION
When the `replicas` on the stack is set to 0 then the deployment should be scaled down regardless of whether it's receiving traffic or not. If it's scaled down and the replicas in stack are set to a non-zero value then it should be scaled back up. There is an override to set the replica count to 0 if the stack is not receiving traffic later in the code.