### PR TITLE
Only prescale once in prescaling timeout

### DIFF
--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
-	"strconv"
 	"time"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
@@ -15,7 +15,6 @@ import (
 
 const (
 	prescaleAnnotationKey        = "stacksetstacks.zalando.org/prescale-replicas"
-	resetHPAMinReplicasSinceKey  = "stacksetstacks.zalando.org/min-replicas-prescale-since"
 	DefaultResetMinReplicasDelay = 10 * time.Minute
 )
 
@@ -23,59 +22,63 @@ type PrescaleTrafficReconciler struct {
 	ResetHPAMinReplicasTimeout time.Duration
 }
 
-// ReconcileDeployment prescales the deployment if the prescale annotation is
-// set. Prescale annotation will only be removed from the deployment after it's
-// getting traffic.
+type prescalingInfo struct {
+	LastUpdated string `json:"lastUpdated"`
+	Replicas    int    `json:"replicas"`
+}
+
+// ReconcileDeployment calculates the number replicas required when prescaling is active. If there is no associated
+// HPA then the replicas of are also increased. Finally once traffic switching is complete the prescaling annotations
+// are removed.
 func (r *PrescaleTrafficReconciler) ReconcileDeployment(stacks map[types.UID]*StackContainer, stack *zv1.Stack, traffic map[string]TrafficStatus, deployment *appsv1.Deployment) error {
-	// prescale logic
-	if prescale, ok := deployment.Annotations[prescaleAnnotationKey]; ok {
-		// don't prescale if desired weight is 0
-		// remove annotation when prescaling is done
-		if traffic != nil && (traffic[stack.Name].DesiredWeight <= 0 || traffic[stack.Name].ActualWeight == traffic[stack.Name].DesiredWeight) {
-			delete(deployment.Annotations, prescaleAnnotationKey)
-			return nil
+	// 1. Check if prescaling active
+	// 2. If traffic does not need changing then return
+	// 3. If prescaling not active calculate replicas
+	// 4. If HPA not present set replicas
+
+	prescalingInfoJson, prescalingActive := deployment.Annotations[prescaleAnnotationKey]
+	var info prescalingInfo
+	if prescalingActive {
+		err := json.Unmarshal([]byte(prescalingInfoJson), &info)
+		if err != nil {
+			return fmt.Errorf("failed to deserialize prescaling informations: %v", err)
 		}
+	}
+
+	if traffic != nil && traffic[stack.Name].DesiredWeight > 0 && traffic[stack.Name].ActualWeight < traffic[stack.Name].DesiredWeight {
+		if !prescalingActive {
+			for _, stackContainer := range stacks {
+				if traffic[stackContainer.Stack.Name].ActualWeight > 0 {
+					if stackContainer.Resources.Deployment != nil && stackContainer.Resources.Deployment.Spec.Replicas != nil {
+						info.Replicas += int(*stackContainer.Resources.Deployment.Spec.Replicas)
+					}
+				}
+			}
+		}
+		info.LastUpdated = time.Now().Format(time.RFC3339)
+
+		updatedPrescalingJson, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("failed to serialize prescaling information: %v", err)
+		}
+		deployment.Annotations[prescaleAnnotationKey] = string(updatedPrescalingJson)
 
 		if stack.Spec.HorizontalPodAutoscaler == nil {
-			prescaleReplicas, err := strconv.Atoi(prescale)
-			if err != nil {
-				return err
-			}
-
-			replicas := int32(prescaleReplicas)
+			replicas := int32(info.Replicas)
 			deployment.Spec.Replicas = &replicas
 		}
 		return nil
 	}
 
-	// prescale deployment if desired weight is > 0 and actual weight is <
-	// desired weight
-	if traffic != nil && traffic[stack.Name].DesiredWeight > 0 && traffic[stack.Name].ActualWeight < traffic[stack.Name].DesiredWeight {
-		var prescaleReplicas int32
-		// sum replicas of all stacks currently getting traffic
-		for _, stackContainer := range stacks {
-			if traffic[stackContainer.Stack.Name].ActualWeight > 0 {
-				if stackContainer.Resources.Deployment != nil && stackContainer.Resources.Deployment.Spec.Replicas != nil {
-					prescaleReplicas += *stackContainer.Resources.Deployment.Spec.Replicas
-				}
-			}
+	if prescalingActive {
+		lastUpdated, err := time.Parse(time.RFC3339, info.LastUpdated)
+		if err != nil {
+			return fmt.Errorf("failed to parse last updated timestamp: %v", err)
 		}
-
-		if stack.Spec.HorizontalPodAutoscaler != nil {
-			prescaleReplicas = int32(math.Min(float64(prescaleReplicas), float64(stack.Spec.HorizontalPodAutoscaler.MaxReplicas)))
-		}
-
-		if prescaleReplicas > 0 {
-			prescaleReplicasStr := strconv.FormatInt(int64(prescaleReplicas), 10)
-			deployment.Annotations[prescaleAnnotationKey] = prescaleReplicasStr
-
-			if stack.Spec.HorizontalPodAutoscaler == nil {
-				replicas := int32(prescaleReplicas)
-				deployment.Spec.Replicas = &replicas
-			}
+		if time.Since(lastUpdated) > r.ResetHPAMinReplicasTimeout {
+			delete(deployment.Annotations, prescaleAnnotationKey)
 		}
 	}
-
 	return nil
 }
 
@@ -84,68 +87,39 @@ func (r *PrescaleTrafficReconciler) ReconcileDeployment(stacks map[types.UID]*St
 // minReplicas value is used from the Stack. This means that the HPA is allowed
 // to scale down once the prescaling is done.
 func (r *PrescaleTrafficReconciler) ReconcileHPA(stack *zv1.Stack, hpa *autoscaling.HorizontalPodAutoscaler, deployment *appsv1.Deployment) error {
-	var minReplicas int32
+	var info prescalingInfo
+	prescalingInfoJson, prescalingActive := deployment.Annotations[prescaleAnnotationKey]
 
-	if stack.Spec.HorizontalPodAutoscaler.MinReplicas != nil {
-		minReplicas = *stack.Spec.HorizontalPodAutoscaler.MinReplicas
-	}
-
-	// reuse the existing HPA minReplicas if the "reset HPA MinReplicas
-	// timeout" wasn't reached yet.
-	if prescaleSince, ok := hpa.Annotations[resetHPAMinReplicasSinceKey]; ok {
-		minReplicaPrescaleSince, err := time.Parse(time.RFC3339, prescaleSince)
+	if prescalingActive {
+		err := json.Unmarshal([]byte(prescalingInfoJson), &info)
 		if err != nil {
-			return fmt.Errorf("failed to parse min-replicas-prescale-since timestamp '%s': %v", prescaleSince, err)
+			return fmt.Errorf("failed to parse prescaling annotation: %v", err)
 		}
-
-		if !minReplicaPrescaleSince.IsZero() && time.Since(minReplicaPrescaleSince) <= r.ResetHPAMinReplicasTimeout {
-			if hpa.Spec.MinReplicas != nil {
-				minReplicas = *hpa.Spec.MinReplicas
-			}
-		} else {
-			// remove the annotation if the reset timeout was
-			// reached.
-			delete(hpa.Annotations, resetHPAMinReplicasSinceKey)
-		}
+		minReplicas := int32(math.Min(float64(info.Replicas), float64(stack.Spec.HorizontalPodAutoscaler.MaxReplicas)))
+		hpa.Spec.MinReplicas = &minReplicas
+		return nil
 	}
 
-	if prescale, ok := deployment.Annotations[prescaleAnnotationKey]; ok {
-		prescaleReplicas, err := strconv.Atoi(prescale)
-		if err != nil {
-			return err
-		}
-
-		if _, ok := hpa.Annotations[resetHPAMinReplicasSinceKey]; !ok {
-			hpa.Annotations[resetHPAMinReplicasSinceKey] = time.Now().Format(time.RFC3339)
-		}
-
-		minReplicas = int32(prescaleReplicas)
-	}
-
-	// cap minReplicas as maxReplicas
-	minReplicas = int32(math.Min(float64(minReplicas), float64(stack.Spec.HorizontalPodAutoscaler.MaxReplicas)))
-
-	hpa.Spec.MinReplicas = &minReplicas
-	hpa.Spec.MaxReplicas = stack.Spec.HorizontalPodAutoscaler.MaxReplicas
-
+	hpa.Spec.MinReplicas = stack.Spec.HorizontalPodAutoscaler.MinReplicas
 	return nil
 }
 
 // getDeploymentPrescale parses and returns the prescale value if set in the
 // deployment annotation.
-func getDeploymentPrescale(deployment *appsv1.Deployment) (int32, bool) {
-	prescaleReplicasStr, ok := deployment.Annotations[prescaleAnnotationKey]
+func getDeploymentPrescale(deployment *appsv1.Deployment) (prescalingInfo, bool) {
+	var info prescalingInfo
+	prescaleReplicasJson, ok := deployment.Annotations[prescaleAnnotationKey]
 	if !ok {
-		return 0, false
+		return info, false
 	}
-	prescaleReplicas, err := strconv.Atoi(prescaleReplicasStr)
+	err := json.Unmarshal([]byte(prescaleReplicasJson), &info)
 	if err != nil {
-		return 0, false
+		return info, false
 	}
-	return int32(prescaleReplicas), true
+	return info, true
 }
 
-// ReconcileIngress calcuates the traffic distribution for the ingress. The
+// ReconcileIngress calculates the traffic distribution for the ingress. The
 // implementation is optimized for prescaling stacks before directing traffic.
 // It works like this:
 //
@@ -169,13 +143,13 @@ func (r *PrescaleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*Stack
 
 		// prescale if stack is currently less than desired traffic
 		if traffic[stack.Stack.Name].ActualWeight < traffic[stack.Stack.Name].DesiredWeight && deployment != nil {
-			if prescale, ok := getDeploymentPrescale(deployment); ok {
+			if pInfo, ok := getDeploymentPrescale(deployment); ok {
 				var desired int32 = 1
 				if deployment.Spec.Replicas != nil {
 					desired = *deployment.Spec.Replicas
 				}
 
-				if desired >= prescale && deployment.Status.ReadyReplicas >= prescale {
+				if desired >= int32(pInfo.Replicas) && deployment.Status.ReadyReplicas >= int32(pInfo.Replicas) {
 					availableBackends[stack.Stack.Name] = traffic[stack.Stack.Name].DesiredWeight
 				}
 			}

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,14 +16,16 @@ import (
 
 func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 	for _, ti := range []struct {
-		msg                 string
-		deployment          *appsv1.Deployment
-		stacks              map[types.UID]*StackContainer
-		stack               *zv1.Stack
-		traffic             map[string]TrafficStatus
-		err                 error
-		expectedReplicas    int32
-		expectedAnnotations map[string]string
+		msg                string
+		deployment         *appsv1.Deployment
+		stacks             map[types.UID]*StackContainer
+		stack              *zv1.Stack
+		traffic            map[string]TrafficStatus
+		err                error
+		expectedReplicas   int32
+		calculatedReplicas int
+		prescalingActive   bool
+		timestampUpdated   bool
 	}{
 		{
 			msg: "should not prescale deployment replicas if there is an HPA defined",
@@ -31,7 +33,8 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svc-3",
 					Annotations: map[string]string{
-						prescaleAnnotationKey: "10",
+						prescaleAnnotationKey: fmt.Sprintf("{\"replicas\": 10, \"lastUpdated\": \"%s\"}",
+							time.Now().Add(-2 * time.Minute).Format(time.RFC3339)),
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -121,10 +124,10 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 					DesiredWeight: 100.0,
 				},
 			},
-			expectedReplicas: 3,
-			expectedAnnotations: map[string]string{
-				prescaleAnnotationKey: "10",
-			},
+			expectedReplicas:   3,
+			calculatedReplicas: 10,
+			prescalingActive:   true,
+			timestampUpdated:   true,
 		},
 		{
 			msg: "should prescale deployment if no HPA is defined",
@@ -132,7 +135,8 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svc-3",
 					Annotations: map[string]string{
-						prescaleAnnotationKey: "10",
+						prescaleAnnotationKey: fmt.Sprintf("{\"replicas\": 10, \"lastUpdated\": \"%s\"}",
+							time.Now().Add(-2*time.Minute)),
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -143,12 +147,7 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svc-3",
 				},
-				Spec: zv1.StackSpec{
-					// HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-					// 	MinReplicas: &[]int32{3}[0],
-					// 	MaxReplicas: 20,
-					// },
-				},
+				Spec: zv1.StackSpec{},
 			},
 			stacks: map[types.UID]*StackContainer{
 				types.UID("1"): &StackContainer{
@@ -198,7 +197,7 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "svc-3",
 								Annotations: map[string]string{
-									prescaleAnnotationKey: "10",
+									prescaleAnnotationKey: "{\"replicas\": 10}",
 								},
 							},
 							Spec: appsv1.DeploymentSpec{
@@ -222,18 +221,20 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 					DesiredWeight: 100.0,
 				},
 			},
-			expectedReplicas: 10,
-			expectedAnnotations: map[string]string{
-				prescaleAnnotationKey: "10",
-			},
+			expectedReplicas:   10,
+			calculatedReplicas: 10,
+			prescalingActive:   true,
+			timestampUpdated:   true,
 		},
 		{
-			msg: "remove prescale annotation if already getting traffic.",
+			msg: "remove prescale annotation if already getting traffic and time elapsed.",
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svc-3",
 					Annotations: map[string]string{
-						prescaleAnnotationKey: "10",
+						prescaleAnnotationKey: fmt.Sprintf(
+							"{\"replicas\": 10, \"lastUpdated\": \"%s\"}", time.Now().
+								Add(-DefaultResetMinReplicasDelay).Format(time.RFC3339)),
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -260,8 +261,10 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 					DesiredWeight: 100.0,
 				},
 			},
-			expectedReplicas:    3,
-			expectedAnnotations: map[string]string{},
+			expectedReplicas:   3,
+			calculatedReplicas: 0,
+			prescalingActive:   false,
+			timestampUpdated:   false,
 		},
 		{
 			msg: "prescale stack if desired is > 0",
@@ -355,10 +358,10 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 					DesiredWeight: 50.0,
 				},
 			},
-			expectedReplicas: 15,
-			expectedAnnotations: map[string]string{
-				prescaleAnnotationKey: "15",
-			},
+			expectedReplicas:   15,
+			prescalingActive:   true,
+			calculatedReplicas: 15,
+			timestampUpdated:   true,
 		},
 		{
 			msg: "prescale stack if desired is > 0 (with HPA)",
@@ -376,112 +379,9 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 					Name: "svc-3",
 				},
 				Spec: zv1.StackSpec{
-					// HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-					// 	MinReplicas: &[]int32{3}[0],
-					// 	MaxReplicas: 20,
-					// },
-				},
-			},
-			stacks: map[types.UID]*StackContainer{
-				types.UID("1"): &StackContainer{
-					Stack: zv1.Stack{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "svc-1",
-						},
-					},
-					Resources: StackResources{
-						Deployment: &appsv1.Deployment{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:        "svc-1",
-								Annotations: map[string]string{},
-							},
-							Spec: appsv1.DeploymentSpec{
-								Replicas: &[]int32{5}[0],
-							},
-						},
-						HPA: &autoscaling.HorizontalPodAutoscaler{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:        "svc-1",
-								Annotations: map[string]string{},
-							},
-						},
-					},
-				},
-				types.UID("2"): &StackContainer{
-					Stack: zv1.Stack{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "svc-2",
-						},
-					},
-					Resources: StackResources{
-						Deployment: &appsv1.Deployment{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:        "svc-2",
-								Annotations: map[string]string{},
-							},
-							Spec: appsv1.DeploymentSpec{
-								Replicas: &[]int32{10}[0],
-							},
-						},
-					},
-				},
-				types.UID("3"): &StackContainer{
-					Stack: zv1.Stack{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "svc-3",
-						},
-					},
-					Resources: StackResources{
-						Deployment: &appsv1.Deployment{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:        "svc-3",
-								Annotations: map[string]string{},
-							},
-							Spec: appsv1.DeploymentSpec{
-								Replicas: &[]int32{3}[0],
-							},
-						},
-					},
-				},
-			},
-			traffic: map[string]TrafficStatus{
-				"svc-1": TrafficStatus{
-					ActualWeight:  50.0,
-					DesiredWeight: 0.0,
-				},
-				"svc-2": TrafficStatus{
-					ActualWeight:  50.0,
-					DesiredWeight: 50.0,
-				},
-				"svc-3": TrafficStatus{
-					ActualWeight:  0.0,
-					DesiredWeight: 50.0,
-				},
-			},
-			expectedReplicas: 15,
-			expectedAnnotations: map[string]string{
-				prescaleAnnotationKey: "15",
-			},
-		},
-		{
-			msg: "prescale stack if desired is > actual (with HPA), cap prescale at Max HPA replicas",
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "svc-3",
-					Annotations: map[string]string{},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: &[]int32{3}[0],
-				},
-			},
-			stack: &zv1.Stack{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "svc-3",
-				},
-				Spec: zv1.StackSpec{
 					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
 						MinReplicas: &[]int32{3}[0],
-						MaxReplicas: 10,
+						MaxReplicas: 20,
 					},
 				},
 			},
