### PR TITLE
Fix wrong naming for json marshaling

### DIFF
--- a/controller/autoscaler.go
+++ b/controller/autoscaler.go
@@ -2,12 +2,13 @@ package controller
 
 import (
 	"fmt"
+	"strconv"
+
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 const (
@@ -92,10 +93,10 @@ func MemoryMetric(metrics zv1.AutoscalerMetrics) (*autoscaling.MetricSpec, error
 		return nil, fmt.Errorf("utilization is not specified")
 	}
 	generated := &autoscaling.MetricSpec{
-		Type:autoscaling.ResourceMetricSourceType,
-		Resource:&autoscaling.ResourceMetricSource{
-			Name: v1.ResourceMemory,
-			TargetAverageUtilization:metrics.AverageUtilization,
+		Type: autoscaling.ResourceMetricSourceType,
+		Resource: &autoscaling.ResourceMetricSource{
+			Name:                     v1.ResourceMemory,
+			TargetAverageUtilization: metrics.AverageUtilization,
 		},
 	}
 	return generated, nil

--- a/pkg/apis/zalando/v1/types.go
+++ b/pkg/apis/zalando/v1/types.go
@@ -81,7 +81,7 @@ type MetricsQueue struct {
 // AutoscalerMetrics is the type of metric to be be used for autoscaling
 // +k8s:deepcopy-gen=true
 type AutoscalerMetrics struct {
-	Type               string           `json:"metricType"`
+	Type               string           `json:"type"`
 	Average            *int32           `json:"average,omitEmpty"`
 	Endpoint           *MetricsEndpoint `json:"endpoint,omitEmpty"`
 	AverageUtilization *int32           `json:"averageUtilization,omitEmpty"`


### PR DESCRIPTION
The wrong name `metricType` was used for the `json:""` annotation of the autoscaler type.