### PR TITLE
Fix prescaling when no other stacks receiving traffic

### DIFF
--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -35,6 +35,10 @@ func (r *PrescaleTrafficReconciler) ReconcileDeployment(stacks map[types.UID]*St
 					}
 				}
 			}
+			// If no other stacks are currently active
+			if stack.Status.Prescaling.Replicas == 0 {
+				stack.Status.Prescaling.Replicas = *stack.Spec.Replicas
+			}
 		}
 		stack.Status.Prescaling.Active = true
 		// Update the timestamp in the prescaling information. This bumps the prescaling timeout

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -469,6 +469,111 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 			calculatedReplicas: 15,
 			timestampUpdated:   true,
 		},
+		{
+			msg: "prescale stack  correctly when other stacks have no replicas",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "svc-3",
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{3}[0],
+				},
+			},
+			stack: &zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-3",
+				},
+				Spec: zv1.StackSpec{
+					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
+						MinReplicas: &[]int32{1}[0],
+						MaxReplicas: 20,
+					},
+					Replicas: pint32(3),
+				},
+				Status: zv1.StackStatus{
+					Prescaling: zv1.PrescalingStatus{
+						Active:              false,
+						Replicas:            0,
+						LastTrafficIncrease: &metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+					},
+				},
+			},
+			stacks: map[types.UID]*StackContainer{
+				types.UID("1"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-1",
+						},
+					},
+					Resources: StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-1",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{0}[0],
+							},
+						},
+					},
+				},
+				types.UID("2"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-2",
+						},
+					},
+					Resources: StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-2",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{0}[0],
+							},
+						},
+					},
+				},
+				types.UID("3"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-3",
+						},
+					},
+					Resources: StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-3",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{3}[0],
+							},
+						},
+					},
+				},
+			},
+			traffic: map[string]TrafficStatus{
+				"svc-1": {
+					ActualWeight:  50.0,
+					DesiredWeight: 0.0,
+				},
+				"svc-2": {
+					ActualWeight:  50.0,
+					DesiredWeight: 50.0,
+				},
+				"svc-3": {
+					ActualWeight:  0.0,
+					DesiredWeight: 50.0,
+				},
+			},
+			expectedReplicas:   3,
+			prescalingActive:   true,
+			calculatedReplicas: 3,
+			timestampUpdated:   true,
+		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{ResetHPAMinReplicasTimeout: DefaultResetMinReplicasDelay}


### PR DESCRIPTION
When the other stacks receiving traffic have no replicas or when there are no stacks currently receiving traffic then the prescaling calculation is incorrect. This PR fixes that issue.

The E2E tests didn't catch this before it happens only in conjunction with `kube-downscaler` and the current stack changing after a deployment.