### PR TITLE
Stacks should be the main entity users interact with

### DIFF
--- a/cmd/e2e/basic_test.go
+++ b/cmd/e2e/basic_test.go
@@ -201,6 +201,14 @@ func verifyStack(t *testing.T, stacksetName, currentVersion string, stacksetSpec
 	}
 }
 
+func verifyStackSetStatus(t *testing.T, stacksetName, version string) {
+	// Verify that the stack status is updated successfully
+	err := stackSetStatusMatches(t, stacksetName, expectedStackSetStatus{
+		observedStackVersion: version,
+	}).await()
+	require.NoError(t, err)
+}
+
 func verifyStacksetIngress(t *testing.T, stacksetName string, stacksetSpec zv1.StackSetSpec, stackWeights map[string]float64) {
 	stacksetResourceLabels := map[string]string{stacksetHeritageLabelKey: stacksetName}
 
@@ -290,6 +298,8 @@ func testStacksetUpdate(t *testing.T, testName string, oldHpa, newHpa, oldIngres
 		verifyStacksetIngress(t, stacksetName, stacksetSpec, map[string]float64{initialVersion: 100})
 	}
 
+	verifyStackSetStatus(t, stacksetName, initialVersion)
+
 	stacksetSpecFactory = NewTestStacksetSpecFactory(stacksetName)
 	updatedVersion := "v2"
 	if newHpa {
@@ -302,6 +312,7 @@ func testStacksetUpdate(t *testing.T, testName string, oldHpa, newHpa, oldIngres
 	err = updateStackset(stacksetName, updatedSpec)
 	require.NoError(t, err)
 	verifyStack(t, stacksetName, updatedVersion, updatedSpec)
+	verifyStackSetStatus(t, stacksetName, updatedVersion)
 
 	if newIngress {
 		verifyStacksetIngress(t, stacksetName, updatedSpec, map[string]float64{initialVersion: 100, updatedVersion: 0})

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -210,6 +210,29 @@ func stackStatusMatches(t *testing.T, stackName string, expectedStatus expectedS
 	})
 }
 
+type expectedStackSetStatus struct {
+	observedStackVersion string
+}
+
+func (expected expectedStackSetStatus) matches(stackSet *zv1.StackSet) error {
+	status := stackSet.Status
+	if expected.observedStackVersion != status.ObservedStackVersion {
+		return fmt.Errorf("%s: observedStackVersion %s != expected %s", stackSet.Name, status.ObservedStackVersion, expected.observedStackVersion)
+	}
+	return nil
+}
+
+func stackSetStatusMatches(t *testing.T, stackSetName string, expectedStatus expectedStackSetStatus) *awaiter {
+	return newAwaiter(t, fmt.Sprintf("stack %s to reach desired condition", stackSetName)).withPoll(func() (retry bool, err error) {
+		stackSet, err := stacksetClient.ZalandoV1().StackSets(namespace).Get(stackSetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, expectedStatus.matches(stackSet)
+
+	})
+}
+
 func stackObjectMeta(name string, prescalingTimeout int) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{
 		Name:      name,

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -90,3 +90,50 @@ func TestStackTTLWithIngress(t *testing.T) {
 		require.False(t, stackExists(stacksetName, fmt.Sprintf("v%d", i)))
 	}
 }
+
+func TestStackTTLForLatestStack(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stackset-ttl-last-stack"
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 0).Ingress()
+
+	// Create 2 stacks in total and wait for their deployments to come up
+	for i := 0; i < 2; i++ {
+		stackVersion := fmt.Sprintf("v%d", i)
+		var err error
+		spec := specFactory.Create(stackVersion)
+		if !stacksetExists(stacksetName) {
+			err = createStackSet(stacksetName, 1, spec)
+		} else {
+			err = updateStackset(stacksetName, spec)
+		}
+		require.NoError(t, err)
+
+		_, err = waitForStack(t, stacksetName, stackVersion)
+		require.NoError(t, err)
+
+		fullStackName := fmt.Sprintf("%s-%s", stacksetName, stackVersion)
+		_, err = waitForIngress(t, fullStackName)
+		require.NoError(t, err)
+
+		if i == 0 {
+			// Explicitly switch traffic to the first stack
+			newWeight := map[string]float64{fullStackName: 100}
+			err = setDesiredTrafficWeights(stacksetName, newWeight)
+			require.NoError(t, err)
+
+			err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newWeight).withTimeout(10 * time.Minute).await()
+			require.NoError(t, err)
+		}
+	}
+
+	// verify that only 1st stack is present and the last 1 has been deleted
+	stackVersion := 0
+	require.True(t, stackExists(stacksetName, fmt.Sprintf("v%d", stackVersion)))
+
+	// verify that the first 1 stack which was created have been deleted
+	stackVersion = 1
+	deploymentName := fmt.Sprintf("%s-v%d", stacksetName, stackVersion)
+	err := resourceDeleted(t, "stack", deploymentName, deploymentInterface()).withTimeout(time.Second * 60).await()
+	require.NoError(t, err)
+	require.False(t, stackExists(stacksetName, fmt.Sprintf("v%d", stackVersion)))
+}

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -132,9 +132,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		}
 	}
 
