### PR TITLE
Not switching traffic until all the prescaling stacks are ready

### DIFF
--- a/cmd/e2e/basic_test.go
+++ b/cmd/e2e/basic_test.go
@@ -247,9 +247,9 @@ func verifyStacksetIngress(t *testing.T, stacksetName string, stacksetSpec zv1.S
 	}}
 	require.EqualValues(t, globalIngressRules, globalIngress.Spec.Rules)
 
-	err = trafficWeightsUpdated(t, stacksetName, weightKindDesired, expectedWeights).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindDesired, expectedWeights, nil).await()
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, expectedWeights).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, expectedWeights, nil).await()
 	require.NoError(t, err)
 }
 

--- a/cmd/e2e/prescaling_test.go
+++ b/cmd/e2e/prescaling_test.go
@@ -40,7 +40,7 @@ func TestPrescalingWithoutHPA(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 
 	// create third stack with only 1 replica and wait for the deployment to be created
@@ -61,7 +61,7 @@ func TestPrescalingWithoutHPA(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 
 	// recheck the deployment of the last stack and verify that the number of replicas is the sum of the previous stacks
@@ -111,7 +111,7 @@ func TestPrescalingWithHPA(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 
 	// create a third stack with only one replica and verify the deployment has only one pod
@@ -133,7 +133,7 @@ func TestPrescalingWithHPA(t *testing.T) {
 
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 
 	// verify that the third stack now has 6 replicas till the end of the prescaling period
@@ -183,7 +183,7 @@ func TestPrescalingPreventDelete(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTrafficMap)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTrafficMap).withTimeout(2 * time.Minute).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTrafficMap, nil).withTimeout(2 * time.Minute).await()
 	require.NoError(t, err)
 
 	// update stackset with third version
@@ -202,7 +202,7 @@ func TestPrescalingPreventDelete(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTrafficMap)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTrafficMap).withTimeout(2 * time.Minute).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTrafficMap, nil).withTimeout(2 * time.Minute).await()
 	require.NoError(t, err)
 
 	// verify that all stack deployments are still present and their prescaling is active
@@ -275,7 +275,7 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 
 	// switch traffic so that all three stacks are receiving 0%, 30% & 70% traffic respectively
@@ -287,6 +287,8 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)
 
+	//TODO: instead of doing this add a func to trafficWeightsUpdated that takes an optional function and fails
+	// immediately if the func returns an error
 	// Verify that a single traffic never gets 100% of the traffic
 	unDesiredTraffic := map[string]float64{
 		fullFirstStack:  0,
@@ -294,10 +296,10 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 		fullThirdStack:  0,
 	}
 
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, unDesiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, unDesiredTraffic, nil).withTimeout(time.Minute * 4).await()
 
 	require.Error(t, err, "A single stack got a 100% of the traffic")
 
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic).withTimeout(time.Minute * 4).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredTraffic, nil).withTimeout(time.Minute * 4).await()
 	require.NoError(t, err)
 }

--- a/cmd/e2e/prescaling_test.go
+++ b/cmd/e2e/prescaling_test.go
@@ -269,9 +269,9 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 	fullThirdStack := fmt.Sprintf("%s-%s", stacksetName, thirdStack)
 
 	desiredTraffic := map[string]float64{
-		fullFirstStack:  50,
+		fullFirstStack:  0,
 		fullSecondStack: 50,
-		fullThirdStack:  0,
+		fullThirdStack:  50,
 	}
 	err = setDesiredTrafficWeights(stacksetName, desiredTraffic)
 	require.NoError(t, err)

