### PR TITLE
Correctly get ports from pods with multiple containers

### DIFF
--- a/controller/stack.go
+++ b/controller/stack.go
@@ -502,9 +502,9 @@ func getServicePorts(backendPort *intstr.IntOrString, stack zv1.Stack) ([]v1.Ser
 // servicePortsFromTemplate gets service port from pod template.
 func servicePortsFromContainers(containers []v1.Container) []v1.ServicePort {
 	ports := make([]v1.ServicePort, 0)
-	for _, container := range containers {
-		for i, port := range container.Ports {
-			name := fmt.Sprintf("port-%d", i)
+	for i, container := range containers {
+		for j, port := range container.Ports {
+			name := fmt.Sprintf("port-%d-%d", i, j)
 			if port.Name != "" {
 				name = port.Name
 			}

--- a/controller/stack_test.go
+++ b/controller/stack_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestGetServicePorts(tt *testing.T) {
 	backendPort := intstr.FromInt(int(8080))
+	backendPort2 := intstr.FromInt(int(8081))
 	namedBackendPort := intstr.FromString("ingress")
 
 	for _, ti := range []struct {
@@ -41,6 +42,13 @@ func TestGetServicePorts(tt *testing.T) {
 										},
 									},
 								},
+								{
+									Ports: []v1.ContainerPort{
+										{
+											ContainerPort: 8081,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -48,10 +56,16 @@ func TestGetServicePorts(tt *testing.T) {
 			},
 			expectedPorts: []v1.ServicePort{
 				{
-					Name:       "port-0",
+					Name:       "port-0-0",
 					Protocol:   v1.ProtocolTCP,
 					Port:       8080,
 					TargetPort: backendPort,
+				},
+				{
+					Name:       "port-1-0",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8081,
+					TargetPort: backendPort2,
 				},
 			},
 			backendPort: nil,
@@ -81,7 +95,7 @@ func TestGetServicePorts(tt *testing.T) {
 			},
 			expectedPorts: []v1.ServicePort{
 				{
-					Name:       "port-0",
+					Name:       "port-0-0",
 					Protocol:   v1.ProtocolTCP,
 					Port:       8080,
 					TargetPort: backendPort,


### PR DESCRIPTION
This fixes a bug where the stackset controller was unable to create a service for a stack with multiple containers in a pod all exposing an unnamed port.

Before it tried to generate ports for the service of the format: `port-<port-index>` where `port-index` is the index in the port array from the container spec. With two containers both exposing ports it was possible to generate the same port name multiple times which would be rejected by the API validation when submitting the service.

Fix is to change the name format to `port-<container-index>-<port-index>`