### PR TITLE
Stack CRD: additionalPrinterColumns: fix JSONPath for "available replicas"

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -28,7 +28,7 @@ spec:
   - name: Available
     type: integer
     description: Number of available replicas
-    JSONPath: .status.updatedReplicas
+    JSONPath: .status.readyReplicas
   - name: Traffic
     type: number
     format: float


### PR DESCRIPTION
It's `.status.readyReplicas`, not `.status.updatedReplicas` (which is already used for _"Number of up-to-date replicas"_).