--- a/cmd/e2e/traffic_switch_test.go
+++ b/cmd/e2e/traffic_switch_test.go
@@ -29,7 +29,7 @@ func TestTrafficSwitch(t *testing.T) {
 	require.NoError(t, err)
 
 	initialWeights := map[string]float64{firstStack: 100}
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, initialWeights).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, initialWeights, nil).await()
 	require.NoError(t, err)
 
 	err = stackStatusMatches(t, firstStack, expectedStackStatus{
@@ -47,7 +47,7 @@ func TestTrafficSwitch(t *testing.T) {
 	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
 	err = setDesiredTrafficWeights(stacksetName, desiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredWeights).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredWeights, nil).await()
 	require.NoError(t, err)
 
 	err = stackStatusMatches(t, firstStack, expectedStackStatus{
@@ -65,7 +65,7 @@ func TestTrafficSwitch(t *testing.T) {
 	newDesiredWeights := map[string]float64{updatedStack: 100}
 	err = setDesiredTrafficWeights(stacksetName, newDesiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newDesiredWeights).await()
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
 	require.NoError(t, err)
 
 	err = stackStatusMatches(t, firstStack, expectedStackStatus{

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -70,7 +70,7 @@ func TestStackTTLWithIngress(t *testing.T) {
 		newWeight := map[string]float64{fullStackName: 100}
 		err = setDesiredTrafficWeights(stacksetName, newWeight)
 		require.NoError(t, err)
-		err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newWeight).withTimeout(10 * time.Minute).await()
+		err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newWeight, nil).withTimeout(10 * time.Minute).await()
 		require.NoError(t, err)
 	}
 
@@ -122,7 +122,7 @@ func TestStackTTLForLatestStack(t *testing.T) {
 			err = setDesiredTrafficWeights(stacksetName, newWeight)
 			require.NoError(t, err)
 
-			err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newWeight).withTimeout(10 * time.Minute).await()
+			err = trafficWeightsUpdated(t, stacksetName, weightKindActual, newWeight, nil).withTimeout(10 * time.Minute).await()
 			require.NoError(t, err)
 		}
 	}

--- a/controller/entities/traffic_reconciler.go
+++ b/controller/entities/traffic_reconciler.go
@@ -13,5 +13,5 @@ import (
 type TrafficReconciler interface {
 	ReconcileDeployment(stacks map[types.UID]*StackContainer, stack *zv1.Stack, traffic map[string]TrafficStatus, deployment *appsv1.Deployment) error
 	ReconcileHPA(stack *zv1.Stack, hpa *autoscaling.HorizontalPodAutoscaler, deployment *appsv1.Deployment) error
-	ReconcileIngress(stacks map[types.UID]*StackContainer, ingress *v1beta1.Ingress, traffic map[string]TrafficStatus) (map[string]float64, map[string]float64)
+	ReconcileIngress(stacks map[types.UID]*StackContainer, ingress *v1beta1.Ingress, traffic map[string]TrafficStatus) (map[string]float64, map[string]float64, error)
 }

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -396,7 +396,7 @@ func (c *ingressReconciler) ingressForStackSet(ssc entities.StackSetContainer, o
 		},
 	}
 
-	availableWeights, allWeights := ssc.TrafficReconciler.ReconcileIngress(ssc.StackContainers, ingress, ssc.Traffic)
+	availableWeights, allWeights := ssc.TrafficReconciler.ReconcileIngress(ssc.StackContainers, ssc.Traffic)
 
 	for backend, traffic := range availableWeights {
 		if traffic > 0 {

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -117,7 +117,7 @@ func (c *ingressReconciler) reconcile(sc entities.StackSetContainer) error {
 			return nil
 		}
 
-		switch e := err.(type) {
+		switch err.(type) {
 		case trafficSwitchingError:
 			c.recorder.Eventf(&sc.StackSet,
 				apiv1.EventTypeWarning,
@@ -125,7 +125,7 @@ func (c *ingressReconciler) reconcile(sc entities.StackSetContainer) error {
 				"Traffic for StackSet %s/%s not switched: %v",
 				sc.StackSet.Namespace,
 				sc.StackSet.Name,
-				e,
+				err,
 			)
 		default:
 			c.recorder.Eventf(&sc.StackSet,
@@ -134,7 +134,7 @@ func (c *ingressReconciler) reconcile(sc entities.StackSetContainer) error {
 				"Failed to generate Ingress for StackSet %s/%s: %v",
 				sc.StackSet.Namespace,
 				sc.StackSet.Name,
-				e,
+				err,
 			)
 			return err
 		}

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -396,7 +396,7 @@ func (c *ingressReconciler) ingressForStackSet(ssc entities.StackSetContainer, o
 		},
 	}
 
-	availableWeights, allWeights := ssc.TrafficReconciler.ReconcileIngress(ssc.StackContainers, ssc.Traffic)
+	availableWeights, allWeights := ssc.TrafficReconciler.ReconcileIngress(ssc.StackContainers, ingress, ssc.Traffic)
 
 	for backend, traffic := range availableWeights {
 		if traffic > 0 {

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -481,7 +481,10 @@ func trafficSwitchingAnnotationsForIngress(ssc entities.StackSetContainer, ingre
 	ingress.Annotations[backendWeightsAnnotationKey] = string(availableWeightsData)
 	ingress.Annotations[stackTrafficWeightsAnnotationKey] = string(allWeightsData)
 
-	return trafficSwitchingErr
+	if trafficSwitchingErr != nil {
+		return trafficSwitchingErr
+	}
+	return nil
 }
 
 // allZero returns true if all weights defined in the map are 0.

--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -137,6 +137,7 @@ func (r *PrescaleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entit
 		normalizeWeights(backendWeights)
 	}
 
+	// don't switch traffic (return currentWeights as is) if 1 or more backends aren't ready yet
 	if len(availableBackends) == 0 || notReadyBackends > 0 {
 		availableBackends = currentWeights
 	}

--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -153,11 +153,11 @@ func (r *PrescaleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entit
 
 	normalizeWeights(availableBackends)
 
-	var err trafficSwitchingError
 	if notReadyBackends > 0 {
 		msg := fmt.Sprintf("%d stacks are not ready yet", notReadyBackends)
-		err = trafficSwitchingError{err: msg}
+		err := trafficSwitchingError{err: msg}
+		return availableBackends, backendWeights, err
 	}
 
-	return availableBackends, backendWeights, err
+	return availableBackends, backendWeights, nil
 }

--- a/controller/prescale_reconciler.go
+++ b/controller/prescale_reconciler.go
@@ -119,7 +119,7 @@ func (r *PrescaleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entit
 		// prescale if stack is currently less than desired traffic
 		if traffic[stack.Stack.Name].ActualWeight < traffic[stack.Stack.Name].DesiredWeight && deployment != nil {
 			var actualReplicas int32 = 1
-			var desiredReplicas int32 = 1
+			var desiredReplicas int32
 			if deployment.Spec.Replicas != nil {
 				actualReplicas = *deployment.Spec.Replicas
 			}

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -1270,7 +1270,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{}
-			availableWeights, allWeights := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
+			availableWeights, allWeights, _ := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
 			require.Equal(t, ti.expectedAvailableWeights, availableWeights)
 			require.Equal(t, ti.expectedAllWeights, allWeights)
 		})

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -1274,7 +1274,9 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{}
 			availableWeights, allWeights, err := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
-			require.Error(t, err)
+			if ti.err != nil {
+				require.Error(t, err)
+			}
 			require.Equal(t, ti.expectedAvailableWeights, availableWeights)
 			require.Equal(t, ti.expectedAllWeights, allWeights)
 		})

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -1179,14 +1179,14 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 		},
 		{
 			msg: "test two prescaled stacks one is ready and one is not with both receiving traffic",
-			stacks: map[types.UID]*StackContainer{
+			stacks: map[types.UID]*entities.StackContainer{
 				types.UID("1"): {
 					Stack: zv1.Stack{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "svc-1",
 						},
 					},
-					Resources: StackResources{
+					Resources: entities.StackResources{
 						Deployment: &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:        "svc-1",
@@ -1204,7 +1204,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 							Prescaling: zv1.PrescalingStatus{Active: true, Replicas: 10},
 						},
 					},
-					Resources: StackResources{
+					Resources: entities.StackResources{
 						Deployment: &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "svc-2",
@@ -1227,7 +1227,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 							Prescaling: zv1.PrescalingStatus{Active: true, Replicas: 10},
 						},
 					},
-					Resources: StackResources{
+					Resources: entities.StackResources{
 						Deployment: &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "svc-3",
@@ -1242,7 +1242,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 					},
 				},
 			},
-			traffic: map[string]TrafficStatus{
+			traffic: map[string]entities.TrafficStatus{
 				"svc-1": {
 					ActualWeight:  0.0,
 					DesiredWeight: 0.0,
@@ -1270,7 +1270,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{}
-			availableWeights, allWeights := trafficReconciler.ReconcileIngress(ti.stacks, ti.traffic)
+			availableWeights, allWeights := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
 			require.Equal(t, ti.expectedAvailableWeights, availableWeights)
 			require.Equal(t, ti.expectedAllWeights, allWeights)
 		})

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -845,6 +845,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				"svc-2": 0.0,
 				"svc-3": 100.0,
 			},
+			err: trafficSwitchingError{"1 stacks are not ready yet"},
 		},
 		{
 			msg: "Prescaled stack should get desired traffic",
@@ -1007,6 +1008,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				"svc-2": 0.0,
 				"svc-3": 100.0,
 			},
+			err: trafficSwitchingError{"1 stacks are not ready yet"},
 		},
 		{
 			msg: "Prescaled stack with actual traffic should not loose traffic if not all replicas are ready",
@@ -1327,7 +1329,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 								Name: "svc-3",
 							},
 							Spec: appsv1.DeploymentSpec{
-								Replicas: &[]int32{117}[0],
+								Replicas: &[]int32{10}[0],
 							},
 							Status: appsv1.DeploymentStatus{
 								ReadyReplicas: 10,
@@ -1417,10 +1419,10 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 								Name: "svc-3",
 							},
 							Spec: appsv1.DeploymentSpec{
-								Replicas: &[]int32{117}[0],
+								Replicas: &[]int32{10}[0],
 							},
 							Status: appsv1.DeploymentStatus{
-								ReadyReplicas: 10,
+								ReadyReplicas: 9,
 							},
 						},
 					},
@@ -1442,14 +1444,16 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				},
 			},
 			expectedAvailableWeights: map[string]float64{
-				"svc-2": 30.0,
-				"svc-3": 70.0,
+				"svc-1": 0.0,
+				"svc-2": 50.0,
+				"svc-3": 50.0,
 			},
 			expectedAllWeights: map[string]float64{
 				"svc-1": 0.0,
 				"svc-2": 30.0,
 				"svc-3": 70.0,
 			},
+			err: trafficSwitchingError{"1 stacks are not ready yet"},
 		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
@@ -1461,6 +1465,8 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 			// Check err later because the weights returned still matter
 			if ti.err != nil {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 		})

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -768,6 +768,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 		traffic                  map[string]entities.TrafficStatus
 		expectedAvailableWeights map[string]float64
 		expectedAllWeights       map[string]float64
+		err                      error
 	}{
 		{
 			msg: "stacks without active prescaling status should not get desired traffic if it was already 0",
@@ -1176,6 +1177,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				"svc-2": 50.0,
 				"svc-3": 50.0,
 			},
+			err: trafficSwitchingError{"1 stacks are not ready yet"},
 		},
 		{
 			msg: "test two prescaled stacks one is ready and one is not with both receiving traffic",
@@ -1266,11 +1268,13 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				"svc-2": 30.0,
 				"svc-3": 70.0,
 			},