-	// TODO (#1750): Don't treat the current stack differently
-	currentStackName := generateStackName(ssc.StackSet, currentStackVersion(ssc.StackSet))
-	stackUnused := stack.Name != currentStackName && ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0
+	stackUnused := ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0
 
 	noTrafficSince := stack.Status.NoTrafficSince
 

--- a/controller/stack.go
+++ b/controller/stack.go
@@ -132,6 +132,7 @@ func (c *stacksReconciler) manageDeployment(sc StackContainer, ssc StackSetConta
 		}
 	}
 
+	// TODO (#1750): Don't treat the current stack differently
 	currentStackName := generateStackName(ssc.StackSet, currentStackVersion(ssc.StackSet))
 	stackUnused := stack.Name != currentStackName && ssc.Traffic != nil && ssc.Traffic[stack.Name].Weight() <= 0
 

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -583,9 +583,10 @@ func (c *StackSetController) ReconcileStackSetStatus(ssc StackSetContainer) erro
 	}
 
 	newStatus := zv1.StackSetStatus{
-		Stacks:            int32(len(stacks)),
-		StacksWithTraffic: stacksWithTraffic,
-		ReadyStacks:       readyStacks(stacks),
+		Stacks:               int32(len(stacks)),
+		StacksWithTraffic:    stacksWithTraffic,
+		ReadyStacks:          readyStacks(stacks),
+		ObservedStackVersion: currentStackVersion(stackset),
 	}
 
 	if !equality.Semantic.DeepEqual(newStatus, stackset.Status) {
@@ -738,7 +739,7 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 	heritageLabels := map[string]string{
 		stacksetHeritageLabelKey: stackset.Name,
 	}
-
+	observedStackVersion := stackset.Status.ObservedStackVersion
 	stackVersion := currentStackVersion(stackset)
 	stackName := generateStackName(stackset, stackVersion)
 
@@ -758,10 +759,7 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 		map[string]string{stackVersionLabelKey: stackVersion},
 	)
 
-	createStack := false
-
-	if stack == nil {
-		createStack = true
+	if stack == nil && observedStackVersion != stackVersion {
 		stack = &zv1.Stack{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      stackName,
@@ -776,18 +774,16 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 				},
 			},
 		}
-	}
 
-	stack.Labels = stackLabels
-	stack.Spec.PodTemplate = *stackset.Spec.StackTemplate.Spec.PodTemplate.DeepCopy()
-	stack.Spec.Replicas = stackset.Spec.StackTemplate.Spec.Replicas
-	stack.Spec.HorizontalPodAutoscaler = stackset.Spec.StackTemplate.Spec.HorizontalPodAutoscaler.DeepCopy()
-	stack.Spec.Autoscaler = stackset.Spec.StackTemplate.Spec.Autoscaler.DeepCopy()
-	if stackset.Spec.StackTemplate.Spec.Service != nil {
-		stack.Spec.Service = sanitizeServicePorts(stackset.Spec.StackTemplate.Spec.Service)
-	}
+		stack.Labels = stackLabels
+		stack.Spec.PodTemplate = *stackset.Spec.StackTemplate.Spec.PodTemplate.DeepCopy()
+		stack.Spec.Replicas = stackset.Spec.StackTemplate.Spec.Replicas
+		stack.Spec.HorizontalPodAutoscaler = stackset.Spec.StackTemplate.Spec.HorizontalPodAutoscaler.DeepCopy()
+		stack.Spec.Autoscaler = stackset.Spec.StackTemplate.Spec.Autoscaler.DeepCopy()
+		if stackset.Spec.StackTemplate.Spec.Service != nil {
+			stack.Spec.Service = sanitizeServicePorts(stackset.Spec.StackTemplate.Spec.Service)
+		}
 
