### PR TITLE
Prevent panic if ingress is not specified

### DIFF
--- a/controller/stack_test.go
+++ b/controller/stack_test.go
@@ -1,12 +1,218 @@
 package controller
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func TestGetServicePorts(tt *testing.T) {
+	backendPort := intstr.FromInt(int(8080))
+	namedBackendPort := intstr.FromString("ingress")
+
+	for _, ti := range []struct {
+		msg           string
+		stack         zv1.Stack
+		backendPort   *intstr.IntOrString
+		expectedPorts []v1.ServicePort
+		err           error
+	}{
+		{
+			msg: "test using ports from pod spec",
+			stack: zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: zv1.StackSpec{
+					Service: nil,
+					PodTemplate: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Ports: []v1.ContainerPort{
+										{
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPorts: []v1.ServicePort{
+				{
+					Name:       "port-0",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: backendPort,
+				},
+			},
+			backendPort: nil,
+		},
+		{
+			msg: "test using ports from pod spec with ingress",
+			stack: zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: zv1.StackSpec{
+					Service: nil,
+					PodTemplate: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Ports: []v1.ContainerPort{
+										{
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPorts: []v1.ServicePort{
+				{
+					Name:       "port-0",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: backendPort,
+				},
+			},
+			backendPort: &backendPort,
+		},
+		{
+			msg: "test using ports from pod spec with named ingress port",
+			stack: zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: zv1.StackSpec{
+					Service: nil,
+					PodTemplate: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Ports: []v1.ContainerPort{
+										{
+											Name:          "ingress",
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPorts: []v1.ServicePort{
+				{
+					Name:       "ingress",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: backendPort,
+				},
+			},
+			backendPort: &namedBackendPort,
+		},
+		{
+			msg: "test using ports from pod spec with invalid named ingress port",
+			stack: zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: zv1.StackSpec{
+					Service: nil,
+					PodTemplate: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Ports: []v1.ContainerPort{
+										{
+											Name:          "ingress-invalid",
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPorts: []v1.ServicePort{
+				{
+					Name:       "ingress",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: backendPort,
+				},
+			},
+			backendPort: &namedBackendPort,
+			err:         errors.New("error"),
+		},
+		{
+			msg: "test using ports from service definition",
+			stack: zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: zv1.StackSpec{
+					Service: &zv1.StackServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:       "ingress",
+								Protocol:   v1.ProtocolTCP,
+								Port:       8080,
+								TargetPort: backendPort,
+							},
+						},
+					},
+					PodTemplate: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Ports: []v1.ContainerPort{
+										{
+											Name:          "ingress-invalid",
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPorts: []v1.ServicePort{
+				{
+					Name:       "ingress",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: backendPort,
+				},
+			},
+			backendPort: &namedBackendPort,
+		},
+	} {
+		tt.Run(ti.msg, func(t *testing.T) {
+			ports, err := getServicePorts(ti.backendPort, ti.stack)
+			if ti.err != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, ports, ti.expectedPorts)
+			}
+		})
+	}
+}
 
 func TestTemplateInjectLabels(t *testing.T) {
 	template := v1.PodTemplateSpec{}


### PR DESCRIPTION
It's possible to specify a `StackSet` without specifying an `ingress` configuration. In this case the controller would crash with the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x108 pc=0xf880e8]

goroutine 79 [running]:
github.com/zalando-incubator/stackset-controller/controller.(*stacksReconciler).manageService(0xc000dbd8a0, 0xc0007362e4, 0x5, 0xc0007362f0, 0xe, 0xc0000618c0, 0x2b, 0x0, 0x0, 0xc0006963e0, ...)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stack.go:421 +0x108
github.com/zalando-incubator/stackset-controller/controller.(*stacksReconciler).manageDeployment(0xc000dbd8a0, 0xc0007362e4, 0x5, 0xc0007362f0, 0xe, 0xc0000618c0, 0x2b, 0x0, 0x0, 0xc0006963e0, ...)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stack.go:237 +0x722
github.com/zalando-incubator/stackset-controller/controller.(*stacksReconciler).manageStack(0xc000d6d8a0, 0xc0007362e4, 0x5, 0xc0007362f0, 0xe, 0xc0000618c0, 0x2b, 0x0, 0x0, 0xc0006963e0, ...)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stack.go:67 +0x88
github.com/zalando-incubator/stackset-controller/controller.(*stacksReconciler).reconcile(0xc000dbd8a0, 0x1225b17, 0x8, 0x122a580, 0xe, 0xc0003adf80, 0x22, 0x0, 0x0, 0xc0005b2100, ...)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stack.go:54 +0x100
github.com/zalando-incubator/stackset-controller/controller.(*StackSetController).ReconcileStacks(0xc000440ae0, 0x1225b17, 0x8, 0x122a580, 0xe, 0xc0003adf80, 0x22, 0x0, 0x0, 0xc0005b2100, ...)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stack.go:49 +0x2ac
github.com/zalando-incubator/stackset-controller/controller.(*StackSetController).Run.func1(0x8, 0x12a4b70)
	/go/src/github.com/zalando-incubator/stackset-controller/controller/stackset.go:105 +0x19d
github.com/zalando-incubator/stackset-controller/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000519b90, 0xc000519c80)
	/go/src/github.com/zalando-incubator/stackset-controller/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x57
created by github.com/zalando-incubator/stackset-controller/vendor/golang.org/x/sync/errgroup.(*Group).Go
	/go/src/github.com/zalando-incubator/stackset-controller/vendor/golang.org/x/sync/errgroup/errgroup.go:55 +0x66
```

The fix is to check if the ingress is specified and only use the `backendPort`, if available, when generating the service.

Includes tests covering the `getServicePorts` function.