### PR TITLE
Prescaling: calculate replicas based on existing stacks

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -253,6 +253,9 @@ type PrescalingStatus struct {
 	// Replicas is the number of replicas required for prescaling
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
+	// DesiredTrafficWeight is the desired traffic weight that the stack was prescaled for
+	// +optional
+	DesiredTrafficWeight float64 `json:"desiredTrafficWeight"`
 	// LastTrafficIncrease is the timestamp when the traffic was last increased on the stack
 	// +optional
 	LastTrafficIncrease *metav1.Time `json:"lastTrafficIncrease,omitempty"`

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -290,9 +290,10 @@ func (sc *StackContainer) GenerateStackStatus() *zv1.StackStatus {
 	prescaling := zv1.PrescalingStatus{}
 	if sc.prescalingActive {
 		prescaling = zv1.PrescalingStatus{
-			Active:              sc.prescalingActive,
-			Replicas:            sc.prescalingReplicas,
-			LastTrafficIncrease: wrapTime(sc.prescalingLastTrafficIncrease),
+			Active:               sc.prescalingActive,
+			Replicas:             sc.prescalingReplicas,
+			DesiredTrafficWeight: sc.prescalingDesiredTrafficWeight,
+			LastTrafficIncrease:  wrapTime(sc.prescalingLastTrafficIncrease),
 		}
 	}
 	return &zv1.StackStatus{

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -569,13 +569,14 @@ func TestGenerateStackStatus(t *testing.T) {
 	hourAgo := time.Now().Add(-time.Hour)
 
 	for _, tc := range []struct {
-		name                          string
-		actualTrafficWeight           float64
-		desiredTrafficWeight          float64
-		noTrafficSince                time.Time
-		prescalingActive              bool
-		prescalingReplicas            int32
-		prescalingLastTrafficIncrease time.Time
+		name                           string
+		actualTrafficWeight            float64
+		desiredTrafficWeight           float64
+		noTrafficSince                 time.Time
+		prescalingActive               bool
+		prescalingReplicas             int32
+		prescalingDesiredTrafficWeight float64
+		prescalingLastTrafficIncrease  time.Time
 	}{
 		{
 			name:                 "with traffic",
@@ -587,26 +588,28 @@ func TestGenerateStackStatus(t *testing.T) {
 			noTrafficSince: hourAgo,
 		},
 		{
-			name:                          "prescaled",
-			actualTrafficWeight:           0.25,
-			desiredTrafficWeight:          0.25,
-			prescalingActive:              true,
-			prescalingReplicas:            3,
-			prescalingLastTrafficIncrease: hourAgo,
+			name:                           "prescaled",
+			actualTrafficWeight:            0.25,
+			desiredTrafficWeight:           0.25,
+			prescalingActive:               true,
+			prescalingReplicas:             3,
+			prescalingDesiredTrafficWeight: 22.75,
+			prescalingLastTrafficIncrease:  hourAgo,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &StackContainer{
-				actualTrafficWeight:           tc.actualTrafficWeight,
-				desiredTrafficWeight:          tc.desiredTrafficWeight,
-				createdReplicas:               3,
-				readyReplicas:                 2,
-				updatedReplicas:               1,
-				desiredReplicas:               4,
-				noTrafficSince:                tc.noTrafficSince,
-				prescalingActive:              tc.prescalingActive,
-				prescalingReplicas:            tc.prescalingReplicas,
-				prescalingLastTrafficIncrease: tc.prescalingLastTrafficIncrease,
+				actualTrafficWeight:            tc.actualTrafficWeight,
+				desiredTrafficWeight:           tc.desiredTrafficWeight,
+				createdReplicas:                3,
+				readyReplicas:                  2,
+				updatedReplicas:                1,
+				desiredReplicas:                4,
+				noTrafficSince:                 tc.noTrafficSince,
+				prescalingActive:               tc.prescalingActive,
+				prescalingReplicas:             tc.prescalingReplicas,
+				prescalingDesiredTrafficWeight: tc.prescalingDesiredTrafficWeight,
+				prescalingLastTrafficIncrease:  tc.prescalingLastTrafficIncrease,
 			}
 			status := c.GenerateStackStatus()
 			expected := &zv1.StackStatus{
@@ -618,9 +621,10 @@ func TestGenerateStackStatus(t *testing.T) {
 				DesiredReplicas:      4,
 				NoTrafficSince:       wrapTime(tc.noTrafficSince),
 				Prescaling: zv1.PrescalingStatus{
-					Active:              tc.prescalingActive,
-					Replicas:            tc.prescalingReplicas,
-					LastTrafficIncrease: wrapTime(tc.prescalingLastTrafficIncrease),
+					Active:               tc.prescalingActive,
+					Replicas:             tc.prescalingReplicas,
+					DesiredTrafficWeight: tc.prescalingDesiredTrafficWeight,
+					LastTrafficIncrease:  wrapTime(tc.prescalingLastTrafficIncrease),
 				},
 			}
 			require.Equal(t, expected, status)

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -429,14 +429,16 @@ func TestStackUpdateFromResources(t *testing.T) {
 
 	runTest("prescaling information is parsed from the status", func(t *testing.T, container *StackContainer) {
 		container.Stack.Status.Prescaling = zv1.PrescalingStatus{
-			Active:              true,
-			Replicas:            11,
-			LastTrafficIncrease: &metav1.Time{Time: hourAgo},
+			Active:               true,
+			Replicas:             11,
+			DesiredTrafficWeight: 23.5,
+			LastTrafficIncrease:  &metav1.Time{Time: hourAgo},
 		}
 		container.updateFromResources()
 		require.EqualValues(t, 1, container.stackReplicas)
 		require.EqualValues(t, true, container.prescalingActive)
 		require.EqualValues(t, 11, container.prescalingReplicas)
+		require.EqualValues(t, 23.5, container.prescalingDesiredTrafficWeight)
 		require.EqualValues(t, hourAgo, container.prescalingLastTrafficIncrease)
 	})
 }

--- a/pkg/core/test_helpers.go
+++ b/pkg/core/test_helpers.go
@@ -78,9 +78,10 @@ func (f *testStackFactory) pendingRemoval() *testStackFactory {
 	return f
 }
 
-func (f *testStackFactory) prescaling(replicas int32, lastTrafficIncrease time.Time) *testStackFactory {
+func (f *testStackFactory) prescaling(replicas int32, desiredTrafficWeight float64, lastTrafficIncrease time.Time) *testStackFactory {
 	f.container.prescalingActive = true
 	f.container.prescalingReplicas = replicas
+	f.container.prescalingDesiredTrafficWeight = desiredTrafficWeight
 	f.container.prescalingLastTrafficIncrease = lastTrafficIncrease
 	return f
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -76,13 +76,14 @@ type StackContainer struct {
 	desiredReplicas    int32
 
 	// Traffic & scaling
-	currentActualTrafficWeight    float64
-	actualTrafficWeight           float64
-	desiredTrafficWeight          float64
-	noTrafficSince                time.Time
-	prescalingActive              bool
-	prescalingReplicas            int32
-	prescalingLastTrafficIncrease time.Time
+	currentActualTrafficWeight     float64
+	actualTrafficWeight            float64
+	desiredTrafficWeight           float64
+	noTrafficSince                 time.Time
+	prescalingActive               bool
+	prescalingReplicas             int32
+	prescalingDesiredTrafficWeight float64
+	prescalingLastTrafficIncrease  time.Time
 }
 
 // TrafficChange contains information about a traffic change event
@@ -264,6 +265,7 @@ func (sc *StackContainer) updateFromResources() {
 	if status.Prescaling.Active {
 		sc.prescalingActive = true
 		sc.prescalingReplicas = status.Prescaling.Replicas
+		sc.prescalingDesiredTrafficWeight = status.Prescaling.DesiredTrafficWeight
 		sc.prescalingLastTrafficIncrease = unwrapTime(status.Prescaling.LastTrafficIncrease)
 	}
 }


### PR DESCRIPTION
Calculate the number of replicas required when prescaling more intelligently. Instead of just adding up all existing pods and using it as the target number, no matter the desired traffic weight, try to derive how many replicas we need based on the current stacks and the target traffic weight. For example, if we find out that 10% of traffic can be handled by 1 pod and the desired weight is 30%, we only prescale up to 3 replicas.

**TBD**: rebase on `master` after the main refactoring PR is merged.