### PR TITLE
Only applying StackLifeCycle.Limit to stacks without traffic and enforcing it to >= 1

### DIFF
--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -91,6 +91,7 @@ func TestStackTTLWithIngress(t *testing.T) {
 	}
 }
 
+// TestStackTTLForLatestStack tests that the latest stack gets scaled down and isn't treated differently
 func TestStackTTLForLatestStack(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-last-stack"
@@ -126,14 +127,15 @@ func TestStackTTLForLatestStack(t *testing.T) {
 		}
 	}
 
-	// verify that only 1st stack is present and the last 1 has been deleted
+	// verify that the 1st stack exists and the latest stack was scaled down
 	stackVersion := 0
 	require.True(t, stackExists(stacksetName, fmt.Sprintf("v%d", stackVersion)))
 
-	// verify that the first 1 stack which was created have been deleted
 	stackVersion = 1
-	deploymentName := fmt.Sprintf("%s-v%d", stacksetName, stackVersion)
-	err := resourceDeleted(t, "stack", deploymentName, deploymentInterface()).withTimeout(time.Second * 60).await()
+	fullStackName := fmt.Sprintf("%s-v%d", stacksetName, stackVersion)
+
+	err := stackStatusMatches(t, fullStackName, expectedStackStatus{
+		replicas: pint32(0),
+	}).await()
 	require.NoError(t, err)
-	require.False(t, stackExists(stacksetName, fmt.Sprintf("v%d", stackVersion)))
 }

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -49,8 +49,8 @@ func TestStackTTLWithIngress(t *testing.T) {
 	stacksetName := "stackset-ttl-ingress"
 	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 0).Ingress()
 
-	// Create 5 stacks each with an ingress
-	for i := 0; i < 5; i++ {
+	// Create 6 stacks each with an ingress
+	for i := 0; i < 6; i++ {
 		stackVersion := fmt.Sprintf("v%d", i)
 		var err error
 		spec := specFactory.Create(stackVersion)
@@ -74,8 +74,8 @@ func TestStackTTLWithIngress(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// verify that only the last 3 created stacks are present
-	for i := 2; i < 5; i++ {
+	// verify that only the last 4 created stacks are present
+	for i := 2; i < 6; i++ {
 		deploymentName := fmt.Sprintf("%s-v%d", stacksetName, i)
 		require.True(t, stackExists(stacksetName, fmt.Sprintf("v%d", i)))
 		_, err := waitForDeployment(t, deploymentName)

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -660,7 +660,8 @@ func (c *StackSetController) getStacksToGC(ssc StackSetContainer) []zv1.Stack {
 	stackset := ssc.StackSet
 	stacks := ssc.Stacks()
 
-	historyLimit := defaultStackLifecycleLimit
+	// historyLimit is defaultStackLifecycleLimit + the stack that's getting traffic
+	historyLimit := defaultStackLifecycleLimit + 1
 	if stackset.Spec.StackLifecycle.Limit != nil {
 		historyLimit = int(*stackset.Spec.StackLifecycle.Limit)
 	}

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -71,6 +71,7 @@ spec:
                 limit:
                   type: integer
                   format: int32
+                  minimum: 1
             stackTemplate:
               properties:
                 spec:


### PR DESCRIPTION
Changing the semantics of StackLifeCycle.Limit to exclude the stacks
that are getting traffic. So `StackLifeCycle.Limit: 1` would now mean, keep
at least 2 stacks. This is more intuitive because the stacks that are getting
traffic would never be deleted anyways.

Also modifying the CRD definition to enforce StackLifeCycle.Limit >= 1.
This is so people have at least 1 stack around to safely switch to. Since
HPAs are now not deleted, this extra stack should get safely downscaled
without costing too much.

Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>