### PR TITLE
Improve error handling

### DIFF
--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestBrokenStacks(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "stackset-broken-stacks"
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(1, 30)
+
+	firstVersion := "v1"
+	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
+	spec := factory.Create(firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, firstVersion)
+	require.NoError(t, err)
+
+	unhealthyVersion := "v2"
+	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
+	spec = factory.Create(unhealthyVersion)
+	spec.StackTemplate.Spec.Service.Ports = []v1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromString("foobar"),
+		},
+	}
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, unhealthyVersion)
+	require.NoError(t, err)
+
+	_, err = waitForIngress(t, stacksetName)
+	require.NoError(t, err)
+
+	initialWeights := map[string]float64{firstStack: 100}
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, initialWeights, nil).await()
+	require.NoError(t, err)
+
+	// Switch traffic to the second stack, this should fail
+	desiredWeights := map[string]float64{unhealthyStack: 100}
+	err = setDesiredTrafficWeights(stacksetName, desiredWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, desiredWeights, nil).await()
+	require.Error(t, err)
+
+	// Create a healthy stack
+	healthyVersion := "v3"
+	healthyStack := fmt.Sprintf("%s-%s", stacksetName, healthyVersion)
+	spec = factory.Create(healthyVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, healthyVersion)
+	require.NoError(t, err)
+
+	healthyWeights := map[string]float64{healthyStack: 100}
+	err = setDesiredTrafficWeights(stacksetName, healthyWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, healthyWeights, nil).await()
+	require.NoError(t, err)
+
+	// Create another healthy stack so we can test GC
+	finalVersion := "v4"
+	finalStack := fmt.Sprintf("%s-%s", stacksetName, finalVersion)
+	spec = factory.Create(finalVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, finalVersion)
+	require.NoError(t, err)
+
+	finalWeights := map[string]float64{finalStack: 100}
+	err = setDesiredTrafficWeights(stacksetName, finalWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdated(t, stacksetName, weightKindActual, finalWeights, nil).await()
+	require.NoError(t, err)
+
+	// Check that the unhealthy stack was deleted
+	for _, stack := range []string{firstStack, unhealthyStack} {
+		err := resourceDeleted(t, "stack", stack, stackInterface()).withTimeout(time.Second * 60).await()
+		require.NoError(t, err)
+	}
+
+}

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -715,10 +715,7 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 	}
 
 	// Mark stacks that should be removed
-	err = container.MarkExpiredStacks()
-	if err != nil {
-		return err
-	}
+	container.MarkExpiredStacks()
 
 	// Create or update resources
 	err = c.ReconcileResources(container)

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -703,10 +703,7 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 	// Update the stacks with the currently selected traffic reconciler
 	err = container.ManageTraffic(time.Now())
 	if err != nil {
-		if !core.IsTrafficSwitchError(err) {
-			return err
-		}
-		c.stacksetLogger(container).Warnf("Traffic reconciliation failed: %v", err)
+		c.stacksetLogger(container).Errorf("Traffic reconciliation failed: %v", err)
 		c.recorder.Eventf(
 			container.StackSet,
 			v1.EventTypeWarning,

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -292,7 +292,7 @@ func TestCreateCurrentStack(t *testing.T) {
 			Stack: stack,
 		},
 	}, container.StackContainers)