@@ -549,22 +449,22 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 			},
 			traffic: map[string]TrafficStatus{
 				"svc-1": TrafficStatus{
-					ActualWeight:  0.0,
+					ActualWeight:  50.0,
 					DesiredWeight: 0.0,
 				},
 				"svc-2": TrafficStatus{
 					ActualWeight:  50.0,
-					DesiredWeight: 0.0,
+					DesiredWeight: 50.0,
 				},
 				"svc-3": TrafficStatus{
-					ActualWeight:  50.0,
-					DesiredWeight: 100.0,
+					ActualWeight:  0.0,
+					DesiredWeight: 50.0,
 				},
 			},
-			expectedReplicas: 3,
-			expectedAnnotations: map[string]string{
-				prescaleAnnotationKey: "10",
-			},
+			expectedReplicas:   3,
+			prescalingActive:   true,
+			calculatedReplicas: 15,
+			timestampUpdated:   true,
 		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
@@ -574,7 +474,16 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.Equal(t, ti.expectedReplicas, *ti.deployment.Spec.Replicas)
-				require.Equal(t, ti.expectedAnnotations, ti.deployment.Annotations)
+				info, active := getDeploymentPrescale(ti.deployment)
+				require.Equal(t, ti.prescalingActive, active, "expected prescaling to be %v", ti.prescalingActive)
+				if ti.prescalingActive {
+					require.Equal(t, ti.calculatedReplicas, info.Replicas)
+				}
+				if ti.timestampUpdated {
+					ts, err := time.Parse(time.RFC3339, info.LastUpdated)
+					require.NoError(t, err, "failed to parse last updated timestamp: %v", err)
+					require.InDelta(t, time.Now().Unix(), ts.Unix(), float64(time.Second*10), "last updated is older than 10 seconds")
+				}
 			}
 		})
 	}
