### PR TITLE
Fixed the order in which the metrics are sorted

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -59,7 +59,7 @@ func (c *stacksReconciler) reconcile(ssc StackSetContainer) error {
 		err = c.manageStack(*sc, ssc)
 		if err != nil {
 			c.recorder.Event(&sc.Stack, v1.EventTypeWarning, "ManageStackFailed",
-				fmt.Sprintf("Failed to reoncile stack: %v", err.Error()))
+				fmt.Sprintf("Failed to reconcile stack: %v", err.Error()))
 		}
 	}
 	return nil
@@ -332,10 +332,6 @@ func (c *stacksReconciler) manageAutoscaling(stack zv1.Stack, hpa *autoscalingv2
 				},
 			},
 		}
-	}
-
-	if hpa.Annotations == nil {
-		hpa.Annotations = map[string]string{}
 	}
 
 	hpa.Labels = deployment.Labels


### PR DESCRIPTION
Because of how the HPA metrics are stored and the how the diff is done for changing the HPA the generated HPAs are continuously updated because the controller thinks it needs to be updated. While this has no downside it's quite bad in terms of calls to the API and updates to the stack object. So I've sorted the metrics in alphabetical order which seems to be how they are stored and retrieved.

