### PR TITLE
Fix prescaling when no active stacks present

### DIFF
--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -51,7 +51,7 @@ func (r *PrescaleTrafficReconciler) ReconcileDeployment(stacks map[types.UID]*St
 		}
 
 		// If there is no associated HPA then manually update the replicas
-		if stack.Spec.HorizontalPodAutoscaler == nil {
+		if stack.Spec.HorizontalPodAutoscaler == nil && stack.Status.Prescaling.Replicas != 0 {
 			replicas := stack.Status.Prescaling.Replicas
 			deployment.Spec.Replicas = &replicas
 		}
@@ -65,7 +65,7 @@ func (r *PrescaleTrafficReconciler) ReconcileDeployment(stacks map[types.UID]*St
 // minReplicas value from the Stack. This means that the HPA is allowed to scale down once the prescaling is done.
 func (r *PrescaleTrafficReconciler) ReconcileHPA(stack *zv1.Stack, hpa *autoscaling.HorizontalPodAutoscaler, deployment *appsv1.Deployment) error {
 	hpa.Spec.MaxReplicas = stack.Spec.HorizontalPodAutoscaler.MaxReplicas
-	if stack.Status.Prescaling.Active {
+	if stack.Status.Prescaling.Active && stack.Status.Prescaling.Replicas != 0 {
 		minReplicas := int32(math.Min(float64(stack.Status.Prescaling.Replicas), float64(stack.Spec.HorizontalPodAutoscaler.MaxReplicas)))
 		hpa.Spec.MinReplicas = &minReplicas
 		return nil

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -59,7 +59,7 @@ func (c *stacksReconciler) reconcile(ssc StackSetContainer) error {
 		err = c.manageStack(*sc, ssc)
 		if err != nil {
 			c.recorder.Event(&sc.Stack, v1.EventTypeWarning, "ManageStackFailed",
-				fmt.Sprintf("Failed to reoncile stack: %v", err.Error()))
+				fmt.Sprintf("Failed to reconcile stack: %v", err.Error()))
 		}
 	}
 	return nil


### PR DESCRIPTION
There can be case when all the current stacks which are receiving traffic are broken and there are no replicas. In this case the calculated prescaling replicas will be 0 preventing a rollout of the new stack because of HPA validation. I've added a condition to the logic such that the prescaling is performed only when the computed replicas are greater than 0.