@@ -582,27 +491,25 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 
 func TestPrescaleReconcilerReconcileHPA(tt *testing.T) {
 	for _, ti := range []struct {
-		msg                       string
-		hpa                       *autoscaling.HorizontalPodAutoscaler
-		deployment                *appsv1.Deployment
-		stack                     *zv1.Stack
-		expectedMinReplicas       int32
-		expectedMaxReplicas       int32
-		expectedHPAAnnotationKeys map[string]struct{}
-		err                       error
+		msg                 string
+		hpa                 *autoscaling.HorizontalPodAutoscaler
+		deployment          *appsv1.Deployment
+		stack               *zv1.Stack
+		expectedMinReplicas int32
+		expectedMaxReplicas int32
+		err                 error
 	}{
 		{
 			msg: "minReplicas should match prescale replicas",
 			hpa: &autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MinReplicas: &[]int32{1}[0],
+					MaxReplicas: 20,
 				},
 			},
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						prescaleAnnotationKey: "10",
-					},
+					Annotations: map[string]string{prescaleAnnotationKey: "{\"replicas\":10}"},
 				},
 			},
 			stack: &zv1.Stack{
@@ -615,117 +522,15 @@ func TestPrescaleReconcilerReconcileHPA(tt *testing.T) {
 			},
 			expectedMaxReplicas: 20,
 			expectedMinReplicas: 10,
-			expectedHPAAnnotationKeys: map[string]struct{}{
-				resetHPAMinReplicasSinceKey: struct{}{},
-			},
-		},
-		{
-			msg: "Invalid prescale replicas should return error",
-			hpa: &autoscaling.HorizontalPodAutoscaler{},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						prescaleAnnotationKey: "abc",
-					},
-				},
-			},
-			stack: &zv1.Stack{
-				Spec: zv1.StackSpec{
-					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-						MinReplicas: &[]int32{10}[0],
-						MaxReplicas: 20,
-					},
-				},
-			},
-			err: errors.New("failure"),
 		},
 		{
 			msg: "stack without prescale annotation should have default MinReplicas.",
-			hpa: &autoscaling.HorizontalPodAutoscaler{},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			stack: &zv1.Stack{
-				Spec: zv1.StackSpec{
-					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-						MinReplicas: &[]int32{3}[0],
-						MaxReplicas: 20,
-					},
-				},
-			},
-			expectedMaxReplicas: 20,
-			expectedMinReplicas: 3,
-		},
-		{
-			msg: "re-use HPA minReplicas if the ResetHPAMinReplicasTimeout has not expired",
 			hpa: &autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						resetHPAMinReplicasSinceKey: time.Now().Format(time.RFC3339),
-					},
-				},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					MinReplicas: &[]int32{20}[0],
 					MaxReplicas: 20,
 				},