-	if createStack {
 		c.recorder.Eventf(&stackset,
 			apiv1.EventTypeNormal,
 			"CreateStackSetStack",
@@ -801,32 +797,6 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 		_, err := c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
 		if err != nil {
 			return err
-		}
-	} else {
-		// TODO (#1750): Stack template in the stackset is only considered when a new stack is created.
-		// Further changes to the spec should be ignored or forbidden to avoid confusion.
-		stacksetGeneration := getStackSetGeneration(stack.ObjectMeta)
-
-		// only update the resource if there are changes
-		// We determine changes by comparing the stacksetGeneration
-		// (observed generation) stored on the stack with the
-		// generation of the StackSet.
-		if stacksetGeneration != stackset.Generation {
-			if stack.Annotations == nil {
-				stack.Annotations = make(map[string]string, 1)
-			}
-			stack.Annotations[stacksetGenerationAnnotationKey] = fmt.Sprintf("%d", stackset.Generation)
-
-			c.recorder.Eventf(&stackset,
-				apiv1.EventTypeNormal,
-				"UpdateStackSetStack",
-				"Updating Stack '%s/%s' for StackSet",
-				stack.Namespace, stack.Name,
-			)
-			_, err := c.client.ZalandoV1().Stacks(stack.Namespace).Update(stack)
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -583,9 +583,11 @@ func (c *StackSetController) ReconcileStackSetStatus(ssc StackSetContainer) erro
 	}
 
 	newStatus := zv1.StackSetStatus{
-		Stacks:               int32(len(stacks)),
-		StacksWithTraffic:    stacksWithTraffic,
-		ReadyStacks:          readyStacks(stacks),
+		Stacks:            int32(len(stacks)),
+		StacksWithTraffic: stacksWithTraffic,
+		ReadyStacks:       readyStacks(stacks),
+		// Recording, the creation of stack. This allows deletion of even the "current" stack,
+		//  since the "current" part is just a small implementation detail of the deployment process.
 		ObservedStackVersion: currentStackVersion(stackset),
 	}
 
@@ -791,9 +793,6 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 			stack.Namespace, stack.Name,
 		)
 
-		// TODO (#1750): Creation of a stack should be recorded somehow.
-		//  This will allow deletion of even the "current" stack,
-		//  since the "current" part is just a small implementation detail of the deployment process.
 		_, err := c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
 		if err != nil {
 			return err

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -795,7 +795,7 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 			stack.Namespace, stack.Name,
 		)
 
-		// TODO: Creation of a stack should be recorded somehow.
+		// TODO (#1750): Creation of a stack should be recorded somehow.
 		//  This will allow deletion of even the "current" stack,
 		//  since the "current" part is just a small implementation detail of the deployment process.
 		_, err := c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
@@ -803,9 +803,8 @@ func (c *StackSetController) ReconcileStack(ssc StackSetContainer) error {
 			return err
 		}
 	} else {
-		//TODO: Stack template in the stackset is only considered when a new stack is created.
+		// TODO (#1750): Stack template in the stackset is only considered when a new stack is created.
 		// Further changes to the spec should be ignored or forbidden to avoid confusion.
-		//TODO: Move this to it's own control loop
 		stacksetGeneration := getStackSetGeneration(stack.ObjectMeta)
 
 		// only update the resource if there are changes

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -583,11 +583,9 @@ func (c *StackSetController) ReconcileStackSetStatus(ssc StackSetContainer) erro
 	}
 
 	newStatus := zv1.StackSetStatus{
-		Stacks:            int32(len(stacks)),
-		StacksWithTraffic: stacksWithTraffic,
-		ReadyStacks:       readyStacks(stacks),
-		// Recording, the creation of stack. This allows deletion of even the "current" stack,
-		//  since the "current" part is just a small implementation detail of the deployment process.
+		Stacks:               int32(len(stacks)),
+		StacksWithTraffic:    stacksWithTraffic,
+		ReadyStacks:          readyStacks(stacks),
 		ObservedStackVersion: currentStackVersion(stackset),
 	}
 

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -392,27 +392,3 @@ func TestStackSetController_ReconcileStackCreate(t *testing.T) {
 	assert.EqualValues(t, 10, *stack.Spec.Autoscaler.MinReplicas)
 	assert.EqualValues(t, 20, stack.Spec.Autoscaler.MaxReplicas)
 }
-
-func TestStackSetController_ReconcileStackUpdate(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset()
-	ssClient := stacksetfake.NewSimpleClientset()
-	fakeClient := clientset.NewClientset(kubeClient, ssClient)
-	controller := NewStackSetController(fakeClient, "test-controller", time.Second)
-	ss := generateStackSet("stack", "test", "01", 10, 20)
-	existingStack := generateStack("stack-01", "test")
-	_, err := fakeClient.ZalandoV1().Stacks("test").Create(&existingStack)
-	assert.NoError(t, err, "failed to create test stack")
-	ssc := StackSetContainer{StackSet: ss, StackContainers: map[types.UID]*StackContainer{
-		"stack-01": {
-			Stack: existingStack,
-		},
-	}}
-	err = controller.ReconcileStack(ssc)
-	assert.NoError(t, err, "error reconciling stack")
-	stackName := generateStackName(ss, "01")
-	stack, err := fakeClient.ZalandoV1().Stacks("test").Get(stackName, metav1.GetOptions{})
-	assert.NoError(t, err, "failed to get created stack")
-	assert.NotNil(t, stack, "created stack cannot be referenced")
-	assert.EqualValues(t, 10, *stack.Spec.Autoscaler.MinReplicas)
-	assert.EqualValues(t, 20, stack.Spec.Autoscaler.MaxReplicas)
-}

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -30,7 +30,7 @@ env E2E_NAMESPACE=$controllerId \
     CLUSTER_DOMAIN=stups-test.zalan.do \
     CONTROLLER_ID=$controllerId \
     KUBECONFIG=$HOME/.kube/config \