+			err: trafficSwitchingError{"1 stacks are not ready yet"},
 		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{}
-			availableWeights, allWeights, _ := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
+			availableWeights, allWeights, err := trafficReconciler.ReconcileIngress(ti.stacks, ti.ingress, ti.traffic)
+			require.Error(t, err)
 			require.Equal(t, ti.expectedAvailableWeights, availableWeights)
 			require.Equal(t, ti.expectedAllWeights, allWeights)
 		})

--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -1167,7 +1167,9 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				},
 			},
 			expectedAvailableWeights: map[string]float64{
+				"svc-1": 0.0,
 				"svc-2": 100.0,
+				"svc-3": 0.0,
 			},
 			expectedAllWeights: map[string]float64{
 				"svc-1": 0.0,
@@ -1255,6 +1257,7 @@ func TestReconcileIngressTraffic(tt *testing.T) {
 				},
 			},
 			expectedAvailableWeights: map[string]float64{
+				"svc-1": 0.0,
 				"svc-2": 50.0,
 				"svc-3": 50.0,
 			},

--- a/controller/traffic_reconciler.go
+++ b/controller/traffic_reconciler.go
@@ -27,9 +27,10 @@ func (r SimpleTrafficReconciler) ReconcileHPA(stack *zv1.Stack, hpa *autoscaling
 }
 
 // ReconcileIngress computes the ingress traffic to distribute to stacks.