-			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			stack: &zv1.Stack{
-				Spec: zv1.StackSpec{
-					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-						MinReplicas: &[]int32{3}[0],
-						MaxReplicas: 20,
-					},
-				},
-			},
-			expectedMaxReplicas: 20,
-			expectedMinReplicas: 20,
-			expectedHPAAnnotationKeys: map[string]struct{}{
-				resetHPAMinReplicasSinceKey: struct{}{},
-			},
-		},
-		{
-			msg: "invalid date format for 'min-replicas-prescale-since' should be an error.",
-			hpa: &autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						resetHPAMinReplicasSinceKey: "invalid date",
-					},
-				},
-			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			stack: &zv1.Stack{
-				Spec: zv1.StackSpec{
-					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
-						MinReplicas: &[]int32{3}[0],
-						MaxReplicas: 20,
-					},
-				},
-			},
-			err: errors.New("error"),
-		},
-		{
-			msg: "Don't re-use HPA minReplicas if the ResetHPAMinReplicasTimeout has expired",
-			hpa: &autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						resetHPAMinReplicasSinceKey: time.Now().Add(-(20 * time.Minute)).Format(time.RFC3339),
-					},
-				},
-				Spec: autoscaling.HorizontalPodAutoscalerSpec{
-					MinReplicas: &[]int32{20}[0],
-					MaxReplicas: 20,
-				},
+				Status: autoscaling.HorizontalPodAutoscalerStatus{},
 			},
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -754,10 +559,6 @@ func TestPrescaleReconcilerReconcileHPA(tt *testing.T) {
 			} else {
 				require.Equal(t, ti.expectedMinReplicas, *ti.hpa.Spec.MinReplicas)
 				require.Equal(t, ti.expectedMaxReplicas, ti.hpa.Spec.MaxReplicas)
-				require.Len(t, ti.hpa.Annotations, len(ti.expectedHPAAnnotationKeys))
-				for k := range ti.expectedHPAAnnotationKeys {
-					require.Contains(t, ti.hpa.Annotations, k)
-				}
 			}
 		})
 	}
