### PR TITLE
Don't set replicas to nil when updating a deployment

### DIFF
--- a/cmd/e2e/prescaling_test.go
+++ b/cmd/e2e/prescaling_test.go
@@ -11,7 +11,7 @@ import (
 func TestPrescalingWithoutHPA(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-prescale-no-hpa"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 0).Replicas(3)
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).Replicas(3)
 
 	// create stack with 3 replicas
 	firstStack := "v1"
@@ -81,7 +81,7 @@ func TestPrescalingWithoutHPA(t *testing.T) {
 func TestPrescalingWithHPA(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-prescale-hpa"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 0).
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).
 		HPA(1, 10).Replicas(3)
 
 	// create first stack with 3 replicas
@@ -153,7 +153,7 @@ func TestPrescalingPreventDelete(t *testing.T) {
 	stackPrescalingTimeout := 5
 	t.Parallel()
 	stacksetName := "stackset-prevent-delete"
-	factory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 0).Ingress().Replicas(3)
+	factory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress().Replicas(3)
 
 	// create stackset with first version
 	firstVersion := "v1"
@@ -234,7 +234,7 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 
 	t.Parallel()
 	stacksetName := "stackset-prescale-backends-wait"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 0).Replicas(3)
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).Replicas(3)
 
 	// create stack with 3 replicas
 	firstStack := "v1"

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -11,7 +11,7 @@ import (
 func TestStackTTLWithoutIngress(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-noingress"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 0)
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 15)
 
 	// Create 5 stacks in total and wait for their deployments to come up
 	for i := 0; i < 5; i++ {
@@ -47,7 +47,7 @@ func TestStackTTLWithoutIngress(t *testing.T) {
 func TestStackTTLWithIngress(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-ingress"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 0).Ingress()
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 15).Ingress()
 
 	// Create 6 stacks each with an ingress
 	for i := 0; i < 6; i++ {
@@ -95,7 +95,7 @@ func TestStackTTLWithIngress(t *testing.T) {
 func TestStackTTLForLatestStack(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-last-stack"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 0).Ingress()
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress()
 
 	// Create 2 stacks in total and wait for their deployments to come up
 	for i := 0; i < 2; i++ {

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -45,7 +45,7 @@ func (c *StackSetController) ReconcileStackDeployment(stack *zv1.Stack, existing
 	}
 
 	// Check if we need to update the deployment
-	if core.IsResourceUpToDate(stack, existing.ObjectMeta) && deployment.Spec.Replicas == nil {
+	if core.IsResourceUpToDate(stack, existing.ObjectMeta) && pint32Equal(existing.Spec.Replicas, deployment.Spec.Replicas) {
 		return nil
 	}
 

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -146,7 +146,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			},
 		},
 		{
-			name:  "deployment is not updated if the stack version remains the same and replica count is unset",
+			name:  "deployment is not updated if the stack version remains the same and replica count is unchanged",
 			stack: baseTestStack,
 			existing: &apps.Deployment{
 				ObjectMeta: baseTestStackOwned,
@@ -158,7 +158,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			updated: &apps.Deployment{
 				ObjectMeta: baseTestStackOwned,
 				Spec: apps.DeploymentSpec{
-					Replicas: nil,
+					Replicas: &exampleReplicas,
 					Template: updatedPodTemplateSpec,
 				},
 			},
@@ -186,7 +186,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			updated: &apps.Deployment{
 				ObjectMeta: updatedTestStackOwned,
 				Spec: apps.DeploymentSpec{
-					Replicas: &exampleReplicas,
+					Replicas: &updatedReplicas,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"updated": "selector"},
 					},
@@ -196,7 +196,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			expected: &apps.Deployment{
 				ObjectMeta: updatedTestStackOwned,
 				Spec: apps.DeploymentSpec{
-					Replicas: &exampleReplicas,
+					Replicas: &updatedReplicas,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"foo": "bar"},
 					},

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -157,6 +157,10 @@ func (sc *StackContainer) GenerateDeployment() *appsv1.Deployment {
 		}
 	}
 
+	if updatedReplicas == nil {
+		updatedReplicas = wrapReplicas(sc.deploymentReplicas)
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: sc.resourceMeta(),
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -388,71 +388,71 @@ func TestStackGenerateDeployment(t *testing.T) {
 		prescalingReplicas int32
 		deploymentReplicas int32
 		noTrafficSince     time.Time
-		expectedReplicas   *int32
+		expectedReplicas   int32
 	}{
 		{
 			name:               "stack scaled down to zero, deployment still running",
 			stackReplicas:      0,
 			deploymentReplicas: 3,
-			expectedReplicas:   wrapReplicas(0),
+			expectedReplicas:   0,
 		},
 		{
 			name:               "stack scaled down to zero, deployment already scaled down",
 			stackReplicas:      0,
 			deploymentReplicas: 0,
-			expectedReplicas:   nil,
+			expectedReplicas:   0,
 		},
 		{
 			name:               "stack scaled down because it doesn't have traffic, deployment still running",
 			stackReplicas:      3,
 			deploymentReplicas: 3,
 			noTrafficSince:     time.Now().Add(-time.Hour),
-			expectedReplicas:   wrapReplicas(0),
+			expectedReplicas:   0,
 		},
 		{
 			name:               "stack scaled down because it doesn't have traffic, deployment already scaled down",
 			stackReplicas:      3,
 			deploymentReplicas: 0,
 			noTrafficSince:     time.Now().Add(-time.Hour),
-			expectedReplicas:   nil,
+			expectedReplicas:   0,
 		},
 		{
 			name:               "stack scaled down to zero, deployment already scaled down",
 			stackReplicas:      0,
 			deploymentReplicas: 0,
-			expectedReplicas:   nil,
+			expectedReplicas:   0,
 		},
 		{
 			name:               "stack running, deployment has zero replicas",
 			stackReplicas:      3,
 			deploymentReplicas: 0,
-			expectedReplicas:   wrapReplicas(3),
+			expectedReplicas:   3,
 		},
 		{
 			name:               "stack running, deployment has zero replicas, hpa enabled",
 			hpaEnabled:         true,
 			stackReplicas:      3,
 			deploymentReplicas: 0,
-			expectedReplicas:   wrapReplicas(3),
+			expectedReplicas:   3,
 		},
 		{
 			name:               "stack running, deployment has the same amount replicas",
 			stackReplicas:      3,
 			deploymentReplicas: 3,
-			expectedReplicas:   nil,
+			expectedReplicas:   3,
 		},
 		{
 			name:               "stack running, deployment has a different amount of replicas",
 			stackReplicas:      3,
 			deploymentReplicas: 5,
-			expectedReplicas:   wrapReplicas(3),
+			expectedReplicas:   3,
 		},
 		{
 			name:               "stack running, deployment has a different amount of replicas, hpa enabled",
 			hpaEnabled:         true,
 			stackReplicas:      3,
 			deploymentReplicas: 5,
-			expectedReplicas:   nil,
+			expectedReplicas:   5,
 		},
 		{
 			name:               "stack running, deployment has zero replicas, prescaling enabled",
@@ -460,7 +460,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			prescalingActive:   true,
 			prescalingReplicas: 7,
 			deploymentReplicas: 0,
-			expectedReplicas:   wrapReplicas(7),
+			expectedReplicas:   7,
 		},
 		{
 			name:               "stack running, deployment has zero replicas, hpa enabled, prescaling enabled",
@@ -469,7 +469,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			prescalingReplicas: 7,
 			stackReplicas:      3,
 			deploymentReplicas: 0,
-			expectedReplicas:   wrapReplicas(7),
+			expectedReplicas:   7,
 		},
 		{
 			name:               "stack running, deployment has the same amount replicas, prescaling enabled",
@@ -477,7 +477,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			prescalingActive:   true,
 			prescalingReplicas: 7,
 			deploymentReplicas: 7,
-			expectedReplicas:   nil,
+			expectedReplicas:   7,
 		},
 		{
 			name:               "stack running, deployment has a different amount of replicas, prescaling enabled",
@@ -485,7 +485,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			prescalingActive:   true,
 			prescalingReplicas: 7,
 			deploymentReplicas: 5,
-			expectedReplicas:   wrapReplicas(7),
+			expectedReplicas:   7,
 		},
 		{
 			name:               "stack running, deployment has a different amount of replicas, hpa enabled, prescaling enabled",
@@ -494,7 +494,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			prescalingReplicas: 7,
 			stackReplicas:      3,
 			deploymentReplicas: 5,
-			expectedReplicas:   nil,
+			expectedReplicas:   5,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -533,7 +533,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 			expected := &apps.Deployment{
 				ObjectMeta: testResourceMeta,
 				Spec: apps.DeploymentSpec{
-					Replicas: tc.expectedReplicas,
+					Replicas: wrapReplicas(tc.expectedReplicas),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							StacksetHeritageLabelKey: "foo",

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -68,12 +68,24 @@ type StackContainer struct {
 	stackReplicas int32
 
 	// Fields from the stack resources
-	resourcesUpdated   bool
+
+	// Set to true only if all related resources have been updated according to the latest stack version
+	resourcesUpdated bool
+
+	// Current number of replicas that the deployment is expected to have, from Deployment.spec
 	deploymentReplicas int32
-	createdReplicas    int32
-	readyReplicas      int32
-	updatedReplicas    int32
-	desiredReplicas    int32
+
+	// Current number of replicas that the deployment has, from Deployment.status
+	createdReplicas int32
+
+	// Current number of replicas that the deployment has, from Deployment.status
+	readyReplicas int32
+
+	// Current number of up-to-date replicas that the deployment has, from Deployment.status
+	updatedReplicas int32
+
+	// Current number of replicas that the HPA expects deployment to have, from HPA.status
+	desiredReplicas int32
 
 	// Traffic & scaling
 	currentActualTrafficWeight     float64


### PR DESCRIPTION
Turns out that setting a field to `nil` when doing an `Update()` doesn't mean that the current value should be preserved. Instead, the API server runs the default logic for it, so every time we update a deployment we also reset replicas to `1`. Fix by keeping the current amount of replicas instead.

Supersedes #147.