### PR TITLE
Generate HPA from Stack Autoscaler

### DIFF
--- a/controller/autoscaler.go
+++ b/controller/autoscaler.go
@@ -37,10 +37,11 @@ func NewAutoscalerReconciler(ssc StackSetContainer) *AutoscalerReconciler {
 
 func (c *AutoscalerReconciler) Reconcile(sc *StackContainer) error {
 
-	if c.ssc.StackSet.Spec.StackTemplate.Spec.HorizontalPodAutoscaler != nil {
+	if sc.Stack.Spec.HorizontalPodAutoscaler != nil {
 		return nil
 	}
-	autoscaler := c.ssc.StackSet.Spec.StackTemplate.Spec.Autoscaler
+
+	autoscaler := sc.Stack.Spec.Autoscaler
 	stacksetName := c.ssc.StackSet.Name
 	stackName := sc.Stack.Name
 

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -778,7 +778,8 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 	stack.Labels = stackLabels
 	stack.Spec.PodTemplate = *stackset.Spec.StackTemplate.Spec.PodTemplate.DeepCopy()
 	stack.Spec.Replicas = stackset.Spec.StackTemplate.Spec.Replicas
-	stack.Spec.HorizontalPodAutoscaler = stackset.Spec.StackTemplate.Spec.HorizontalPodAutoscaler
+	stack.Spec.HorizontalPodAutoscaler = stackset.Spec.StackTemplate.Spec.HorizontalPodAutoscaler.DeepCopy()
+	stack.Spec.Autoscaler = stackset.Spec.StackTemplate.Spec.Autoscaler.DeepCopy()
 	if stackset.Spec.StackTemplate.Spec.Service != nil {
 		stack.Spec.Service = sanitizeServicePorts(stackset.Spec.StackTemplate.Spec.Service)
 	}

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	fake2 "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned/fake"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
@@ -339,4 +342,76 @@ func int32Ptr(i int32) *int32 {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+func generateStackSet(stacksetName, namespace, version string, minReplicas, maxReplicas int) zv1.StackSet {
+	return zv1.StackSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stacksetName,
+			Namespace: namespace,
+		},
+		Spec: zv1.StackSetSpec{
+			StackTemplate: zv1.StackTemplate{
+				Spec: zv1.StackSpecTemplate{
+					Version: version,
+					StackSpec: zv1.StackSpec{
+						Autoscaler: &zv1.Autoscaler{
+							MinReplicas: &[]int32{int32(minReplicas)}[0],
+							MaxReplicas: int32(maxReplicas),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateStack(name, namespace string) zv1.Stack {
+	return zv1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func TestStackSetController_ReconcileStackCreate(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	ssClient := fake2.NewSimpleClientset()
+	fakeClient := clientset.NewClientset(kubeClient, ssClient)
+	controller := NewStackSetController(fakeClient, "test-controller", time.Second)
+	ss := generateStackSet("stack", "test", "01", 10, 20)
+	ssc := StackSetContainer{StackSet: ss}
+	err := controller.ReconcileStack(ssc)
+	assert.NoError(t, err, "error reconciling stack")
+	stackName := generateStackName(ss, "01")
+	stack, err := fakeClient.ZalandoV1().Stacks("test").Get(stackName, metav1.GetOptions{})
+	assert.NoError(t, err, "failed to get created stack")
+	assert.NotNil(t, stack, "created stack cannot be referenced")
+	assert.EqualValues(t, 10, *stack.Spec.Autoscaler.MinReplicas)
+	assert.EqualValues(t, 20, stack.Spec.Autoscaler.MaxReplicas)
+}
+
+func TestStackSetController_ReconcileStackUpdate(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	ssClient := fake2.NewSimpleClientset()
+	fakeClient := clientset.NewClientset(kubeClient, ssClient)
+	controller := NewStackSetController(fakeClient, "test-controller", time.Second)
+	ss := generateStackSet("stack", "test", "01", 10, 20)
+	existingStack := generateStack("stack-01", "test")
+	_, err := fakeClient.ZalandoV1().Stacks("test").Create(&existingStack)
+	assert.NoError(t, err, "failed to create test stack")
+	ssc := StackSetContainer{StackSet: ss, StackContainers: map[types.UID]*StackContainer{
+		"stack-01": {
+			Stack: existingStack,
+		},
+	}}
+	err = controller.ReconcileStack(ssc)
+	assert.NoError(t, err, "error reconciling stack")
+	stackName := generateStackName(ss, "01")
+	stack, err := fakeClient.ZalandoV1().Stacks("test").Get(stackName, metav1.GetOptions{})
+	assert.NoError(t, err, "failed to get created stack")
+	assert.NotNil(t, stack, "created stack cannot be referenced")
+	assert.EqualValues(t, 10, *stack.Spec.Autoscaler.MinReplicas)
+	assert.EqualValues(t, 20, stack.Spec.Autoscaler.MaxReplicas)
 }


### PR DESCRIPTION
Current the generated HPA is generated directly from the `Autoscaler` defined in the _StackSet` spec. The `Autoscaler` is not copied to the stack. This is means that when the stackset definition is changed all the HPA are changed. This might not be desirable behavior in the case when the pod is resized. In the future the HPA should be an independent resource and should not be changed when the Stackset spec is changed.