### PR TITLE
Changed the autoscaler reconciler to use weighted backends

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -674,7 +674,6 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
-    "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -95,11 +95,6 @@ func (c *StackSetController) Run(ctx context.Context) {
 
 			var reconcileGroup errgroup.Group
 			for stackset, container := range stackContainers {
-				err = c.ReconcileAutoscalers(container)
-				if err != nil {
-					c.recorder.Event(&container.StackSet, v1.EventTypeWarning,
-						"GenerateHPA", fmt.Sprintf("Failed to generate HPA %v", err.Error()))
-				}
 
 				container := *container
 


### PR DESCRIPTION
The `kube-metrics-adapter` now supports weighted backend metrics for RPS scaling. I have change the generation of metrics for the `HorizontalPodAutoscaler` to now generate the weighted metric.