-func (r SimpleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entities.StackContainer, ingress *v1beta1.Ingress, traffic map[string]entities.TrafficStatus) (map[string]float64, map[string]float64) {
+func (r SimpleTrafficReconciler) ReconcileIngress(stacks map[types.UID]*entities.StackContainer, ingress *v1beta1.Ingress, traffic map[string]entities.TrafficStatus) (map[string]float64, map[string]float64, error) {
 	stackStatuses := entities.GetStackStatuses(stacks)
-	return computeBackendWeights(stackStatuses, traffic)
+	availableBackends, allBackends := computeBackendWeights(stackStatuses, traffic)
+	return availableBackends, allBackends, nil
 }
 
 func computeBackendWeights(stacks []entities.StackStatus, traffic map[string]entities.TrafficStatus) (map[string]float64, map[string]float64) {

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -43,13 +43,13 @@ zkubectl create ns $controllerId
 env E2E_NAMESPACE=$controllerId \
     CONTROLLER_ID=$controllerId \
     KUBECONFIG=$HOME/.kube/config \
-    build/e2e -test.v -test.parallel 64 || true
+    build/e2e -test.v -test.run TestPrescalingWaitsForBackends || true
 
 # Delete the test namespace.
-zkubectl delete ns $controllerId
+#zkubectl delete ns $controllerId
 
 # Kill all background jobs.
 echo "Jobs to kill:"
 jobs
-pkill stackset-controller
-pkill -f kubectl
+#pkill stackset-controller
+#pkill -f kubectl

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -43,13 +43,13 @@ zkubectl create ns $controllerId
 env E2E_NAMESPACE=$controllerId \
     CONTROLLER_ID=$controllerId \
     KUBECONFIG=$HOME/.kube/config \
-    build/e2e -test.v -test.run TestPrescalingWaitsForBackends || true
+    build/e2e -test.v -test.parallel 64 || true
 
 # Delete the test namespace.
-#zkubectl delete ns $controllerId
+zkubectl delete ns $controllerId
 
 # Kill all background jobs.
 echo "Jobs to kill:"
 jobs
-#pkill stackset-controller
-#pkill -f kubectl
+pkill stackset-controller
+pkill -f kubectl


### PR DESCRIPTION
When there are multiple stacks which are prescaled and one of them doesn't have all it's replicas ready then traffic is only sent to the one with all replicas ready. This is an issue because both could have been receiving traffic and suddenly only one will get all the traffic.