-    go test -parallel 64 -v -failfast -count=1 \
+    go test -run TestStackTTLForLatestStack -v -failfast -count=1 \
         github.com/zalando-incubator/stackset-controller/cmd/e2e \
     || true
 

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -6,15 +6,15 @@ set -euf -o pipefail
 make build.local build/e2e
 
 # Forward API server calls to the stups-test cluster.
-zkubectl login stups-test
-zkubectl proxy&
+#zkubectl login stups-test
+#zkubectl proxy&
 # Listens on 127.0.0.1:8001.
 
 # Generate a controller ID for this run.
 controllerId=ssc-e2e-$(dd if=/dev/urandom bs=8 count=1 2>/dev/null | hexdump -e '"%x"')
 
 # We'll store the controller logs in a separate file to keep stdout clean.
-controllerLog=$(mktemp /tmp/ssc-log-XXXXX.log)
+controllerLog="/tmp/ssc-log-XXXXX.log"
 echo ">>> Writing controller logs in $controllerLog"
 
 # Find and run the controller locally.
@@ -41,4 +41,4 @@ zkubectl delete ns $controllerId
 echo "Jobs to kill:"
 jobs
 pkill stackset-contro
-pkill -f kubectl
+#pkill -f kubectl

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -142,6 +142,7 @@ type StackSetStatus struct {
 	// +optional
 	StacksWithTraffic int32 `json:"stacksWithTraffic,omitempty" protobuf:"varint,2,opt,name=stacksWithTraffic"`
 	// ObservedStackVersion is the version of Stack generated from the current StackSet definition.
+	// TODO: add a more detailed comment
 	// +optional
 	ObservedStackVersion string `json:"observedStackVersion,omitempty"`
 }

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -141,6 +141,9 @@ type StackSetStatus struct {
 	// which are getting traffic.
 	// +optional
 	StacksWithTraffic int32 `json:"stacksWithTraffic,omitempty" protobuf:"varint,2,opt,name=stacksWithTraffic"`
+	// ObservedStackVersion is the version of Stack generated from the current StackSet definition.
+	// +optional
+	ObservedStackVersion string `json:"observedStackVersion,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -24,15 +24,14 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 var parameterCodec = runtime.NewParameterCodec(scheme)
-
-func init() {
-	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	zalandov1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -45,10 +44,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	zalandov1.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -24,15 +24,14 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
-
-func init() {
-	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(Scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	zalandov1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -45,10 +44,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	zalandov1.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(Scheme))
 }


### PR DESCRIPTION
# Stacks should be the main entity

In the current implementation, users create a stackset resource in the cluster which then creates a corresponding stack resource. Deployment of a new version overwrites both the `template` and the `name` in the stackset, causing the controller to create a new stack resource to match. If the stackset is changed without modifying the `name`, the "current" stack will be modified and the previous stacks will be left untouched because the information about their spec is completely lost. This leads to a weird situation where the users have 2 different kinds of stacks, the "current" one that cannot be changed by itself or deleted, and the previous ones which can **only** be changed by modifying the stacks, since the stackset changes no longer affect them. The situation becomes even worse if the users decide to go back to a previous version. An obvious solution would be to just switch traffic to one of the previous stacks and delete the one that's no longer needed, but this doesn't work if it's the "current" one.

Other Kubernetes resources and Senza stacks don't really work like this. In both cases there's one resource that the users interact with. For Kubernetes it's the deployment, which automagically creates and manages the replicasets (and you usually don't fiddle with those). For Senza it's the stacks, and there's no controlling resource for those. We should do something similar for stacksets as well.

@aermakov-zalando  proposes changing the logic to the following one:
 * Stack template in the stackset is only considered when a new stack is created. Further changes to the spec should be ignored or forbidden to avoid confusion.
 * Users are encouraged to think of stacks as the main entities they interact with. They should be able to delete a stack
 * Creation of a stack should be recorded somehow. This will allow deletion of even the "current" stack, since the "current" part is just a small implementation detail of the deployment process.
