### PR TITLE
Don't serialize empty prescaling.desiredTrafficWeight

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -255,7 +255,7 @@ type PrescalingStatus struct {
 	Replicas int32 `json:"replicas,omitempty"`
 	// DesiredTrafficWeight is the desired traffic weight that the stack was prescaled for
 	// +optional
-	DesiredTrafficWeight float64 `json:"desiredTrafficWeight"`
+	DesiredTrafficWeight float64 `json:"desiredTrafficWeight,omitempty"`
 	// LastTrafficIncrease is the timestamp when the traffic was last increased on the stack
 	// +optional
 	LastTrafficIncrease *metav1.Time `json:"lastTrafficIncrease,omitempty"`


### PR DESCRIPTION
It just looks weird, better to not render it.