@@ -767,20 +568,20 @@ func TestGetDeploymentPrescale(t *testing.T) {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				prescaleAnnotationKey: "10",
+				prescaleAnnotationKey: "{\"replicas\": 10}",
 			},
 		},
 	}
 
 	prescale, ok := getDeploymentPrescale(deployment)
 	require.True(t, ok)
-	require.Equal(t, int32(10), prescale)
+	require.Equal(t, 10, prescale.Replicas)
 
 	deployment.Annotations = map[string]string{}
 	_, ok = getDeploymentPrescale(deployment)
 	require.False(t, ok)
 
-	deployment.Annotations = map[string]string{prescaleAnnotationKey: "abc"}
+	deployment.Annotations = map[string]string{prescaleAnnotationKey: "\"abc\": 1}"}
 	_, ok = getDeploymentPrescale(deployment)
 	require.False(t, ok)
 }
@@ -914,7 +715,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "svc-3",
 								Annotations: map[string]string{
-									prescaleAnnotationKey: "10",
+									prescaleAnnotationKey: "{\"replicas\": 10}",
 								},
 							},
 							Spec: appsv1.DeploymentSpec{
@@ -1192,9 +993,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				},
 			},
 			expectedAvailableWeights: map[string]float64{
-				// "svc-1": 0.0,
 				"svc-2": 100.0,
-				// "svc-3": 0.0,
 			},
 			expectedAllWeights: map[string]float64{
 				"svc-1": 0.0,


### PR DESCRIPTION
In the current setup the prescaling occurs on every traffic switch step. This means that the calculations includes the currently prescaled replicas which increases the number of replicas to very large number. This PR changes that by calculating the prescaling step only once and then subsequent updates the prescaling timeout whenever there is a traffic switch step.