### PR TITLE
Breaking up ingressForStackSet

### DIFF
--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -385,6 +385,10 @@ func (c *ingressReconciler) ingressForStackSet(ssc entities.StackSetContainer, o
 		},
 	}
 
+	if ingress.Annotations == nil {
+		ingress.Annotations = map[string]string{}
+	}
+
 	// insert annotations
 	for k, v := range stackset.Spec.Ingress.Annotations {
 		ingress.Annotations[k] = v


### PR DESCRIPTION
Breaking out trafficSwitchingAnnotationForIngress from ingressFromStackSet
to be able to propagate traffic switching errors more easily.

ref:https://github.com/zalando-incubator/stackset-controller/pull/128
Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>