### PR TITLE
Don't downscale the current stack even if it has no traffic

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -154,7 +154,10 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		}
 	}
 
-	if ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0 {
+	currentStackName := generateStackName(ssc.StackSet, currentStackVersion(ssc.StackSet))
+
+	// Avoid downscaling the current stack
+	if sc.Stack.Name != currentStackName && ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0 {
 		if ttl, ok := deployment.Annotations[noTrafficSinceAnnotationKey]; ok {
 			noTrafficSince, err := time.Parse(time.RFC3339, ttl)
 			if err != nil {


### PR DESCRIPTION
This allows the deployment to proceed even if the users set a short TTL. A downside is that they'll have a deployment which doesn't do anything if they decide to go back to a previous version, but it looks like an acceptable trade-off.