### PR TITLE
e2e: add a stackset to the deployment pipeline

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -40,6 +40,8 @@ pipeline:
         value: "registry.opensource.zalan.do/teapot/stackset-controller-test:#{CDP_BUILD_VERSION}"
       - name: CONTROLLER_ID
         value: "#{CDP_BUILD_VERSION}"
+      - name: CLUSTER_DOMAIN
+        value: stups-test.zalan.do
     end2end_tests:
       metadata:
         name: e2e

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -1,0 +1,43 @@
+apiVersion: zalando.org/v1
+kind: StackSet
+metadata:
+  name: e2e-deploy-sample
+  labels:
+    application: "e2e-deploy-sample"
+  annotations:
+    "stackset-controller.zalando.org/controller": "{{{CONTROLLER_ID}}}"
+spec:
+  ingress:
+    hosts:
+    - "e2e-deploy-sample.{{{CLUSTER_DOMAIN}}}"
+    backendPort: 80
+  stackLifecycle:
+    scaledownTTLSeconds: 300
+    limit: 3
+  stackTemplate:
+    spec:
+      version: "{{{CDP_BUILD_VERSION}}}"
+      replicas: 2
+      autoscaler:
+        minReplicas: 2
+        maxReplicas: 2
+        metrics:
+        - type: CPU
+          averageUtilization: 50
+      podTemplate:
+        metadata:
+          labels:
+            application: "e2e-deploy-sample"
+        spec:
+          containers:
+          - name: "e2e-deploy-sample"
+            image: nginx
+            ports:
+            - containerPort: 80
+            resources:
+              requests:
+                cpu: 1m
+                memory: 100Mi
+              limits:
+                cpu: 1m
+                memory: 100Mi


### PR DESCRIPTION
This allows us to see if there are any issues with the cdp-steps probers.