### PR TITLE
Return error right away to prevent side effects

### DIFF
--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -425,6 +425,9 @@ func (c *ingressReconciler) ingressForStackSet(ssc entities.StackSetContainer, o
 func trafficSwitchingAnnotationsForIngress(ssc entities.StackSetContainer, ingress *v1beta1.Ingress) error {
 	stackset := &ssc.StackSet
 	availableWeights, allWeights, trafficSwitchingErr := ssc.TrafficReconciler.ReconcileIngress(ssc.StackContainers, ingress, ssc.Traffic)
+	if trafficSwitchingErr != nil {
+		return trafficSwitchingErr
+	}
 
 	rule := v1beta1.IngressRule{
 		IngressRuleValue: v1beta1.IngressRuleValue{
@@ -481,9 +484,6 @@ func trafficSwitchingAnnotationsForIngress(ssc entities.StackSetContainer, ingre
 	ingress.Annotations[backendWeightsAnnotationKey] = string(availableWeightsData)
 	ingress.Annotations[stackTrafficWeightsAnnotationKey] = string(allWeightsData)
 
-	if trafficSwitchingErr != nil {
-		return trafficSwitchingErr
-	}
 	return nil
 }
 


### PR DESCRIPTION
Moves the error handling to where the error is returned. This ensures that we don't modify the `ingress` variable even when an error is returned.

In the actual code this didn't matter because it would be handled later on. But it makes it simpler to follow the code IMO and allows the `ReconcileIngress` implementation to return `nil` for the traffic maps in case of an error without crashing the program.