-	require.Equal(t, "v1", stackset.Status.ObservedStackVersion)
+	require.Equal(t, "v1", container.StackSet.Status.ObservedStackVersion)
 
 	// Check that we don't create the stack if not needed
 	stackset.Status.ObservedStackVersion = "v2"

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -270,7 +270,7 @@ func TestCreateCurrentStack(t *testing.T) {
 	_, err = env.client.ZalandoV1().Stacks(stackset.Namespace).Get("foo-v1", metav1.GetOptions{})
 	require.True(t, errors.IsNotFound(err))
 
-	container := core.StackSetContainer{
+	container := &core.StackSetContainer{
 		StackSet:          &stackset,
 		StackContainers:   map[types.UID]*core.StackContainer{},
 		TrafficReconciler: &core.SimpleTrafficReconciler{},
@@ -320,7 +320,7 @@ func TestCleanupOldStacks(t *testing.T) {
 	err = env.CreateStacks([]zv1.Stack{testStack1, testStack2, testStack3, testStack4})
 	require.NoError(t, err)
 
-	container := core.StackSetContainer{
+	container := &core.StackSetContainer{
 		StackSet: &stackset,
 		StackContainers: map[types.UID]*core.StackContainer{
 			testStack1.UID: {

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -98,7 +98,7 @@ func (ssc *StackSetContainer) NewStack() (*StackContainer, string) {
 }
 
 // MarkExpiredStacks marks stacks that should be deleted
-func (ssc *StackSetContainer) MarkExpiredStacks() error {
+func (ssc *StackSetContainer) MarkExpiredStacks() {
 	historyLimit := defaultStackLifecycleLimit
 	if ssc.StackSet.Spec.StackLifecycle.Limit != nil {
 		historyLimit = int(*ssc.StackSet.Spec.StackLifecycle.Limit)
@@ -115,7 +115,7 @@ func (ssc *StackSetContainer) MarkExpiredStacks() error {
 
 	// only garbage collect if history limit is reached
 	if len(gcCandidates) <= historyLimit {
-		return nil
+		return
 	}
 
 	// sort candidates by oldest
@@ -128,8 +128,6 @@ func (ssc *StackSetContainer) MarkExpiredStacks() error {
 	for _, sc := range gcCandidates[:excessStacks] {
 		sc.PendingRemoval = true
 	}
-
-	return nil
 }
 
 func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -114,8 +114,7 @@ func TestExpiredStacks(t *testing.T) {
 				c.StackContainers[types.UID(stack.Name())] = stack
 			}
 
-			err := c.MarkExpiredStacks()
-			require.NoError(t, err)
+			c.MarkExpiredStacks()
 			for _, stack := range tc.stacks {
 				require.Equal(t, tc.expected[stack.Name()], stack.PendingRemoval, "stack %s", stack.Stack.Name)
 			}

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -339,16 +339,12 @@ func TestStackUpdateFromResources(t *testing.T) {
 			},
 		}
 	}
-	hpa := func(stackGeneration int64, generation int64, observedGeneration int64) *autoscaling.HorizontalPodAutoscaler {
+	hpa := func(stackGeneration int64) *autoscaling.HorizontalPodAutoscaler {
 		return &autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Generation: generation,
 				Annotations: map[string]string{
 					stackGenerationAnnotationKey: strconv.FormatInt(stackGeneration, 10),
 				},
-			},
-			Status: autoscaling.HorizontalPodAutoscalerStatus{
-				ObservedGeneration: &observedGeneration,
 			},
 		}
 	}
@@ -469,16 +465,15 @@ func TestStackUpdateFromResources(t *testing.T) {
 		container.Stack.Spec.Autoscaler = &zv1.Autoscaler{}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
-		container.Resources.HPA = hpa(10, 5, 5)
+		container.Resources.HPA = hpa(10)
 		container.updateFromResources()
 		require.EqualValues(t, false, container.resourcesUpdated)
 	})
-	runTest("hpa isn't considered updated if observedGeneration is different", func(t *testing.T, container *StackContainer) {
+	runTest("hpa isn't considered updated if it should be gone", func(t *testing.T, container *StackContainer) {
 		container.Stack.Generation = 11
-		container.Stack.Spec.Autoscaler = &zv1.Autoscaler{}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
-		container.Resources.HPA = hpa(11, 5, 4)
+		container.Resources.HPA = hpa(11)
 		container.updateFromResources()
 		require.EqualValues(t, false, container.resourcesUpdated)
 	})
@@ -497,7 +492,7 @@ func TestStackUpdateFromResources(t *testing.T) {
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
 		container.Resources.Ingress = ingress(11)
-		container.Resources.HPA = hpa(11, 5, 5)
+		container.Resources.HPA = hpa(11)
 		container.updateFromResources()
 		require.EqualValues(t, true, container.resourcesUpdated)
 	})

--- a/pkg/core/test_helpers.go
+++ b/pkg/core/test_helpers.go
@@ -29,15 +29,15 @@ func testStack(name string) *testStackFactory {
 }
 
 func (f *testStackFactory) ready(replicas int32) *testStackFactory {
-	f.container.deploymentUpdated = true
+	f.container.resourcesUpdated = true
 	f.container.deploymentReplicas = replicas
 	f.container.updatedReplicas = replicas
 	f.container.readyReplicas = replicas
 	return f
 }
 
-func (f *testStackFactory) deployment(updated bool, deploymentReplicas, updatedReplicas, readyReplicas int32) *testStackFactory {
-	f.container.deploymentUpdated = updated
+func (f *testStackFactory) deployment(resourcesUpdated bool, deploymentReplicas, updatedReplicas, readyReplicas int32) *testStackFactory {
+	f.container.resourcesUpdated = resourcesUpdated
 	f.container.deploymentReplicas = deploymentReplicas
 	f.container.updatedReplicas = updatedReplicas
 	f.container.readyReplicas = readyReplicas

--- a/pkg/core/traffic.go
+++ b/pkg/core/traffic.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -9,23 +8,6 @@ const (
 	stackTrafficWeightsAnnotationKey = "zalando.org/stack-traffic-weights"
 	backendWeightsAnnotationKey      = "zalando.org/backend-weights"
 )
-
-type trafficSwitchError struct {
-	reason string
-}
-
-func (e *trafficSwitchError) Error() string {
-	return e.reason
-}
-
-func IsTrafficSwitchError(err error) bool {
-	_, ok := err.(*trafficSwitchError)
-	return ok
-}
-
-func newTrafficSwitchError(format string, args ...interface{}) error {
-	return &trafficSwitchError{reason: fmt.Sprintf(format, args...)}
-}
 
 type TrafficReconciler interface {
 	// Handle the traffic switching and/or scaling logic.

--- a/pkg/core/traffic_prescaling.go
+++ b/pkg/core/traffic_prescaling.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -101,7 +102,7 @@ func (r PrescalingTrafficReconciler) Reconcile(stacks map[string]*StackContainer
 
 	if len(nonReadyStacks) > 0 {
 		sort.Strings(nonReadyStacks)
-		return newTrafficSwitchError("stacks not ready: %s", strings.Join(nonReadyStacks, ", "))
+		return fmt.Errorf("stacks not ready: %s", strings.Join(nonReadyStacks, ", "))
 	}
 
 	// TODO: think of case were all are zero and the service/deployment is deleted.

--- a/pkg/core/traffic_simple.go
+++ b/pkg/core/traffic_simple.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -23,7 +24,7 @@ func (SimpleTrafficReconciler) Reconcile(stacks map[string]*StackContainer, curr
 	}
 	if len(nonReadyStacks) > 0 {
 		sort.Strings(nonReadyStacks)
-		return newTrafficSwitchError("stacks not ready: %s", strings.Join(nonReadyStacks, ", "))
+		return fmt.Errorf("stacks not ready: %s", strings.Join(nonReadyStacks, ", "))
 	}
 
 	// TODO: think of case were all are zero and the service/deployment is deleted.

--- a/pkg/core/traffic_test.go
+++ b/pkg/core/traffic_test.go
@@ -91,10 +91,8 @@ func TestTrafficSwitchSimpleNotReady(t *testing.T) {
 				TrafficReconciler: SimpleTrafficReconciler{},
 			}
 			err := c.ManageTraffic(time.Now())
-			expected := &trafficSwitchError{
-				reason: "stacks not ready: foo-v1",
-			}
-			require.Equal(t, expected, err)
+			require.Error(t, err)
+			require.Equal(t, "stacks not ready: foo-v1", err.Error())
 		})
 	}
 }

--- a/pkg/core/traffic_test.go
+++ b/pkg/core/traffic_test.go
@@ -50,28 +50,28 @@ func TestTrafficSwitchSimpleNotReady(t *testing.T) {
 	for _, tc := range []struct {
 		name               string
 		stack              *StackContainer
-		deploymentUpdated  bool
+		resourcesUpdated   bool
 		deploymentReplicas int32
 		updatedReplicas    int32
 		readyReplicas      int32
 	}{
 		{
 			name:               "deployment not updated yet",
-			deploymentUpdated:  false,
+			resourcesUpdated:   false,
 			deploymentReplicas: 3,
 			updatedReplicas:    3,
 			readyReplicas:      3,
 		},
 		{
 			name:               "not enough updated replicas",
-			deploymentUpdated:  true,
+			resourcesUpdated:   true,
 			deploymentReplicas: 3,
 			updatedReplicas:    2,
 			readyReplicas:      3,
 		},
 		{
 			name:               "not enough ready replicas",
-			deploymentUpdated:  true,
+			resourcesUpdated:   true,
 			deploymentReplicas: 3,
 			updatedReplicas:    3,
 			readyReplicas:      2,
@@ -85,7 +85,7 @@ func TestTrafficSwitchSimpleNotReady(t *testing.T) {
 					},
 				},
 				StackContainers: map[types.UID]*StackContainer{
-					"v1": testStack("foo-v1").traffic(70, 30).deployment(tc.deploymentUpdated, tc.deploymentReplicas, tc.updatedReplicas, tc.readyReplicas).stack(),
+					"v1": testStack("foo-v1").traffic(70, 30).deployment(tc.resourcesUpdated, tc.deploymentReplicas, tc.updatedReplicas, tc.readyReplicas).stack(),
 					"v2": testStack("foo-v2").traffic(30, 70).ready(3).stack(),
 				},
 				TrafficReconciler: SimpleTrafficReconciler{},

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -269,7 +269,7 @@ func (sc *StackContainer) updateFromResources() {
 		sc.desiredReplicas = hpa.Status.DesiredReplicas
 	}
 	if sc.IsAutoscaled() {
-		hpaUpdated = sc.Resources.HPA != nil && IsResourceUpToDate(sc.Stack, sc.Resources.HPA.ObjectMeta) && sc.Resources.HPA.Status.ObservedGeneration != nil && *sc.Resources.HPA.Status.ObservedGeneration == sc.Resources.HPA.Generation
+		hpaUpdated = sc.Resources.HPA != nil && IsResourceUpToDate(sc.Stack, sc.Resources.HPA.ObjectMeta)
 	} else {
 		hpaUpdated = sc.Resources.HPA == nil
 	}


### PR DESCRIPTION
Instead of just aborting on the first encountered error, try to proceed and reconcile the remaining resources. The only thing that currently causes a hard error is `UpdateFromResources()`, the rest should be logged, reported as an event and ignored.

`StackContainer` logic has been adjusted to check other stack resources in `IsReady()` as well to prevent a situation where traffic is directed to a stack that can't be reconciled.