### PR TITLE
Correctly inject stack labels to pod template

### DIFF
--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -57,10 +57,8 @@ func newDeploymentFromStack(stack zv1.Stack) *appsv1.Deployment {
 func newPodTemplateFromStack(stack zv1.Stack) v1.PodTemplateSpec {
 	template := *stack.Spec.PodTemplate.DeepCopy()
 
-	// Copy Labels from Stack.Labels to the Deployment
-	template.ObjectMeta.Labels = mapCopy(stack.Labels)
-
-	return template
+	// add labels from Stack.Labels to pods
+	return templateInjectLabels(template, stack.Labels)
 }
 
 func mapCopy(m map[string]string) map[string]string {


### PR DESCRIPTION
Correctly inject labels to the pod template instead of overwriting the labels on deployment creation. If we don't do this creating a deployment will result in any user defined labels being dropped. This is fixed as soon as the deployment is updated but results in creating a new ReplicaSet which is confusing and triggers a rolling update of the deployment.