### PR TITLE
WIP: Automated Gradual Deployments with Feedback Loop

### DIFF
--- a/controller/canary/README.md
+++ b/controller/canary/README.md
@@ -1,0 +1,47 @@
+# canary: Automated Gradual Deployments with Feedback Loop
+
+The `canary` package implements "automated gradual deployments with feedback loop"
+(or just "gradual deployments" for short) in the stackset controller.
+This document summarizes what gradual deployments are and how to use them.
+
+Gradual deployments are driven by annotations on the StackSet and on the Stack being deployed.
+In the following description, all annotations should be prefixed with `stackset-controller.zalando.org/canary/`
+(omitted for readability).
+
+Gradual deployments work as follows:
+
+1. A StackSet is created with the `gradual-deployments-enabled` annotation.
+   Under the hood, this makes it use a `canary.TrafficReconciler` (CTR) instead of the usual
+   `SimpleTrafficReconciler` or `PrescaleTrafficReconciler`.
+   The CTR wraps one of these to delegate usual stackset manipulations (`ReconcileDeployments`, etc.).
+   
+1. A Stack is created with the `is-green` annotation, as well as a few mandatory metadata annotations
+   (see `controller/canary/annotations.go`).
+   It is a "green stack" (by virtue of `is-green`), a concept that we explain below.
+   
+   The **`blue` annotation** holds the name of the "blue stack", which is another, older Stack from which
+   all traffic will be transferred to the green stack in a progressive ("gradual") way.
+   The goal of gradual deployments is to continuously monitor the performance of the green stack
+   and compare it to the performance of the blue stack, so that we can rollback as soon as possible
+   to the (stable) blue stack in case of a regression in the green stack.
+   
+   However, we do not directly compare blue and green stacks, because the blue stack is older and "warmer".
+   Instead, we introduce a third stack, "baseline", that runs blue code but in the same context (age, replicas)
+   as green. The baseline stack name is held by the **`baseline` annotation**.
+   
+   The **`desired-switch-duration` annotation** determines how long the progressive traffic switch will take.
+   The stackset controller will adapt the size of each traffic switch increment to approximately match that
+   duration.
+
+1. Green stacks (stacks with the `is-green` annotation) are analyzed in the new `ReconcileStacks` method
+   of the TrafficReconciler, which decides the direction of traffic switch (continue deploying, or rollback),
+   creates the baseline stack when needed, and updates the stack annotations.
+   
+1. `ReconcileIngress` computes the new traffic values according to `ReconcileStacks`' decision, and calls the
+   underlying `TrafficReconciler.ReconcileIngress` method to abstract away pre-scaling details.
+
+1. After the green stack reaches 100% of the target traffic (both blue and baseline are at 0%), its performance
+   is still monitored according to the `desired-final-observation-duration` annotation.
+   
+1. After the observation period, the `is-green` annotation is removed and the stack is treated just like
+   any other. Blue and baseline are not specially removed: they will be deleted according to the stack limit.

--- a/controller/canary/annotations.go
+++ b/controller/canary/annotations.go
@@ -1,0 +1,44 @@
+package canary
+
+const (
+	canaryAnnotationKeyPrefix = "stackset-controller.zalando.org/canary."
+
+	StacksetAnnotationKey = canaryAnnotationKeyPrefix + "gradual-deployments-enabled"
+
+	// greenAnnotationKey is the Green stack annotation that identifies a stack as Green.
+	// All other annotations may be kept after a successful gradual traffic switch
+	// (for informational purposes) and so cannot be reliably used to select
+	// currently Green stacks that deserve attention.
+	greenAnnotationKey = canaryAnnotationKeyPrefix + "is-green"
+
+	// baselineAnnotationKey is the Green stack annotation recording
+	// the corresponding Baseline stack's ID.
+	// Empty or absent if Baseline doesn't exist yet.
+	baselineAnnotationKey = canaryAnnotationKeyPrefix + "baseline"
+
+	// blueAnnotationKey is the Green stack annotation recording
+	// the corresponding Blue stack's ID. Required.
+	blueAnnotationKey = canaryAnnotationKeyPrefix + "blue"
+
+	// desiredSwitchDurationKey is the Green stack annotation that records the user-specified
+	// duration after which Green should be receiving 100% of traffic. Required.
+	desiredSwitchDurationKey = canaryAnnotationKeyPrefix + "desired-switch-duration"
+
+	// switchStartKey is the Green stack annotation that records when the Green stack started
+	// being assigned more than 0% of traffic (the "start of the traffic switching").
+	// Empty or absent if the traffic switch has not started.
+	switchStartKey = canaryAnnotationKeyPrefix + "switch-start"
+
+	// desiredFinalDurationKey is the Green stack annotation that records the user-specified
+	// duration between Green receiving 100% of traffic and Green no longer being monitored.
+	// In other words, it is the duration for which a completely-switched Green stack can
+	// still be disabled by a rollback to Baseline. Required.
+	desiredFinalDurationKey = canaryAnnotationKeyPrefix + "desired-final-observation-duration"
+
+	// finalStartKey is the Green stack annotation that records when the Green stack
+	// started its final observation period, i.e. the period during which it is assigned
+	// 100% of traffic but is still monitored and could still be rolled back to Baseline
+	// if the user expectations were no longer satisfied.
+	// Empty or absent if the final observation period has not started.
+	finalStartKey = canaryAnnotationKeyPrefix + "final-observation-start"
+)

--- a/controller/canary/canary_context.go
+++ b/controller/canary/canary_context.go
@@ -7,14 +7,14 @@ import (
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 )
 
