### PR TITLE
Reset the prescaling replica count when prescaling multiple times

### DIFF
--- a/controller/prescale_reconciler_test.go
+++ b/controller/prescale_reconciler_test.go
@@ -680,6 +680,111 @@ func TestPrescaleReconcilerReconcileDeployment(tt *testing.T) {
 			calculatedReplicas: 3,
 			timestampUpdated:   true,
 		},
+		{
+			msg: "reset prescaling replica count when calculating prescaling replicas",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "svc-3",
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &[]int32{3}[0],
+				},
+			},
+			stack: &zv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-3",
+				},
+				Spec: zv1.StackSpec{
+					HorizontalPodAutoscaler: &zv1.HorizontalPodAutoscaler{
+						MinReplicas: &[]int32{1}[0],
+						MaxReplicas: 30,
+					},
+					Replicas: pint32(3),
+				},
+				Status: zv1.StackStatus{
+					Prescaling: zv1.PrescalingStatus{
+						Active:              false,
+						Replicas:            10,
+						LastTrafficIncrease: &metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+					},
+				},
+			},
+			stacks: map[types.UID]*entities.StackContainer{
+				types.UID("1"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-1",
+						},
+					},
+					Resources: entities.StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-1",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{3}[0],
+							},
+						},
+					},
+				},
+				types.UID("2"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-2",
+						},
+					},
+					Resources: entities.StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-2",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{3}[0],
+							},
+						},
+					},
+				},
+				types.UID("3"): {
+					Stack: zv1.Stack{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "svc-3",
+						},
+					},
+					Resources: entities.StackResources{
+						Deployment: &appsv1.Deployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "svc-3",
+								Annotations: map[string]string{},
+							},
+							Spec: appsv1.DeploymentSpec{
+								Replicas: &[]int32{3}[0],
+							},
+						},
+					},
+				},
+			},
+			traffic: map[string]entities.TrafficStatus{
+				"svc-1": {
+					ActualWeight:  50.0,
+					DesiredWeight: 0.0,
+				},
+				"svc-2": {
+					ActualWeight:  50.0,
+					DesiredWeight: 50.0,
+				},
+				"svc-3": {
+					ActualWeight:  0.0,
+					DesiredWeight: 50.0,
+				},
+			},
+			expectedReplicas:   3,
+			prescalingActive:   true,
+			calculatedReplicas: 6,
+			timestampUpdated:   true,
+		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			trafficReconciler := PrescaleTrafficReconciler{ResetHPAMinReplicasTimeout: DefaultResetMinReplicasDelay}


### PR DESCRIPTION
There was a bug in the prescaling logic where the previously calculated replicas was not reset and subsequent prescaling calculations would be added to past calculations.