### PR TITLE
Make stacksets and stacks visible in kubectl get all

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -10,6 +10,8 @@ spec:
     kind: Stack
     singular: stack
     plural: stacks
+    categories:
+    - all
   additionalPrinterColumns:
   - name: Desired
     type: integer

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -10,6 +10,8 @@ spec:
     kind: StackSet
     singular: stackset
     plural: stacksets
+    categories:
+    - all
   additionalPrinterColumns:
   - name: Stacks
     type: integer


### PR DESCRIPTION
Enable this feature of CRDs: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#categories such that stacks and stacksets are listed when you do: `kubectl get all`.