-type Env struct {
+type CanaryContext struct {
 	Client KubeClient
 	Logger logrus.FieldLogger
 }
 
-func (e Env) WithLogger(logger logrus.FieldLogger) Env {
-	return Env{
-		Client: e.Client,
+func (c CanaryContext) WithLogger(logger logrus.FieldLogger) CanaryContext {
+	return CanaryContext{
+		Client: c.Client,
 		Logger: logger,
 	}
 }
@@ -28,13 +28,13 @@ type KubeClient interface {
 	MarkStackNotGreen(set *zv1.StackSet, stack *zv1.Stack, reason string)
 }
 
-func (e Env) SetAnnotation(
+func (c CanaryContext) SetAnnotation(
 	set *zv1.StackSet,
 	stack *zv1.Stack,
 	key, value string,
 ) (*zv1.Stack, error) {
 	stack.Annotations[key] = value
 	msg := fmt.Sprintf("set annotation %q to %q", key, value)
-	e.Logger.Debugf("stack %s/%s: %s", stack.Namespace, stack.Name, msg)
-	return e.Client.UpdateStack(set, stack, msg)
+	c.Logger.Debugf("stack %s/%s: %s", stack.Namespace, stack.Name, msg)
+	return c.Client.UpdateStack(set, stack, msg)
 }

--- a/controller/canary/env.go
+++ b/controller/canary/env.go
@@ -1,0 +1,40 @@
+package canary
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+)
+
+type Env struct {
+	Client KubeClient
+	Logger logrus.FieldLogger
+}
+
+func (e Env) WithLogger(logger logrus.FieldLogger) Env {
+	return Env{
+		Client: e.Client,
+		Logger: logger,
+	}
+}
+
+type KubeClient interface {
+	CreateStack(set *zv1.StackSet, name string, version string, spec zv1.StackSpec) (*zv1.Stack, error)
+	UpdateStack(set *zv1.StackSet, stack *zv1.Stack, reasonFmt string, reasonArgs ...interface{}) (*zv1.Stack, error)
+	RemoveStack(set *zv1.StackSet, name, reasonFmt string, reasonArgs ...interface{}) error
+	// MarkStackNotGreen always succeeds. Even if the underlying k8s call fails, there is no point
+	// in returning an error since we are not doing anything with non-green stacks.
+	MarkStackNotGreen(set *zv1.StackSet, stack *zv1.Stack, reason string)
+}
+
+func (e Env) SetAnnotation(
+	set *zv1.StackSet,
+	stack *zv1.Stack,
+	key, value string,
+) (*zv1.Stack, error) {
+	stack.Annotations[key] = value
+	msg := fmt.Sprintf("set annotation %q to %q", key, value)
+	e.Logger.Debugf("stack %s/%s: %s", stack.Namespace, stack.Name, msg)
+	return e.Client.UpdateStack(set, stack, msg)
+}

--- a/controller/canary/errors.go
+++ b/controller/canary/errors.go
@@ -1,0 +1,110 @@
+package canary
+
+import (
+	"fmt"
+)
+
+type stackId struct {
+	name      string
+	namespace string
+	kind      stackKind
+}
+
+func newStackId(stack canaryStack) stackId {
+	return stackId{
+		name:      stack.Name,
+		namespace: stack.Namespace,
+		kind:      stack.canaryKind,
+	}
+}
+
+func (s stackId) String() string {
+	qualifiedName := fmt.Sprintf("%s/%s", s.namespace, s.name)
+	return fmt.Sprintf("%s stack %q", s.kind, qualifiedName)
+}
+
+type noBlueAnnotError struct {
+	stack stackId
+}
+
+func (e noBlueAnnotError) Error() string {
+	return fmt.Sprintf(
+		"missing annotation %q in %s",
+		blueAnnotationKey, e.stack,
+	)
+}
+
+func newNoBlueAnnotError(green canaryStack) noBlueAnnotError {
+	return noBlueAnnotError{newStackId(green)}
+}
+
+type stackNotFoundError struct {
+	green stackId
+	lost  stackId
+}
+
+func (e stackNotFoundError) Error() string {
+	return fmt.Sprintf("%s not found for %s", e.lost, e.green)
+}
+
+func newStackNotFoundError(green canaryStack, name string, kind stackKind) stackNotFoundError {
+	return stackNotFoundError{
+		green: newStackId(green),
+		lost: stackId{
+			name:      name,
+			namespace: green.Namespace,
+			kind:      kind,
+		},
+	}
+}
+
+type noTrafficDataError struct {
+	stack stackId
+}
+
+func (e noTrafficDataError) Error() string {
+	return fmt.Sprintf("no traffic data in ingress for %s", e.stack)
+}
+
+func newNoTrafficDataError(stack canaryStack) noTrafficDataError {
+	return noTrafficDataError{newStackId(stack)}
+}
+
+type badDurationError struct {
+	green    stackId
+	duration string
+	key      string
+}
+
+func (e badDurationError) Error() string {
+	return fmt.Sprintf(
+		"bad %q period specified for %s: %q",
+		e.key, e.green, e.duration,
+	)
+}
+
+func newBadDurationError(green canaryStack, duration, key string) badDurationError {
+	return badDurationError{
+		green:    newStackId(green),
+		duration: duration,
+		key:      key,
+	}
+}
+
+type badObservationStartError struct {
+	green stackId
+	start string
+}
+
+func (e badObservationStartError) Error() string {
+	return fmt.Sprintf(
+		"bad observation start timestamp %q specified for %s: %q",
+		finalStartKey, e.green, e.start,
+	)
+}
+
+func newBadObservationStartError(green canaryStack) badObservationStartError {
+	return badObservationStartError{
+		green: newStackId(green),
+	}
+}

--- a/controller/canary/expectation_checker.go
+++ b/controller/canary/expectation_checker.go
@@ -1,0 +1,14 @@
+package canary
+
+import (
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+)
+
+// ExpectationChecker defines the interface between stackset-controller
+// and the component in charge of deciding whether a gradual traffic switching
+// should continue.
+type ExpectationChecker interface {
+	// ExpectationsFulfilled returns whether stack green still fulfills user expectations
+	// compared to baseline.
+	ExpectationsFulfilled(green, baseline zv1.Stack) bool
+}

--- a/controller/canary/expectation_checker_annotation.go
+++ b/controller/canary/expectation_checker_annotation.go
@@ -1,0 +1,12 @@
+package canary
+
+import v1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+
+type annotationChecker struct{}
+
+const annotationCheckerKey = canaryAnnotationKeyPrefix + "expectations-not-fulfilled"
+
+func (c annotationChecker) ExpectationsFulfilled(green, _ v1.Stack) bool {
+	_, ok := green.Annotations[annotationCheckerKey]
+	return !ok
+}

--- a/controller/canary/expectation_checker_annotation.go
+++ b/controller/canary/expectation_checker_annotation.go
@@ -1,18 +1,18 @@
 package canary
 
-import v1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+import zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 
 // annotationChecker is a very basic ExpectationChecker.
 // It considers expectations fulfilled if and only if the green stack does not have
-// the annotationCheckerKey annotation, which is not removed.
+// the annotationCheckerKey annotation (which is not removed if it exists).
 // Handy for manual experiments, but do not use in production:
-// it probably is not be desirable to continue a gradual deployment when the service responsible
-// for adding the annotationCheckerKey annotation is down.
+// it probably is not desirable to continue a gradual deployment when the service responsible
+// for adding the annotation is down.
 type annotationChecker struct{}
 
 const annotationCheckerKey = canaryAnnotationKeyPrefix + "expectations-not-fulfilled"
 
-func (c annotationChecker) ExpectationsFulfilled(green, _ v1.Stack) bool {
+func (c annotationChecker) ExpectationsFulfilled(green, _ zv1.Stack) bool {
 	_, ok := green.Annotations[annotationCheckerKey]
 	return !ok
 }

--- a/controller/canary/expectation_checker_annotation.go
+++ b/controller/canary/expectation_checker_annotation.go
@@ -2,6 +2,12 @@ package canary
 
 import v1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 
+// annotationChecker is a very basic ExpectationChecker.
+// It considers expectations fulfilled if and only if the green stack does not have
+// the annotationCheckerKey annotation, which is not removed.
+// Handy for manual experiments, but do not use in production:
+// it probably is not be desirable to continue a gradual deployment when the service responsible
+// for adding the annotationCheckerKey annotation is down.
 type annotationChecker struct{}
 
 const annotationCheckerKey = canaryAnnotationKeyPrefix + "expectations-not-fulfilled"

--- a/controller/canary/full_blue_rollback.go
+++ b/controller/canary/full_blue_rollback.go
@@ -1,0 +1,16 @@
+package canary
+
+import "github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+
+// FullBlueRollBack is a Rollbacker that switches all the visible traffic onto the Blue stack.
+type FullBlueRollBack struct {
+	blueName           string
+	baselineName       string
+	greenName          string
+	totalActualTraffic percent.Percent
+}
+
+func (rb FullBlueRollBack) Rollback(trafficMap TrafficMap) (TrafficMap, error) {
+	modifiableStacks := StackNameSet{rb.baselineName: struct{}{}, rb.greenName: struct{}{}}
+	return ComputeNewTraffic(trafficMap, rb.blueName, rb.totalActualTraffic, modifiableStacks)
+}

--- a/controller/canary/increase.go
+++ b/controller/canary/increase.go
@@ -20,7 +20,7 @@ func increaseTraffic(
 		),
 	))
 
-	if greenActualTraffic == *newGreenTraffic {
+	if greenActualTraffic == newGreenTraffic {
 		return trafficMap, nil
 	}
 
@@ -31,7 +31,7 @@ func increaseTraffic(
 		newTrafficMap, err = ComputeNewTraffic(
 			trafficMap,
 			greenName,
-			*newGreenTraffic,
+			newGreenTraffic,
 			modifiableStacks,
 		)
 	} else { // Phase 1
@@ -39,7 +39,7 @@ func increaseTraffic(
 		newTrafficMap, err = ComputeNewTraffic(
 			trafficMap,
 			blueName,
-			*newBlueTraffic,
+			newBlueTraffic,
 			modifiableStacks,
 		)
 	}

--- a/controller/canary/increase.go
+++ b/controller/canary/increase.go
@@ -1,0 +1,47 @@
+package canary
+
+import (
+	"math"
+	"time"
+
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+)
+
+func increaseTraffic(
+	trafficMap TrafficMap,
+	blueName, baselineName, greenName string,
+	greenActualTraffic, totalActualTraffic percent.Percent,
+	desiredSwitchDuration, elapsedTime time.Duration,
+) (newTrafficMap TrafficMap, err error) {
+	newGreenTraffic := percent.NewFromFloat(math.Min(
+		100,
+		math.Ceil(
+			totalActualTraffic.AsFloat()*float64(elapsedTime)/float64(desiredSwitchDuration),
+		),
+	))
+
+	if greenActualTraffic == *newGreenTraffic {
+		return trafficMap, nil
+	}
+
+	modifiableStacks := StackNameSet{baselineName: struct{}{}, greenName: struct{}{}}
+	blueActualTraffic := percent.NewFromFloat(trafficMap[blueName].ActualWeight)
+
+	if blueActualTraffic.IsZero() { // Phase 2
+		newTrafficMap, err = ComputeNewTraffic(
+			trafficMap,
+			greenName,
+			*newGreenTraffic,
+			modifiableStacks,
+		)
+	} else { // Phase 1
+		newBlueTraffic := totalActualTraffic.SubCapped(newGreenTraffic.AddCapped(newGreenTraffic))
+		newTrafficMap, err = ComputeNewTraffic(
+			trafficMap,
+			blueName,
+			*newBlueTraffic,
+			modifiableStacks,
+		)
+	}
+	return
+}

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -1,0 +1,18 @@
+package canary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando-incubator/stackset-controller/controller/entities"
+)
+
+func Test_Unchanged_GreenTraffic(t *testing.T) {
+	trafficMap := TrafficMap{
+		"A": entities.NewTrafficStatusSame(100),
+		"B": entities.NewTrafficStatusSame(100),
+		"C": entities.NewTrafficStatusSame(100),
+	}
+
+	assert.Equal(t, trafficMap, trafficMap)
+}

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -32,6 +32,33 @@ func Test_Unchanged_GreenTraffic(t *testing.T) {
 
 func Test_Phase1(t *testing.T) {
 	trafficMap := TrafficMap{
+		"A": entities.NewTrafficStatusSame(20),
+		"B": entities.NewTrafficStatusSame(40),
+		"C": entities.NewTrafficStatusSame(40),
+	}
+
+	expectedMap := TrafficMap{
+		"A": entities.NewTrafficStatus(20, 80),
+		"B": entities.NewTrafficStatus(40, 10),
+		"C": entities.NewTrafficStatus(40, 10),
+	}
+
+	newTraffic, _ := increaseTraffic(
+		trafficMap,
+		"A",
+		"B",
+		"C",
+		*percent.NewFromInt(40),
+		*percent.NewFromInt(100),
+		10*60*1000*time.Millisecond,
+		1*60*1000*time.Millisecond,
+	)
+
+	assert.Equal(t, expectedMap, newTraffic)
+}
+
+func Test_Phase2(t *testing.T) {
+	trafficMap := TrafficMap{
 		"A": entities.NewTrafficStatusSame(0),
 		"B": entities.NewTrafficStatusSame(55),
 		"C": entities.NewTrafficStatusSame(45),

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -50,8 +50,8 @@ func Test_Phase1(t *testing.T) {
 		"C",
 		*percent.NewFromInt(45),
 		*percent.NewFromInt(100),
-		2 * 60 * 1000 * time.Millisecond,
-		1 * 60 * 1000 * time.Millisecond,
+		2*60*1000*time.Millisecond,
+		1*60*1000*time.Millisecond,
 	)
 
 	assert.Equal(t, expectedMap, newTraffic)

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -9,11 +9,26 @@ import (
 	"github.com/zalando-incubator/stackset-controller/controller/entities"
 )
 
+// Helper test constructors for common TrafficStatus values
+func NewTrafficStatusSame(weight float64) entities.TrafficStatus {
+	return entities.TrafficStatus{
+		ActualWeight:  weight,
+		DesiredWeight: weight,
+	}
+}
+
+func NewTrafficStatus(actualWeight, desiredWeight float64) entities.TrafficStatus {
+	return entities.TrafficStatus{
+		ActualWeight:  actualWeight,
+		DesiredWeight: desiredWeight,
+	}
+}
+
 func Test_Unchanged_GreenTraffic(t *testing.T) {
 	trafficMap := TrafficMap{
-		"A": entities.NewTrafficStatusSame(100),
-		"B": entities.NewTrafficStatusSame(0),
-		"C": entities.NewTrafficStatusSame(0),
+		"A": NewTrafficStatusSame(100),
+		"B": NewTrafficStatusSame(0),
+		"C": NewTrafficStatusSame(0),
 	}
 
 	newTraffic, _ := increaseTraffic(
@@ -21,8 +36,8 @@ func Test_Unchanged_GreenTraffic(t *testing.T) {
 		"A",
 		"B",
 		"C",
-		*percent.NewFromInt(95),
-		*percent.NewFromInt(95),
+		percent.NewFromInt(95),
+		percent.NewFromInt(95),
 		time.Millisecond,
 		time.Millisecond,
 	)
@@ -32,15 +47,15 @@ func Test_Unchanged_GreenTraffic(t *testing.T) {
 
 func Test_Phase1(t *testing.T) {
 	trafficMap := TrafficMap{
-		"A": entities.NewTrafficStatusSame(20),
-		"B": entities.NewTrafficStatusSame(40),
-		"C": entities.NewTrafficStatusSame(40),
+		"A": NewTrafficStatusSame(20),
+		"B": NewTrafficStatusSame(40),
+		"C": NewTrafficStatusSame(40),
 	}
 
 	expectedMap := TrafficMap{
-		"A": entities.NewTrafficStatus(20, 80),
-		"B": entities.NewTrafficStatus(40, 10),
-		"C": entities.NewTrafficStatus(40, 10),
+		"A": NewTrafficStatus(20, 80),
+		"B": NewTrafficStatus(40, 10),
+		"C": NewTrafficStatus(40, 10),
 	}
 
 	newTraffic, _ := increaseTraffic(
@@ -48,8 +63,8 @@ func Test_Phase1(t *testing.T) {
 		"A",
 		"B",
 		"C",
-		*percent.NewFromInt(40),
-		*percent.NewFromInt(100),
+		percent.NewFromInt(40),
+		percent.NewFromInt(100),
 		10*60*1000*time.Millisecond,
 		1*60*1000*time.Millisecond,
 	)
@@ -59,15 +74,15 @@ func Test_Phase1(t *testing.T) {
 
 func Test_Phase2(t *testing.T) {
 	trafficMap := TrafficMap{
-		"A": entities.NewTrafficStatusSame(0),
-		"B": entities.NewTrafficStatusSame(55),
-		"C": entities.NewTrafficStatusSame(45),
+		"A": NewTrafficStatusSame(0),
+		"B": NewTrafficStatusSame(55),
+		"C": NewTrafficStatusSame(45),
 	}
 
 	expectedMap := TrafficMap{
-		"A": entities.NewTrafficStatusSame(0),
-		"B": entities.NewTrafficStatus(55, 50),
-		"C": entities.NewTrafficStatus(45, 50),
+		"A": NewTrafficStatusSame(0),
+		"B": NewTrafficStatus(55, 50),
+		"C": NewTrafficStatus(45, 50),
 	}
 
 	newTraffic, _ := increaseTraffic(
@@ -75,8 +90,8 @@ func Test_Phase2(t *testing.T) {
 		"A",
 		"B",
 		"C",
-		*percent.NewFromInt(45),
-		*percent.NewFromInt(100),
+		percent.NewFromInt(45),
+		percent.NewFromInt(100),
 		2*60*1000*time.Millisecond,
 		1*60*1000*time.Millisecond,
 	)

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -29,3 +29,30 @@ func Test_Unchanged_GreenTraffic(t *testing.T) {
 
 	assert.Equal(t, trafficMap, newTraffic)
 }
+
+func Test_Phase1(t *testing.T) {
+	trafficMap := TrafficMap{
+		"A": entities.NewTrafficStatusSame(0),
+		"B": entities.NewTrafficStatusSame(55),
+		"C": entities.NewTrafficStatusSame(45),
+	}
+
+	expectedMap := TrafficMap{
+		"A": entities.NewTrafficStatusSame(0),
+		"B": entities.NewTrafficStatus(55, 50),
+		"C": entities.NewTrafficStatus(45, 50),
+	}
+
+	newTraffic, _ := increaseTraffic(
+		trafficMap,
+		"A",
+		"B",
+		"C",
+		*percent.NewFromInt(45),
+		*percent.NewFromInt(100),
+		2 * 60 * 1000 * time.Millisecond,
+		1 * 60 * 1000 * time.Millisecond,
+	)
+
+	assert.Equal(t, expectedMap, newTraffic)
+}

--- a/controller/canary/increase_test.go
+++ b/controller/canary/increase_test.go
@@ -2,17 +2,30 @@ package canary
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
 	"github.com/zalando-incubator/stackset-controller/controller/entities"
 )
 
 func Test_Unchanged_GreenTraffic(t *testing.T) {
 	trafficMap := TrafficMap{
 		"A": entities.NewTrafficStatusSame(100),
-		"B": entities.NewTrafficStatusSame(100),
-		"C": entities.NewTrafficStatusSame(100),
+		"B": entities.NewTrafficStatusSame(0),
+		"C": entities.NewTrafficStatusSame(0),
 	}
 
-	assert.Equal(t, trafficMap, trafficMap)
+	newTraffic, _ := increaseTraffic(
+		trafficMap,
+		"A",
+		"B",
+		"C",
+		*percent.NewFromInt(95),
+		*percent.NewFromInt(95),
+		time.Millisecond,
+		time.Millisecond,
+	)
+
+	assert.Equal(t, trafficMap, newTraffic)
 }

--- a/controller/canary/kubeclient_real.go
+++ b/controller/canary/kubeclient_real.go
@@ -1,0 +1,102 @@
+package canary
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/stackset-controller/controller/entities"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type RealKubeClient struct {
+	client   clientset.Interface
+	recorder record.EventRecorder
+	log      logrus.FieldLogger
+}
+
+func NewRealKubeClient(
+	client clientset.Interface,
+	rec record.EventRecorder,
+	logger logrus.FieldLogger,
+) *RealKubeClient {
+	return &RealKubeClient{
+		client:   client,
+		recorder: rec,
+		log:      logger,
+	}
+}
+
+func (c *RealKubeClient) CreateStack(
+	set *zv1.StackSet,
+	name string,
+	version string,
+	spec zv1.StackSpec,
+) (*zv1.Stack, error) {
+	owner := v1.OwnerReference{
+		APIVersion: set.APIVersion,
+		Kind:       set.Kind,
+		Name:       set.Name,
+		UID:        set.UID,
+	}
+	stack := entities.NewStack(name, set.Namespace, version, owner, spec)
+	for k, v := range set.Labels {
+		stack.Labels[k] = v
+	}
+	c.recorder.Eventf(
+		set,
+		apiv1.EventTypeNormal,
+		"CreateStackSetStack",
+		"Creating Stack '%s/%s' for StackSet",
+		stack.Namespace, stack.Name,
+	)
+	return c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
+}
+
+func (c *RealKubeClient) UpdateStack(
+	set *zv1.StackSet,
+	stack *zv1.Stack,
+	reasonFmt string,
+	reasonArgs ...interface{},
+) (*zv1.Stack, error) {
+	c.recorder.Eventf(
+		set,
+		apiv1.EventTypeNormal,
+		"UpdateStackSetStack",
+		"Updating Stack '%s/%s' for StackSet: %s",
+		stack.Namespace, stack.Name, fmt.Sprintf(reasonFmt, reasonArgs...),
+	)
+	return c.client.ZalandoV1().Stacks(stack.Namespace).Update(stack)
+}
+
+func (c *RealKubeClient) RemoveStack(set *zv1.StackSet, name, reasonFmt string, reasonArgs ...interface{}) error {
+	c.recorder.Eventf(
+		set,
+		apiv1.EventTypeNormal,
+		"RemoveStackSetStack",
+		"Deleting Stack '%s/%s' for StackSet: %s",
+		set.Namespace, name, fmt.Sprintf(reasonFmt, reasonArgs...),
+	)
+	return c.client.ZalandoV1().Stacks(set.Namespace).Delete(name, v1.NewDeleteOptions(0))
+}
+
+func (c *RealKubeClient) MarkStackNotGreen(set *zv1.StackSet, stack *zv1.Stack, reason string) {
+	// TODO: Add an annotation with the reason of unmarking.
+
+	stack, err := c.client.ZalandoV1().Stacks(set.Namespace).Get(stack.Name, v1.GetOptions{})
+	if err != nil {
+		c.log.Errorf("failed to fetch the latest stack %s: %s", stack.Name, err)
+	}
+
+	delete(stack.Annotations, greenAnnotationKey)
+
+	newStack, err := c.UpdateStack(set, stack, "MarkStackNotGreen: %s", reason)
+	if err == nil {
+		*stack = *newStack
+	} else {
+		c.log.Errorf("failed to remove is-green annotation: %s", err)
+	}
+}

--- a/controller/canary/kubeclient_real.go
+++ b/controller/canary/kubeclient_real.go
@@ -46,14 +46,22 @@ func (c *RealKubeClient) CreateStack(
 	for k, v := range set.Labels {
 		stack.Labels[k] = v
 	}
+
+	newStack, err := c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
+	if err != nil {
+		c.log.Errorf("Could not create Stack %s: %s", stack.Name, err)
+		return nil, err
+	}
+
 	c.recorder.Eventf(
 		set,
 		apiv1.EventTypeNormal,
 		"CreateStackSetStack",
-		"Creating Stack '%s/%s' for StackSet",
+		"Created Stack '%s/%s' for StackSet",
 		stack.Namespace, stack.Name,
 	)
-	return c.client.ZalandoV1().Stacks(stack.Namespace).Create(stack)
+
+	return newStack, nil
 }
 
 func (c *RealKubeClient) UpdateStack(

--- a/controller/canary/percent/percent.go
+++ b/controller/canary/percent/percent.go
@@ -1,0 +1,157 @@
+package percent
+
+import (
+	"fmt"
+	"math"
+)
+
+// Percent is a fixed-precision numeric type for representing percentages
+// with one decimal place.
+// It is a struct in order to prevent direct comparisons of the underlying
+// representation with unrelated values, which may return irrelevant results
+// if the internal representation uses a different format.
+//
+// Compared to float, Percent does range validation, captures intent, and allows
+// simple comparisons (whereas comparing floats can be dangerous).
+// Compared to math/big.Rat, Percent does range validation and captures intent,
+// while keeping a simple implementation.
+//
+// Range errors are stored in the corresponding (invalid) Percent result, instead of
+// returning error on each method call, and are returned by the Error() method.
+// A Percent in error state will short-circuit all arithmetic operations and panic in
+// conversion methods like AsFloat.
+type Percent struct {
+	val int
+	err error
+}
+
+// NewFromFloat converts a float64 into a Percent value.
+// Since Percent has a precision of only one decimal place, f is rounded to the closest 0.1.
+// An "error" Percent is returned if f represents a value larger than 100 or negative.
+func NewFromFloat(f float64) *Percent {
+	expanded := math.Round(f * 10)
+	if expanded < 0 || expanded > 1000 || math.IsNaN(expanded) {
+		return &Percent{err: fmt.Errorf("invalid percentage: %v", f)}
+	}
+	return &Percent{val: int(expanded)}
+}
+
+// NewFromInt converts an int into a Percent value.
+// An error is returned if n represents a value larger than 100 or negative.
+func NewFromInt(n int) *Percent {
+	if n < 0 || n > 100 {
+		return &Percent{err: fmt.Errorf("invalid percentage: %v", n)}
+	}
+	return &Percent{val: int(n * 10)}
+}
+
+// Error returns the error associated with this percentage, if any.
+func (p *Percent) Error() error {
+	return p.err
+}
+
+// AsFloat converts p into a string. It panics if p has an error.
+func (p *Percent) String() string {
+	if p.err != nil {
+		panic(fmt.Sprintf("can't call String on invalid Percent: %v", p.err))
+	}
+	return fmt.Sprintf("%.3g%%", float64(p.val)/10)
+}
+
+// AsFloat converts p into a float64. It panics if p has an error.
+func (p *Percent) AsFloat() float64 {
+	if p.err != nil {
+		panic(fmt.Sprintf("can't call AsFloat on invalid Percent: %v", p.err))
+	}
+	return float64(p.val) / 10
+}
+
+// IsZero returns true if and only if p represents 0%. It panics if p has an error.
+func (p *Percent) IsZero() bool {
+	if p.err != nil {
+		panic(fmt.Sprintf("can't call IsZero on invalid Percent: %v", p.err))
+	}
+	return p.val == 0
+}
+
+// Is100 returns true if and only if p represents 100%. It panics if p has an error.
+func (p *Percent) Is100() bool {
+	if p.err != nil {
+		panic(fmt.Sprintf("can't call Is100 on invalid Percent: %v", p.err))
+	}
+	return p.val == 1000
+}
+
+// Cmp compares p and q and returns X such as:
+// X < 0 if p < q, X == 0 if p == q, and X > 0 if p > q.
+// It panics if either p or q have an error.
+func (p *Percent) Cmp(q *Percent) int {
+	return p.val - q.val
+}
+
+func shortCircuitErrors(res, p, q *Percent) bool {
+	if p.err != nil {
+		res.err = p.err
+		return true
+	}
+	if q.err != nil {
+		res.err = q.err
+		return true
+	}
+	return false
+}
+
+// Add sets z to the sum x+y and returns z.
+// The result has an error if either x or y have an error, or if x+y is larger than 100.
+func (p *Percent) Add(q *Percent) *Percent {
+	res := &Percent{}
+	if shortCircuitErrors(res, p, q) {
+		return res
+	}
+	sum := p.val + q.val
+	if sum > 1000 {
+		res.err = fmt.Errorf("cannot add %s to %s: result is above 100%%", p, q)
+	} else {
+		res.val = sum
+	}
+	return res
+}
+
+// AddCapped returns min(p+q, 100).
+// The result has an error if either x or y have an error.
+func (p *Percent) AddCapped(q *Percent) *Percent {
+	res := &Percent{val: 1000}
+	if shortCircuitErrors(res, p, q) {
+		return res
+	}
+	sum := p.val + q.val
+	if sum < 1000 {
+		res.val = sum
+	}
+	return res
+}
+
+// SubCapped returns max(p-q, 0).
+// The result has an error if either x or y have an error.
+func (p *Percent) SubCapped(q *Percent) *Percent {
+	res := &Percent{}
+	if shortCircuitErrors(res, p, q) {
+		return res
+	}
+	result := p.val - q.val
+	if result > 0 {
+		res.val = result
+	}
+	return res
+}
+
+// Mul sets z to the product x×y and returns z.
+// The result has an error if either x or y have an error.
+func (p *Percent) Mul(q *Percent) *Percent {
+	res := &Percent{}
+	if shortCircuitErrors(res, p, q) {
+		return res
+	}
+	res.val = int(math.Round(float64(p.val*q.val) / 1000)) // <0 or >100 are impossible
+	return res
+}

--- a/controller/canary/percent/percent.go
+++ b/controller/canary/percent/percent.go
@@ -28,30 +28,30 @@ type Percent struct {
 // NewFromFloat converts a float64 into a Percent value.
 // Since Percent has a precision of only one decimal place, f is rounded to the closest 0.1.
 // An "error" Percent is returned if f represents a value larger than 100 or negative.
-func NewFromFloat(f float64) *Percent {
+func NewFromFloat(f float64) Percent {
 	expanded := math.Round(f * 10)
 	if expanded < 0 || expanded > 1000 || math.IsNaN(expanded) {
-		return &Percent{err: fmt.Errorf("invalid percentage: %v", f)}
+		return Percent{err: fmt.Errorf("invalid percentage: %v", f)}
 	}
-	return &Percent{val: int(expanded)}
+	return Percent{val: int(expanded)}
 }
 
 // NewFromInt converts an int into a Percent value.
 // An error is returned if n represents a value larger than 100 or negative.
-func NewFromInt(n int) *Percent {
+func NewFromInt(n int) Percent {
 	if n < 0 || n > 100 {
-		return &Percent{err: fmt.Errorf("invalid percentage: %v", n)}
+		return Percent{err: fmt.Errorf("invalid percentage: %v", n)}
 	}
-	return &Percent{val: int(n * 10)}
+	return Percent{val: int(n * 10)}
 }
 
 // Error returns the error associated with this percentage, if any.
-func (p *Percent) Error() error {
+func (p Percent) Error() error {
 	return p.err
 }
 
 // AsFloat converts p into a string. It panics if p has an error.
-func (p *Percent) String() string {
+func (p Percent) String() string {
 	if p.err != nil {
 		panic(fmt.Sprintf("can't call String on invalid Percent: %v", p.err))
 	}
@@ -59,7 +59,7 @@ func (p *Percent) String() string {
 }
 
 // AsFloat converts p into a float64. It panics if p has an error.
-func (p *Percent) AsFloat() float64 {
+func (p Percent) AsFloat() float64 {
 	if p.err != nil {
 		panic(fmt.Sprintf("can't call AsFloat on invalid Percent: %v", p.err))
 	}
@@ -67,7 +67,7 @@ func (p *Percent) AsFloat() float64 {
 }
 
 // IsZero returns true if and only if p represents 0%. It panics if p has an error.
-func (p *Percent) IsZero() bool {
+func (p Percent) IsZero() bool {
 	if p.err != nil {
 		panic(fmt.Sprintf("can't call IsZero on invalid Percent: %v", p.err))
 	}
@@ -75,7 +75,7 @@ func (p *Percent) IsZero() bool {
 }
 
 // Is100 returns true if and only if p represents 100%. It panics if p has an error.
-func (p *Percent) Is100() bool {
+func (p Percent) Is100() bool {
 	if p.err != nil {
 		panic(fmt.Sprintf("can't call Is100 on invalid Percent: %v", p.err))
 	}
@@ -85,7 +85,7 @@ func (p *Percent) Is100() bool {
 // Cmp compares p and q and returns X such as:
 // X < 0 if p < q, X == 0 if p == q, and X > 0 if p > q.
 // It panics if either p or q have an error.
-func (p *Percent) Cmp(q *Percent) int {
+func (p Percent) Cmp(q Percent) int {
 	if p.err != nil {
 		panic(fmt.Sprintf("can't call Cmp on invalid Percent: %v", p.err))
 	}
@@ -95,7 +95,7 @@ func (p *Percent) Cmp(q *Percent) int {
 	return p.val - q.val
 }
 
-func shortCircuitErrors(res, p, q *Percent) bool {
+func shortCircuitErrors(res, p, q Percent) bool {
 	if p.err != nil {
 		res.err = p.err
 		return true
@@ -109,8 +109,8 @@ func shortCircuitErrors(res, p, q *Percent) bool {
 
 // Add sets z to the sum x+y and returns z.
 // The result has an error if either x or y have an error, or if x+y is larger than 100.
-func (p *Percent) Add(q *Percent) *Percent {
-	res := &Percent{}
+func (p Percent) Add(q Percent) Percent {
+	res := Percent{}
 	if shortCircuitErrors(res, p, q) {
 		return res
 	}
@@ -125,8 +125,8 @@ func (p *Percent) Add(q *Percent) *Percent {
 
 // AddCapped returns min(p+q, 100).
 // The result has an error if either x or y have an error.
-func (p *Percent) AddCapped(q *Percent) *Percent {
-	res := &Percent{val: 1000}
+func (p Percent) AddCapped(q Percent) Percent {
+	res := Percent{val: 1000}
 	if shortCircuitErrors(res, p, q) {
 		return res
 	}
@@ -139,8 +139,8 @@ func (p *Percent) AddCapped(q *Percent) *Percent {
 
 // SubCapped returns max(p-q, 0).
 // The result has an error if either x or y have an error.
-func (p *Percent) SubCapped(q *Percent) *Percent {
-	res := &Percent{}
+func (p Percent) SubCapped(q Percent) Percent {
+	res := Percent{}
 	if shortCircuitErrors(res, p, q) {
 		return res
 	}
@@ -153,8 +153,8 @@ func (p *Percent) SubCapped(q *Percent) *Percent {
 
 // Mul sets z to the product x×y and returns z.
 // The result has an error if either x or y have an error.
-func (p *Percent) Mul(q *Percent) *Percent {
-	res := &Percent{}
+func (p Percent) Mul(q Percent) Percent {
+	res := Percent{}
 	if shortCircuitErrors(res, p, q) {
 		return res
 	}

--- a/controller/canary/percent/percent.go
+++ b/controller/canary/percent/percent.go
@@ -86,6 +86,12 @@ func (p *Percent) Is100() bool {
 // X < 0 if p < q, X == 0 if p == q, and X > 0 if p > q.
 // It panics if either p or q have an error.
 func (p *Percent) Cmp(q *Percent) int {
+	if p.err != nil {
+		panic(fmt.Sprintf("can't call Cmp on invalid Percent: %v", p.err))
+	}
+	if q.err != nil {
+		panic(fmt.Sprintf("can't call Cmp on invalid Percent: %v", q.err))
+	}
 	return p.val - q.val
 }
 

--- a/controller/canary/percent/percent_test.go
+++ b/controller/canary/percent/percent_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestPercent_String(t *testing.T) {
 	pc100 := percent.NewFromInt(100)
-	assert.Equal(t, "100%", pc100.String())
+	assert.Equal(t, `100%`, pc100.String())
 
 	pc25_1 := percent.NewFromFloat(25.1)
-	assert.Equal(t, "25.1%", fmt.Sprintf("%v", pc25_1))
+	assert.Equal(t, `25.1%`, fmt.Sprintf("%v", pc25_1))
 }
 
 func TestPercent_AsFloat(t *testing.T) {

--- a/controller/canary/percent/percent_test.go
+++ b/controller/canary/percent/percent_test.go
@@ -1,0 +1,75 @@
+package percent_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+)
+
+func TestPercent_String(t *testing.T) {
+	pc100 := percent.NewFromInt(100)
+	assert.Equal(t, "100%", pc100.String())
+
+	pc25_1 := percent.NewFromFloat(25.1)
+	assert.Equal(t, "25.1%", fmt.Sprintf("%v", pc25_1))
+}
+
+func TestPercent_AsFloat(t *testing.T) {
+	validFloats := []float64{0.0, -0.0, 1.0, 1.2, 0.1, 50.9, 99.9, 100.0}
+	for _, f := range validFloats {
+		f := f // Run runs a goroutine.
+		t.Run(fmt.Sprintf("valid %v", f), func(t *testing.T) {
+			pc := percent.NewFromFloat(f)
+			assert.Nil(t, pc.Error())
+			assert.Equal(t, f, pc.AsFloat())
+		})
+	}
+	invalidFloats := []float64{-1.0, -100.0, math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, f := range invalidFloats {
+		f := f
+		t.Run(fmt.Sprintf("invalid %v", f), func(t *testing.T) {
+			pc := percent.NewFromFloat(f)
+			assert.Error(t, pc.Error())
+			assert.Panics(t, func() { pc.AsFloat() })
+		})
+	}
+}
+
+func TestPercent_Add(t *testing.T) {
+	t.Run("basic use case", func(t *testing.T) {
+		a := percent.NewFromInt(32)
+		b := percent.NewFromFloat(22.1)
+		assert.Equal(t, percent.NewFromFloat(54.1), a.Add(b), "result should be valid")
+		assert.Equal(t, percent.NewFromFloat(32), a, "receiver should not change")
+		assert.Equal(t, percent.NewFromFloat(22.1), b, "argument should not change")
+	})
+	t.Run("twice the same operand", func(t *testing.T) {
+		pc25 := percent.NewFromInt(25)
+		assert.Equal(t, percent.NewFromInt(50), pc25.Add(pc25), "result should be valid")
+		assert.Equal(t, percent.NewFromInt(25), pc25, "receiver should not change")
+	})
+	t.Run("percentage overflow", func(t *testing.T) {
+		pc50_1 := percent.NewFromFloat(50.1)
+		result := pc50_1.Add(pc50_1)
+		assert.Error(t, result.Error())
+		assert.Equal(t, percent.NewFromFloat(50.1), pc50_1, "receiver should not change")
+	})
+}
+
+func TestPercent_Mul(t *testing.T) {
+	t.Run("basic use case", func(t *testing.T) {
+		a := percent.NewFromInt(32)
+		b := percent.NewFromFloat(22.1)
+		assert.Equal(t, percent.NewFromFloat(7.1), a.Mul(b), "result should be valid")
+		assert.Equal(t, percent.NewFromFloat(32), a, "receiver should not change")
+		assert.Equal(t, percent.NewFromFloat(22.1), b, "argument should not change")
+	})
+	t.Run("twice the same operand", func(t *testing.T) {
+		pc25 := percent.NewFromInt(25)
+		assert.Equal(t, percent.NewFromFloat(6.3), pc25.Mul(pc25), "result should be valid")
+		assert.Equal(t, percent.NewFromFloat(25), pc25, "receiver should not change")
+	})
+}

--- a/controller/canary/rollback.go
+++ b/controller/canary/rollback.go
@@ -1,0 +1,12 @@
+package canary
+
+/*
+Rollbacker defines the interface to implement a strategy to rollback.
+
+This interface is for at least two possible rollbacks in case of failures:
+ - Switch all the visible traffic onto the Blue stack (full_blue_rollback.go).
+ - Evenly distribute all visible traffic over the Baseline and Blue stacks.
+*/
+type Rollbacker interface {
+	Rollback(trafficMap TrafficMap) (TrafficMap, error)
+}

--- a/controller/canary/stack.go
+++ b/controller/canary/stack.go
@@ -45,7 +45,7 @@ func (cs *canaryStack) readActualTraffic(tm TrafficMap) error {
 	trafficPercent := percent.NewFromFloat(trafficStatus.ActualWeight)
 	err := trafficPercent.Error()
 	if err == nil {
-		cs.actualTraffic = *trafficPercent
+		cs.actualTraffic = trafficPercent
 	}
 	return err
 }

--- a/controller/canary/stack.go
+++ b/controller/canary/stack.go
@@ -1,0 +1,55 @@
+package canary
+
+import (
+	"fmt"
+
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+)
+
+type stackKind int
+
+const (
+	skGreen = iota + 1
+	skBlue
+	skBaseline
+)
+
+func (k stackKind) String() string {
+	switch k {
+	case skGreen:
+		return "green"
+	case skBaseline:
+		return "baseline"
+	case skBlue:
+		return "blue"
+	default:
+		panic(fmt.Sprintf("unsupported stack kind %v", int(k)))
+	}
+}
+
+type canaryStack struct {
+	*zv1.Stack
+	canaryKind    stackKind
+	actualTraffic percent.Percent
+}
+
+func (cs *canaryStack) readActualTraffic(tm TrafficMap) error {
+	if tm == nil {
+		return nil
+	}
+	trafficStatus, ok := tm[cs.Name]
+	if !ok {
+		return newNoTrafficDataError(*cs)
+	}
+	trafficPercent := percent.NewFromFloat(trafficStatus.ActualWeight)
+	err := trafficPercent.Error()
+	if err == nil {
+		cs.actualTraffic = *trafficPercent
+	}
+	return err
+}
+
+func (cs canaryStack) String() string {
+	return newStackId(cs).String()
+}

--- a/controller/canary/traffic_reconciler.go
+++ b/controller/canary/traffic_reconciler.go
@@ -1,0 +1,455 @@
+package canary
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+	"github.com/zalando-incubator/stackset-controller/controller/entities"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+	"github.com/zalando-incubator/stackset-controller/pkg/clientset"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+)
+
+// TrafficReconciler implements gradual deployments from Blue to Green via Baseline stacks.
+type TrafficReconciler struct {
+	// The reconciler which actually implements the traffic switch
+	baseReconciler entities.TrafficReconciler
+	checker        ExpectationChecker
+	greenStates    map[string]tsState
+	env            Env
+}
+
+func NewTrafficReconcilerReal(
+	base entities.TrafficReconciler,
+	client clientset.Interface,
+	rec record.EventRecorder,
+	logger logrus.FieldLogger,
+) *TrafficReconciler {
+
+	return &TrafficReconciler{
+		baseReconciler: base,
+		checker:        annotationChecker{},
+		greenStates:    nil,
+		env: Env{
+			Client: NewRealKubeClient(client, rec, logger),
+			Logger: logger,
+		},
+	}
+}
+
+// tsState is how ReconcileStacks updates the state read by ReconcileIngress.
+type tsState struct {
+	greenActualTraffic percent.Percent
+
+	blueName          string
+	blueActualTraffic percent.Percent
+
+	baselineName          string
+	baselineActualTraffic percent.Percent
+
+	totalActualTraffic    percent.Percent
+	desiredSwitchDuration time.Duration
+	switchStartTime       time.Time
+	ingressAction         reconcileIngressAction
+}
+
+type reconcileIngressAction int
+
+const (
+	actionDoNothing reconcileIngressAction = iota
+	actionRollback
+	actionIncrease
+)
+
+// ReconcileDeployment just delegates to the underlying baseReconciler.
+func (r *TrafficReconciler) ReconcileDeployment(
+	stacks map[types.UID]*entities.StackContainer,
+	stack *zv1.Stack,
+	traffic map[string]entities.TrafficStatus,
+	deployment *appsv1.Deployment,
+) error {
+	return r.baseReconciler.ReconcileDeployment(stacks, stack, traffic, deployment)
+}
+
+// ReconcileHPA just delegates to the underlying baseReconciler.
+func (r *TrafficReconciler) ReconcileHPA(
+	stack *zv1.Stack,
+	hpa *autoscaling.HorizontalPodAutoscaler,
+	deployment *appsv1.Deployment,
+) error {
+	return r.baseReconciler.ReconcileHPA(stack, hpa, deployment)
+}
+
+// ReconcileIngress computes the new weights necessary for gradual traffic switching.
+// Returns (actualWeights, desiredWeights)
+func (r *TrafficReconciler) ReconcileIngress(
+	stacks map[types.UID]*entities.StackContainer,
+	ingress *v1beta1.Ingress,
+	traffic map[string]entities.TrafficStatus,
+) (map[string]float64, map[string]float64) {
+	for greenName, greenState := range r.greenStates {
+		var err error
+		switch greenState.ingressAction {
+		case actionRollback:
+			rollbacker := FullBlueRollBack{
+				blueName:           greenState.blueName,
+				baselineName:       greenState.baselineName,
+				greenName:          greenName,
+				totalActualTraffic: greenState.totalActualTraffic,
+			}
+			traffic, err = rollbacker.Rollback(traffic)
+			if err != nil {
+				r.env.Logger.Errorf("failed to rollback: %s", err)
+			}
+		case actionIncrease:
+			elapsedTime := time.Now().Sub(greenState.switchStartTime)
+
+			var newTraffic TrafficMap
+			newTraffic, err = increaseTraffic(
+				traffic,
+				greenState.blueName,
+				greenState.baselineName,
+				greenName,
+				greenState.greenActualTraffic,
+				greenState.totalActualTraffic,
+				greenState.desiredSwitchDuration,
+				elapsedTime,
+			)
+			if err == nil {
+				traffic = newTraffic
+			} else {
+				r.env.Logger.Errorf("failed to increase traffic: %s", err)
+			}
+		}
+	}
+	return r.baseReconciler.ReconcileIngress(stacks, ingress, traffic)
+}
+
+// ReconcileStacks creates baseline and manages Green lifecycle via annotations.
+func (r *TrafficReconciler) ReconcileStacks(ssc *entities.StackSetContainer) error {
+	logger := r.env.Logger.WithField(
+		"stackset",
+		fmt.Sprintf("%s/%s", ssc.StackSet.Namespace, ssc.StackSet.Name),
+	)
+	logger.Info("ReconcileStacks started")
+	newGreenStates := map[string]tsState{}
+	for _, sc := range allGreenStacks(ssc.StackContainers) {
+		logger := logger.WithField("green", sc.Name)
+
+		d, errors := newTsInput(sc.Stack, ssc.StackContainers, ssc.Traffic)
+		if errors != nil {
+			for _, err := range errors {
+				logger.Error(err)
+			}
+			continue
+		}
+		logger = logger.WithField("blue", d.blue.Name)
+		logger = logger.WithField("desiredSwitchPeriod", d.desiredSwitchDuration)
+
+		if d.baseline == nil {
+			if err := createBaseline(r.env.WithLogger(logger), *d, &ssc.StackSet); err != nil {
+				logger.Errorf("failed to create baseline: %s", err)
+			}
+			continue // Traffic will be assigned at the next stackset-controller run.
+		}
+		logger = logger.WithField("baseline", d.baseline.Name)
+
+		totalActualTraffic := totalActualTrafficFor([]canaryStack{d.green, d.blue, *d.baseline})
+		if totalActualTraffic.Error() != nil {
+			logger.Errorf(
+				"failed to compute green+blue+baseline traffic: %s", totalActualTraffic.Error())
+			continue
+		}
+
+		state := tsState{
+			greenActualTraffic:    d.green.actualTraffic,
+			blueName:              d.blue.Name,
+			blueActualTraffic:     d.blue.actualTraffic,
+			baselineName:          d.baseline.Name,
+			baselineActualTraffic: d.baseline.actualTraffic,
+			desiredSwitchDuration: d.desiredSwitchDuration,
+			switchStartTime:       d.switchStartTime,
+			totalActualTraffic:    totalActualTraffic,
+			ingressAction:         actionDoNothing,
+		}
+		e := r.env.WithLogger(logger)
+		if d.switchStartTime.IsZero() || d.green.actualTraffic.IsZero() {
+			if !manageStateForNoTraffic(e, &state, *d, &ssc.StackSet) {
+				continue
+			}
+		} else if r.checker.ExpectationsFulfilled(*d.green.Stack, *d.baseline.Stack) {
+			logger.Infof("expectations still fulfilled, continuing")
+			ok := manageStateForExpectationsFulfilled(e, &state, *d, &ssc.StackSet, totalActualTraffic)
+			if !ok {
+				continue
+			}
+		} else {
+			state.ingressAction = actionRollback
+			r.env.Client.MarkStackNotGreen(&ssc.StackSet, d.green.Stack, "rollback")
+		}
+		newGreenStates[d.green.Name] = state
+	}
+	r.greenStates = newGreenStates // Also cleans up the old states.
+	return nil
+}
+
+// tsInput is a helper type for ReconcileStacks and its own helper functions. Please do not use it outside.
+type tsInput struct {
+	green                 canaryStack
+	blue                  canaryStack
+	baseline              *canaryStack
+	desiredSwitchDuration time.Duration
+	switchStartTime       time.Time
+}
+
+func newTsInput(green *zv1.Stack, allStacks map[types.UID]*entities.StackContainer, tm TrafficMap) (*tsInput, []error) {
+	errors := []error{}
+	g := canaryStack{
+		Stack:      green,
+		canaryKind: skGreen,
+	}
+	if err := g.readActualTraffic(tm); err != nil {
+		errors = append(errors, err)
+	}
+
+	desiredSwitchDuration, err := desiredSwitchDurationFor(g)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	switchStartTime, err := switchStartTimeFor(g)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	blue, err := blueStackFor(g, allStacks)
+	if err == nil {
+		if err := blue.readActualTraffic(tm); err != nil {
+			errors = append(errors, err)
+		}
+	} else {
+		errors = append(errors, err)
+	}
+
+	baseline, err := baselineStackFor(g, allStacks)
+	if err != nil {
+		errors = append(errors, err)
+	} else if baseline != nil {
+		if err := baseline.readActualTraffic(tm); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		return nil, errors
+	}
+	return &tsInput{
+		green:                 g,
+		blue:                  *blue,
+		baseline:              baseline,
+		desiredSwitchDuration: desiredSwitchDuration,
+		switchStartTime:       switchStartTime,
+	}, nil
+}
+
+func createBaseline(env Env, d tsInput, set *zv1.StackSet) error {
+	baselineName := d.green.Name + "-baseline"
+	env.Logger.Infof("creating baseline stack %q", baselineName)
+	baselineSpec := zv1.StackSpec{ // Same infrastructure as green but same code as blue!
+		Replicas:                d.green.Spec.Replicas,
+		HorizontalPodAutoscaler: d.green.Spec.HorizontalPodAutoscaler.DeepCopy(),
+		Service:                 d.green.Spec.Service.DeepCopy(),
+		PodTemplate:             d.blue.Spec.PodTemplate,
+		Autoscaler:              d.green.Spec.Autoscaler.DeepCopy(),
+	}
+	baseline, err := env.Client.CreateStack(set, baselineName, "default", baselineSpec)
+	if err != nil {
+		return err
+	}
+	d.green.Annotations[baselineAnnotationKey] = baseline.Name
+	_, err = env.Client.UpdateStack(set, d.green.Stack, "add baseline annotation")
+	if err != nil {
+		e := env.Client.RemoveStack(set, baseline.Name, "failed to update green annotations")
+		env.Logger.Errorf("failed to clean up aborted baseline stack: %s", e)
+	}
+	return err
+}
+
+func manageStateForNoTraffic(env Env, state *tsState, d tsInput, set *zv1.StackSet) bool {
+	env.Logger.Infof("starting switching traffic to green")
+	var err error
+	state.switchStartTime, err = markStartTrafficSwitch(env, set, &d.green)
+	if err != nil {
+		env.Logger.Errorf("failed to update %s: %v", d.green, err)
+		return false
+	}
+	state.ingressAction = actionIncrease
+	return true
+}
+
+func manageStateForExpectationsFulfilled(
+	env Env,
+	state *tsState,
+	d tsInput,
+	set *zv1.StackSet,
+	totalActualTraffic percent.Percent,
+) bool {
+	if cmp := d.green.actualTraffic.Cmp(&totalActualTraffic); cmp >= 0 {
+		// We are finished with the traffic switch.
+		if cmp > 0 {
+			env.Logger.Warnf(
+				"traffic for %s (%s) is larger than targeted final traffic (%s)",
+				d.green, d.green.actualTraffic, totalActualTraffic,
+			)
+		}
+		return manageObsPeriod(env, d, set)
+	}
+	if d.baseline.actualTraffic.IsZero() {
+		env.Logger.Info("waiting for latest baseline traffic increase to be applied")
+		state.ingressAction = actionDoNothing
+	} else {
+		state.ingressAction = actionIncrease
+	}
+	return true
+}
+
+func manageObsPeriod(env Env, d tsInput, set *zv1.StackSet) bool {
+	env.Logger.Infof("%s is in observation period", d.green)
+	obsPeriod, obsStart, err := readObservationData(d.green)
+	if err != nil {
+		env.Logger.Error(err)
+		return false
+	}
+	if obsPeriod == 0 {
+		// Gradual deployment successfully finished without observation period!
+		env.Client.MarkStackNotGreen(set, d.green.Stack, "reached target traffic, no observation period")
+		return false // Everything is fine but we don't want to keep the state.
+	}
+	if obsStart.IsZero() {
+		_, err := markStartObservation(env, set, &d.green)
+		if err != nil {
+			env.Logger.Errorf("failed to start observation period: %v", err)
+			return false
+		}
+		return true
+	}
+	if obsStart.Add(obsPeriod).Before(time.Now()) {
+		// Gradual deployment successfully finished after observation period!
+		env.Client.MarkStackNotGreen(set, d.green.Stack, fmt.Sprintf(
+			"reached target traffic, observation period %v over (started at %v)",
+			obsPeriod, obsStart,
+		))
+		return false // Everything is fine but we don't want to keep the state.
+	}
+	return true
+}
+
+func markStartTrafficSwitch(env Env, set *zv1.StackSet, green *canaryStack) (time.Time, error) {
+	return markStartOf(env, set, green, switchStartKey)
+}
+
+func markStartObservation(env Env, set *zv1.StackSet, green *canaryStack) (time.Time, error) {
+	return markStartOf(env, set, green, finalStartKey)
+}
+
+func markStartOf(env Env, set *zv1.StackSet, green *canaryStack, key string) (time.Time, error) {
+	env.Logger.Debugf("setting %s of %s to now", key, *green)
+	t := time.Now()
+	updatedStack, err := env.SetAnnotation(set, green.Stack, key, t.Format(time.RFC3339))
+	if err == nil {
+		green.Stack = updatedStack
+	}
+	return t, err
+}
+
+// allGreenStacks returns all provided StackContainer that contain a green stack.
+func allGreenStacks(stackContainers map[types.UID]*entities.StackContainer) []canaryStack {
+	greens := []canaryStack{}
+	for _, sc := range stackContainers {
+		if _, ok := sc.Stack.Annotations[greenAnnotationKey]; ok {
+			greens = append(greens, canaryStack{Stack: &sc.Stack, canaryKind: skGreen})
+		}
+	}
+	return greens
+}
+
+func desiredSwitchDurationFor(green canaryStack) (duration time.Duration, err error) {
+	durationStr := green.Annotations[desiredSwitchDurationKey]
+	duration, err = time.ParseDuration(durationStr)
+	if err != nil {
+		err = newBadDurationError(green, durationStr, desiredSwitchDurationKey)
+	}
+	return
+}
+
+func switchStartTimeFor(green canaryStack) (time.Time, error) {
+	return readOptionalTimeAnnotation(green.Annotations, switchStartKey)
+}
+
+func blueStackFor(green canaryStack, scs map[types.UID]*entities.StackContainer) (*canaryStack, error) {
+	blueName := green.Annotations[blueAnnotationKey]
+	if blueName == "" {
+		return nil, newNoBlueAnnotError(green)
+	}
+	for _, sc := range scs {
+		if sc.Stack.Name == blueName {
+			return &canaryStack{Stack: &sc.Stack, canaryKind: skBlue}, nil
+		}
+	}
+	return nil, newStackNotFoundError(green, blueName, skBlue)
+}
+
+func baselineStackFor(green canaryStack, scs map[types.UID]*entities.StackContainer) (*canaryStack, error) {
+	baselineName, ok := green.Annotations[baselineAnnotationKey]
+	if !ok {
+		return nil, nil // We need to create the baseline stack.
+	}
+	for _, sc := range scs {
+		if sc.Stack.Name == baselineName {
+			return &canaryStack{Stack: &sc.Stack, canaryKind: skBaseline}, nil
+		}
+	}
+	return nil, newStackNotFoundError(green, baselineName, skBaseline)
+}
+
+func totalActualTrafficFor(stacks []canaryStack) percent.Percent {
+	total := percent.NewFromInt(0)
+	for _, s := range stacks {
+		total = total.Add(&s.actualTraffic)
+	}
+	return *total
+}
+
+func readObservationData(green canaryStack) (time.Duration, time.Time, error) {
+	durationStr := green.Annotations[desiredFinalDurationKey]
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 0, time.Time{}, newBadDurationError(green, durationStr, desiredFinalDurationKey)
+	}
+	t, err := readOptionalTimeAnnotation(green.Annotations, finalStartKey)
+	if err != nil {
+		return 0, time.Time{}, newBadObservationStartError(green)
+	}
+	return duration, t, nil
+}
+
+// readOptionalTimeAnnotation reads the value corresponding to the key annotation.
+// That value may not exist (which is not an error), but when it does it must be
+// a RFC3339-formatted date (otherwise an error is returned).
+func readOptionalTimeAnnotation(annotations map[string]string, key string) (time.Time, error) {
+	str, ok := annotations[key]
+	if !ok {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read %v: %v", key, err)
+	}
+	return t, nil
+}

--- a/controller/canary/traffic_reconciler.go
+++ b/controller/canary/traffic_reconciler.go
@@ -91,7 +91,7 @@ func (r *TrafficReconciler) ReconcileIngress(
 	stacks map[types.UID]*entities.StackContainer,
 	ingress *v1beta1.Ingress,
 	traffic map[string]entities.TrafficStatus,
-) (map[string]float64, map[string]float64) {
+) (map[string]float64, map[string]float64, error) {
 	for greenName, greenState := range r.greenStates {
 		var err error
 		switch greenState.ingressAction {

--- a/controller/canary/traffic_switch.go
+++ b/controller/canary/traffic_switch.go
@@ -1,0 +1,156 @@
+package canary
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+	"github.com/zalando-incubator/stackset-controller/controller/entities"
+)
+
+type TrafficMap = map[string]entities.TrafficStatus
+
+type StackNameSet = map[string]struct{}
+
+// ComputeNewTraffic returns a copy of currentTrafficMap where targetStackName has desiredStackTraffic percentage of
+// the total traffic (or an error if this is impossible) by only modifying the traffic of other stacks listed in
+// modifiableStacks.
+func ComputeNewTraffic(
+	currentTrafficMap TrafficMap,
+	targetStackName string,
+	desiredStackTraffic percent.Percent,
+	modifiableStacks StackNameSet,
+) (TrafficMap, error) {
+	if _, ok := currentTrafficMap[targetStackName]; !ok {
+		return nil, fmt.Errorf("target stack %q not found in current traffic map", targetStackName)
+	}
+	if len(modifiableStacks) == 0 {
+		return nil, fmt.Errorf("no modifiable stacks provided apart from the target stack")
+	}
+	if err := desiredStackTraffic.Error(); err != nil {
+		return nil, fmt.Errorf("cannot compute new traffic map for invalid target traffic: %v", err)
+	}
+
+	var err error
+	currentTrafficMap, err = unfloatTrafficMap(currentTrafficMap)
+	if err != nil {
+		return nil, err
+	}
+
+	modifiableStacksSlice := make([]string, 0, len(modifiableStacks))
+	for k := range modifiableStacks {
+		if k != targetStackName {
+			modifiableStacksSlice = append(modifiableStacksSlice, k)
+		}
+	}
+	trafficDiffByStack, err := computeStackDiffs(
+		modifiableStacksSlice,
+		currentTrafficMap,
+		targetStackName,
+		desiredStackTraffic.AsFloat(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute new traffic map: %v", err)
+	}
+
+	newTrafficMap := make(TrafficMap, len(currentTrafficMap))
+	for stackName, currentTraffic := range currentTrafficMap {
+		var newDesiredWeight float64
+
+		if stackName == targetStackName {
+			newDesiredWeight = desiredStackTraffic.AsFloat()
+		} else if _, ok := modifiableStacks[stackName]; ok {
+			newDesiredWeight = currentTraffic.DesiredWeight + trafficDiffByStack[stackName]
+		} else {
+			newDesiredWeight = currentTraffic.DesiredWeight
+		}
+
+		newTrafficMap[stackName] = entities.TrafficStatus{
+			ActualWeight:  currentTraffic.ActualWeight,
+			DesiredWeight: newDesiredWeight,
+		}
+	}
+	return newTrafficMap, nil
+}
+
+// computeStackDiffs returns, for each modifiable stack, the traffic diff that should be applied
+// to it to reach desiredTraffic on targetStack by taking traffic from modifiableStacks in the
+// most uniform way possible.
+// modifiableStacks will be sorted in place.
+func computeStackDiffs(
+	modifiableStacks []string,
+	tm TrafficMap,
+	targetStack string,
+	desiredTraffic float64,
+) (map[string]float64, error) {
+	// Sort modifiableStacks so that the stacks with the smallest leeway (i.e. that will most
+	// probably not be able to accept the uniform, "distributed" diff) come first.
+	// This way, we can adapt the distributed diff to take into account what could not be put on
+	// the first stacks, and continue trying to apply this modified distributed diff to the next
+	// stacks. Without sorting, we would have to loop over modifiableStacks and change stack diffs
+	// multiple times until satisfied.
+	trafficFunc := func(i int) float64 { return tm[modifiableStacks[i]].DesiredWeight }
+	var possibleDiffFunc func(int) float64
+	diff := tm[targetStack].DesiredWeight - desiredTraffic
+	if diff > 0 { // we add traffic to modifiable stacks (diff > 0)
+		sort.Slice(modifiableStacks, func(i, j int) bool { return trafficFunc(i) > trafficFunc(j) })
+		possibleDiffFunc = func(i int) float64 { return 100 - trafficFunc(i) }
+	} else { // we remove traffic from modifiable stacks (diff < 0)
+		sort.Slice(modifiableStacks, func(i, j int) bool { return trafficFunc(i) < trafficFunc(j) })
+		possibleDiffFunc = func(i int) float64 { return -trafficFunc(i) }
+	}
+
+	trafficDiffByStack := make(map[string]float64)
+	// amount of traffic we'd like to add/remove uniformly in modifiableStacks
+	distributedDiff := diff / float64(len(modifiableStacks))
+	for i, stackName := range modifiableStacks {
+		possibleDiff := possibleDiffFunc(i)
+		if math.Abs(possibleDiff) < math.Abs(distributedDiff) { // they have the same sign so we can
+			rest := distributedDiff - possibleDiff
+			nbRemainingStacks := len(modifiableStacks) - i - 1
+			if nbRemainingStacks == 0 {
+				return nil, fmt.Errorf(
+					"not enough leeway in modifiable stacks to give %f%% to the target stack %q; missing %v%%",
+					desiredTraffic, targetStack, rest,
+				)
+			}
+			trafficDiffByStack[stackName] = possibleDiff
+			distributedDiff += rest / float64(nbRemainingStacks)
+		} else {
+			trafficDiffByStack[stackName] = distributedDiff
+		}
+	}
+	return trafficDiffByStack, nil
+}
+
+// unfloatTrafficMap "simplifies" all DesiredWeight float values by converting them to Percent then back to float.
+// The conversion to Percent ensures that they are in range and rounds them to one decimal place. This avoids errors
+// where a traffic float is almost equal to zero (like 1e-16) but not quite.
+// The tm argument is not modified. Also ensures that the sum of all traffic is equal to 100%.
+func unfloatTrafficMap(tm TrafficMap) (TrafficMap, error) {
+	total := percent.NewFromInt(0)
+	res := make(TrafficMap, len(tm))
+	for stack, ts := range tm {
+		pc := percent.NewFromFloat(ts.DesiredWeight)
+		if pc.Error() != nil {
+			return nil, pc.Error()
+		}
+
+		total = total.Add(pc)
+		if total.Error() != nil {
+			return nil, fmt.Errorf("invalid desired traffic in map: %s", total.Error())
+		}
+
+		res[stack] = entities.TrafficStatus{
+			ActualWeight:  ts.ActualWeight,
+			DesiredWeight: pc.AsFloat(),
+		}
+	}
+	if total.Cmp(pc100) != 0 {
+		return nil, fmt.Errorf("invalid input traffic map: total traffic %s is less than %s", total, pc100)
+	}
+	return res, nil
+}
+
+var pc100 = percent.NewFromInt(100)

--- a/controller/canary/traffic_switch_test.go
+++ b/controller/canary/traffic_switch_test.go
@@ -1,0 +1,236 @@
+package canary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
+	"github.com/zalando-incubator/stackset-controller/controller/entities"
+)
+
+func TestComputeNewTraffic(t *testing.T) {
+	t.Run("empty traffic map", func(t *testing.T) {
+		newTrafficMap, err := ComputeNewTraffic(
+			TrafficMap{},
+			"B",
+			*percent.NewFromInt(100),
+			StackNameSet{},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+	t.Run("unknown target stack", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(100),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"B",
+			*percent.NewFromInt(100),
+			StackNameSet{},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+	t.Run("no modifiable stacks", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(100),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"A",
+			*percent.NewFromInt(100),
+			StackNameSet{},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+	t.Run("unreachable percentage target", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(75),
+			"B": entities.NewTrafficStatusSame(20),
+			"C": entities.NewTrafficStatusSame(5),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"B",
+			*percent.NewFromInt(100),
+			StackNameSet{
+				"A": struct{}{},
+			},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+	t.Run("increasing traffic", func(t *testing.T) {
+		t.Run("with target stack not in modifiable stacks", func(t *testing.T) {
+			currentTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatusSame(75),
+				"B": entities.NewTrafficStatusSame(25),
+			}
+			newTrafficMap, err := ComputeNewTraffic(
+				currentTrafficMap,
+				"B",
+				*percent.NewFromInt(100),
+				StackNameSet{
+					"A": struct{}{},
+				},
+			)
+			assert.Nil(t, err)
+			expectedTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatus(75, 0),
+				"B": entities.NewTrafficStatus(25, 100),
+			}
+			assert.Equal(t, expectedTrafficMap, newTrafficMap)
+		})
+		t.Run("with target stack in modifiable stacks", func(t *testing.T) {
+			currentTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatusSame(75),
+				"B": entities.NewTrafficStatusSame(25),
+			}
+			newTrafficMap, err := ComputeNewTraffic(
+				currentTrafficMap,
+				"B",
+				*percent.NewFromInt(100),
+				StackNameSet{
+					"A": struct{}{},
+					"B": struct{}{},
+				},
+			)
+			assert.Nil(t, err)
+			expectedTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatus(75, 0),
+				"B": entities.NewTrafficStatus(25, 100),
+			}
+			assert.Equal(t, expectedTrafficMap, newTrafficMap)
+		})
+		t.Run("with non-modifiable stacks", func(t *testing.T) {
+			currentTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatusSame(75),
+				"B": entities.NewTrafficStatusSame(20),
+				"C": entities.NewTrafficStatusSame(5),
+			}
+			percent95 := percent.NewFromInt(95)
+			newTrafficMap, err := ComputeNewTraffic(
+				currentTrafficMap,
+				"B",
+				*percent95,
+				StackNameSet{
+					"A": struct{}{},
+				},
+			)
+			assert.Nil(t, err)
+			expectedTrafficMap := TrafficMap{
+				"A": entities.NewTrafficStatus(75, 0),
+				"B": entities.NewTrafficStatus(20, 95),
+				"C": entities.NewTrafficStatusSame(5),
+			}
+			assert.Equal(t, expectedTrafficMap, newTrafficMap)
+		})
+	})
+	t.Run("decreasing traffic", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(75),
+			"B": entities.NewTrafficStatusSame(20),
+			"C": entities.NewTrafficStatusSame(5),
+		}
+		percent60_1 := percent.NewFromFloat(60.1)
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"A",
+			*percent60_1,
+			StackNameSet{
+				"B": struct{}{},
+			},
+		)
+		assert.Nil(t, err)
+		expectedTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatus(75, 60.1),
+			"B": entities.NewTrafficStatus(20, 34.9),
+			"C": entities.NewTrafficStatusSame(5),
+		}
+		assert.Equal(t, expectedTrafficMap, newTrafficMap)
+	})
+	t.Run("ignore modifiable stacks already at extremes", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(0),
+			"B": entities.NewTrafficStatusSame(100),
+			"C": entities.NewTrafficStatusSame(0),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"A",
+			*percent.NewFromInt(100),
+			StackNameSet{
+				"B": struct{}{},
+				"C": struct{}{}, // not actually modifiable
+			},
+		)
+		assert.Nil(t, err)
+		expectedTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatus(0, 100),
+			"B": entities.NewTrafficStatus(100, 0),
+			"C": entities.NewTrafficStatusSame(0),
+		}
+		assert.Equal(t, expectedTrafficMap, newTrafficMap)
+	})
+	t.Run("ignore modifiable stacks almost at extremes", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(0),
+			"B": entities.NewTrafficStatusSame(99),
+			"C": entities.NewTrafficStatusSame(1),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"A",
+			*percent.NewFromInt(100),
+			StackNameSet{
+				"B": struct{}{},
+				"C": struct{}{}, // not actually modifiable
+			},
+		)
+		assert.Nil(t, err)
+		expectedTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatus(0, 100),
+			"B": entities.NewTrafficStatus(99, 0),
+			"C": entities.NewTrafficStatus(1, 0),
+		}
+		assert.Equal(t, expectedTrafficMap, newTrafficMap)
+	})
+	t.Run("input traffic map has more than 100% traffic", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(50),
+			"B": entities.NewTrafficStatusSame(0),
+			"C": entities.NewTrafficStatusSame(51),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"B",
+			*percent.NewFromInt(100),
+			StackNameSet{
+				"A": struct{}{},
+				"C": struct{}{},
+			},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+	t.Run("input traffic map has less than 100% traffic", func(t *testing.T) {
+		currentTrafficMap := TrafficMap{
+			"A": entities.NewTrafficStatusSame(50),
+			"B": entities.NewTrafficStatusSame(0),
+			"C": entities.NewTrafficStatusSame(49),
+		}
+		newTrafficMap, err := ComputeNewTraffic(
+			currentTrafficMap,
+			"A",
+			*percent.NewFromInt(0),
+			StackNameSet{
+				"B": struct{}{},
+				"C": struct{}{},
+			},
+		)
+		assert.Nil(t, newTrafficMap)
+		assert.Error(t, err)
+	})
+}

--- a/controller/canary/traffic_switch_test.go
+++ b/controller/canary/traffic_switch_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando-incubator/stackset-controller/controller/canary/percent"
-	"github.com/zalando-incubator/stackset-controller/controller/entities"
 )
 
 func TestComputeNewTraffic(t *testing.T) {
@@ -13,7 +12,7 @@ func TestComputeNewTraffic(t *testing.T) {
 		newTrafficMap, err := ComputeNewTraffic(
 			TrafficMap{},
 			"B",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{},
 		)
 		assert.Nil(t, newTrafficMap)
@@ -21,12 +20,12 @@ func TestComputeNewTraffic(t *testing.T) {
 	})
 	t.Run("unknown target stack", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(100),
+			"A": NewTrafficStatusSame(100),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"B",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{},
 		)
 		assert.Nil(t, newTrafficMap)
@@ -34,12 +33,12 @@ func TestComputeNewTraffic(t *testing.T) {
 	})
 	t.Run("no modifiable stacks", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(100),
+			"A": NewTrafficStatusSame(100),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"A",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{},
 		)
 		assert.Nil(t, newTrafficMap)
@@ -47,14 +46,14 @@ func TestComputeNewTraffic(t *testing.T) {
 	})
 	t.Run("unreachable percentage target", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(75),
-			"B": entities.NewTrafficStatusSame(20),
-			"C": entities.NewTrafficStatusSame(5),
+			"A": NewTrafficStatusSame(75),
+			"B": NewTrafficStatusSame(20),
+			"C": NewTrafficStatusSame(5),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"B",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{
 				"A": struct{}{},
 			},
@@ -65,33 +64,33 @@ func TestComputeNewTraffic(t *testing.T) {
 	t.Run("increasing traffic", func(t *testing.T) {
 		t.Run("with target stack not in modifiable stacks", func(t *testing.T) {
 			currentTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatusSame(75),
-				"B": entities.NewTrafficStatusSame(25),
+				"A": NewTrafficStatusSame(75),
+				"B": NewTrafficStatusSame(25),
 			}
 			newTrafficMap, err := ComputeNewTraffic(
 				currentTrafficMap,
 				"B",
-				*percent.NewFromInt(100),
+				percent.NewFromInt(100),
 				StackNameSet{
 					"A": struct{}{},
 				},
 			)
 			assert.Nil(t, err)
 			expectedTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatus(75, 0),
-				"B": entities.NewTrafficStatus(25, 100),
+				"A": NewTrafficStatus(75, 0),
+				"B": NewTrafficStatus(25, 100),
 			}
 			assert.Equal(t, expectedTrafficMap, newTrafficMap)
 		})
 		t.Run("with target stack in modifiable stacks", func(t *testing.T) {
 			currentTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatusSame(75),
-				"B": entities.NewTrafficStatusSame(25),
+				"A": NewTrafficStatusSame(75),
+				"B": NewTrafficStatusSame(25),
 			}
 			newTrafficMap, err := ComputeNewTraffic(
 				currentTrafficMap,
 				"B",
-				*percent.NewFromInt(100),
+				percent.NewFromInt(100),
 				StackNameSet{
 					"A": struct{}{},
 					"B": struct{}{},
@@ -99,68 +98,68 @@ func TestComputeNewTraffic(t *testing.T) {
 			)
 			assert.Nil(t, err)
 			expectedTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatus(75, 0),
-				"B": entities.NewTrafficStatus(25, 100),
+				"A": NewTrafficStatus(75, 0),
+				"B": NewTrafficStatus(25, 100),
 			}
 			assert.Equal(t, expectedTrafficMap, newTrafficMap)
 		})
 		t.Run("with non-modifiable stacks", func(t *testing.T) {
 			currentTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatusSame(75),
-				"B": entities.NewTrafficStatusSame(20),
-				"C": entities.NewTrafficStatusSame(5),
+				"A": NewTrafficStatusSame(75),
+				"B": NewTrafficStatusSame(20),
+				"C": NewTrafficStatusSame(5),
 			}
 			percent95 := percent.NewFromInt(95)
 			newTrafficMap, err := ComputeNewTraffic(
 				currentTrafficMap,
 				"B",
-				*percent95,
+				percent95,
 				StackNameSet{
 					"A": struct{}{},
 				},
 			)
 			assert.Nil(t, err)
 			expectedTrafficMap := TrafficMap{
-				"A": entities.NewTrafficStatus(75, 0),
-				"B": entities.NewTrafficStatus(20, 95),
-				"C": entities.NewTrafficStatusSame(5),
+				"A": NewTrafficStatus(75, 0),
+				"B": NewTrafficStatus(20, 95),
+				"C": NewTrafficStatusSame(5),
 			}
 			assert.Equal(t, expectedTrafficMap, newTrafficMap)
 		})
 	})
 	t.Run("decreasing traffic", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(75),
-			"B": entities.NewTrafficStatusSame(20),
-			"C": entities.NewTrafficStatusSame(5),
+			"A": NewTrafficStatusSame(75),
+			"B": NewTrafficStatusSame(20),
+			"C": NewTrafficStatusSame(5),
 		}
 		percent60_1 := percent.NewFromFloat(60.1)
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"A",
-			*percent60_1,
+			percent60_1,
 			StackNameSet{
 				"B": struct{}{},
 			},
 		)
 		assert.Nil(t, err)
 		expectedTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatus(75, 60.1),
-			"B": entities.NewTrafficStatus(20, 34.9),
-			"C": entities.NewTrafficStatusSame(5),
+			"A": NewTrafficStatus(75, 60.1),
+			"B": NewTrafficStatus(20, 34.9),
+			"C": NewTrafficStatusSame(5),
 		}
 		assert.Equal(t, expectedTrafficMap, newTrafficMap)
 	})
 	t.Run("ignore modifiable stacks already at extremes", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(0),
-			"B": entities.NewTrafficStatusSame(100),
-			"C": entities.NewTrafficStatusSame(0),
+			"A": NewTrafficStatusSame(0),
+			"B": NewTrafficStatusSame(100),
+			"C": NewTrafficStatusSame(0),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"A",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{
 				"B": struct{}{},
 				"C": struct{}{}, // not actually modifiable
@@ -168,22 +167,22 @@ func TestComputeNewTraffic(t *testing.T) {
 		)
 		assert.Nil(t, err)
 		expectedTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatus(0, 100),
-			"B": entities.NewTrafficStatus(100, 0),
-			"C": entities.NewTrafficStatusSame(0),
+			"A": NewTrafficStatus(0, 100),
+			"B": NewTrafficStatus(100, 0),
+			"C": NewTrafficStatusSame(0),
 		}
 		assert.Equal(t, expectedTrafficMap, newTrafficMap)
 	})
 	t.Run("ignore modifiable stacks almost at extremes", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(0),
-			"B": entities.NewTrafficStatusSame(99),
-			"C": entities.NewTrafficStatusSame(1),
+			"A": NewTrafficStatusSame(0),
+			"B": NewTrafficStatusSame(99),
+			"C": NewTrafficStatusSame(1),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"A",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{
 				"B": struct{}{},
 				"C": struct{}{}, // not actually modifiable
@@ -191,22 +190,22 @@ func TestComputeNewTraffic(t *testing.T) {
 		)
 		assert.Nil(t, err)
 		expectedTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatus(0, 100),
-			"B": entities.NewTrafficStatus(99, 0),
-			"C": entities.NewTrafficStatus(1, 0),
+			"A": NewTrafficStatus(0, 100),
+			"B": NewTrafficStatus(99, 0),
+			"C": NewTrafficStatus(1, 0),
 		}
 		assert.Equal(t, expectedTrafficMap, newTrafficMap)
 	})
 	t.Run("input traffic map has more than 100% traffic", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(50),
-			"B": entities.NewTrafficStatusSame(0),
-			"C": entities.NewTrafficStatusSame(51),
+			"A": NewTrafficStatusSame(50),
+			"B": NewTrafficStatusSame(0),
+			"C": NewTrafficStatusSame(51),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"B",
-			*percent.NewFromInt(100),
+			percent.NewFromInt(100),
 			StackNameSet{
 				"A": struct{}{},
 				"C": struct{}{},
@@ -217,14 +216,14 @@ func TestComputeNewTraffic(t *testing.T) {
 	})
 	t.Run("input traffic map has less than 100% traffic", func(t *testing.T) {
 		currentTrafficMap := TrafficMap{
-			"A": entities.NewTrafficStatusSame(50),
-			"B": entities.NewTrafficStatusSame(0),
-			"C": entities.NewTrafficStatusSame(49),
+			"A": NewTrafficStatusSame(50),
+			"B": NewTrafficStatusSame(0),
+			"C": NewTrafficStatusSame(49),
 		}
 		newTrafficMap, err := ComputeNewTraffic(
 			currentTrafficMap,
 			"A",
-			*percent.NewFromInt(0),
+			percent.NewFromInt(0),
 			StackNameSet{
 				"B": struct{}{},
 				"C": struct{}{},

--- a/controller/entities/stack.go
+++ b/controller/entities/stack.go
@@ -1,0 +1,45 @@
+package entities
+
+import (
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewStack creates a new Stack object according to the provided specification.
+func NewStack(
+	name string,
+	namespace string,
+	version string,
+	owner metav1.OwnerReference,
+	spec zv1.StackSpec,
+) *zv1.Stack {
+	if spec.Service != nil {
+		spec.Service = sanitizeServicePorts(spec.Service)
+	}
+	return &zv1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				StacksetHeritageLabelKey: owner.Name,
+				StackVersionLabelKey:     version,
+			},
+			OwnerReferences: []metav1.OwnerReference{owner},
+		},
+		Spec: spec,
+	}
+}
+
+// sanitizeServicePorts makes sure the ports has the default fields set if not
+// specified.
+func sanitizeServicePorts(service *zv1.StackServiceSpec) *zv1.StackServiceSpec {
+	for i, port := range service.Ports {
+		// set default protocol if not specified
+		if port.Protocol == "" {
+			port.Protocol = v1.ProtocolTCP
+		}
+		service.Ports[i] = port
+	}
+	return service
+}

--- a/controller/entities/stack_test.go
+++ b/controller/entities/stack_test.go
@@ -1,0 +1,23 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestSanitizeServicePorts(t *testing.T) {
+	service := &zv1.StackServiceSpec{
+		Ports: []v1.ServicePort{
+			{
+				Protocol: "",
+			},
+		},
+	}
+
+	service = sanitizeServicePorts(service)
+	assert.Len(t, service.Ports, 1)
+	assert.Equal(t, v1.ProtocolTCP, service.Ports[0].Protocol)
+}

--- a/controller/entities/stackset_container.go
+++ b/controller/entities/stackset_container.go
@@ -47,15 +47,6 @@ func (ssc StackSetContainer) Stacks() []zv1.Stack {
 	return stacks
 }
 
-func (ssc StackSetContainer) StackFromName(name string) *zv1.Stack {
-	for _, sc := range ssc.StackContainers {
-		if sc.Stack.Name == name {
-			return &sc.Stack
-		}
-	}
-	return nil
-}
-
 // ScaledownTTL returns the ScaledownTTLSeconds value of a StackSet as a
 // time.Duration.
 func (ssc StackSetContainer) ScaledownTTL() time.Duration {

--- a/controller/entities/stackset_container.go
+++ b/controller/entities/stackset_container.go
@@ -39,18 +39,27 @@ type StackSetContainer struct {
 }
 
 // Stacks returns a slice of Stack resources.
-func (sc StackSetContainer) Stacks() []zv1.Stack {
-	stacks := make([]zv1.Stack, 0, len(sc.StackContainers))
-	for _, stackContainer := range sc.StackContainers {
+func (ssc StackSetContainer) Stacks() []zv1.Stack {
+	stacks := make([]zv1.Stack, 0, len(ssc.StackContainers))
+	for _, stackContainer := range ssc.StackContainers {
 		stacks = append(stacks, stackContainer.Stack)
 	}
 	return stacks
 }
 
+func (ssc StackSetContainer) StackFromName(name string) *zv1.Stack {
+	for _, sc := range ssc.StackContainers {
+		if sc.Stack.Name == name {
+			return &sc.Stack
+		}
+	}
+	return nil
+}
+
 // ScaledownTTL returns the ScaledownTTLSeconds value of a StackSet as a
 // time.Duration.
-func (sc StackSetContainer) ScaledownTTL() time.Duration {
-	if ttlSec := sc.StackSet.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
+func (ssc StackSetContainer) ScaledownTTL() time.Duration {
+	if ttlSec := ssc.StackSet.Spec.StackLifecycle.ScaledownTTLSeconds; ttlSec != nil {
 		return time.Second * time.Duration(*ttlSec)
 	}
 	return 0

--- a/controller/entities/traffic_reconciler.go
+++ b/controller/entities/traffic_reconciler.go
@@ -14,4 +14,5 @@ type TrafficReconciler interface {
 	ReconcileDeployment(stacks map[types.UID]*StackContainer, stack *zv1.Stack, traffic map[string]TrafficStatus, deployment *appsv1.Deployment) error
 	ReconcileHPA(stack *zv1.Stack, hpa *autoscaling.HorizontalPodAutoscaler, deployment *appsv1.Deployment) error
 	ReconcileIngress(stacks map[types.UID]*StackContainer, ingress *v1beta1.Ingress, traffic map[string]TrafficStatus) (map[string]float64, map[string]float64, error)
+	ReconcileStacks(ssc *StackSetContainer) error
 }

--- a/controller/entities/traffic_status.go
+++ b/controller/entities/traffic_status.go
@@ -14,18 +14,3 @@ type TrafficStatus struct {
 func (t TrafficStatus) Weight() float64 {
 	return math.Max(t.ActualWeight, t.DesiredWeight)
 }
-
-// Helper constructors for common TrafficStatus values
-func NewTrafficStatusSame(weight float64) TrafficStatus {
-	return TrafficStatus{
-		ActualWeight:  weight,
-		DesiredWeight: weight,
-	}
-}
-
-func NewTrafficStatus(actualWeight, desiredWeight float64) TrafficStatus {
-	return TrafficStatus{
-		ActualWeight:  actualWeight,
-		DesiredWeight: desiredWeight,
-	}
-}

--- a/controller/entities/traffic_status.go
+++ b/controller/entities/traffic_status.go
@@ -14,3 +14,18 @@ type TrafficStatus struct {
 func (t TrafficStatus) Weight() float64 {
 	return math.Max(t.ActualWeight, t.DesiredWeight)
 }
+
+// Helper constructors for common TrafficStatus values
+func NewTrafficStatusSame(weight float64) TrafficStatus {
+	return TrafficStatus{
+		ActualWeight:  weight,
+		DesiredWeight: weight,
+	}
+}
+
+func NewTrafficStatus(actualWeight, desiredWeight float64) TrafficStatus {
+	return TrafficStatus{
+		ActualWeight:  actualWeight,
+		DesiredWeight: desiredWeight,
+	}
+}

--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -165,3 +165,7 @@ func (r *PrescaleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entit
 
 	return availableBackends, backendWeights, nil
 }
+
+func (r *PrescaleTrafficReconciler) ReconcileStacks(ssc *entities.StackSetContainer) error {
+	return nil
+}

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 	"github.com/zalando-incubator/stackset-controller/pkg/recorder"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -357,20 +356,6 @@ func TestGetOwnerUID(t *testing.T) {
 	uid, ok = getOwnerUID(metav1.ObjectMeta{})
 	assert.Equal(t, types.UID(""), uid)
 	assert.False(t, ok)
-}
-
-func TestSanitizeServicePorts(t *testing.T) {
-	service := &zv1.StackServiceSpec{
-		Ports: []v1.ServicePort{
-			{
-				Protocol: "",
-			},
-		},
-	}
-
-	service = sanitizeServicePorts(service)
-	assert.Len(t, service.Ports, 1)
-	assert.Equal(t, v1.ProtocolTCP, service.Ports[0].Protocol)
 }
 
 func TestMergeLabels(t *testing.T) {

--- a/controller/traffic_reconciler.go
+++ b/controller/traffic_reconciler.go
@@ -59,3 +59,7 @@ func computeBackendWeights(stacks []entities.StackStatus, traffic map[string]ent
 
 	return availableBackends, backendWeights
 }
+
+func (r SimpleTrafficReconciler) ReconcileStacks(ssc *entities.StackSetContainer) error {
+	return nil
+}


### PR DESCRIPTION
Implements part of the logic described in our [_Automated Gradual Deployments with Feedback Loop_ narrative][narrative]: stacks marked as "green" (via an annotation) go through an additional lifecycle loosely described in the following flowchart:

![controller-behavior](https://user-images.githubusercontent.com/968838/57468157-37448e00-7284-11e9-8f6c-c30cc7ba6ffe.png)

The result should be a progressive traffic switching between an older "blue" stack and that "green" stack, based on comparisons of the performance of both "green" and a third "baseline" stack (which is the codebase of "blue" at the scale and age of "green").

[narrative]: https://docs.google.com/document/d/1K3QS0sQoJTJCTbxwpaZRmuIl241fT-PNGgMCGnLqGko