### PR TITLE
Don't consider scaled down stacks ready

### DIFF
--- a/pkg/core/traffic_test.go
+++ b/pkg/core/traffic_test.go
@@ -76,6 +76,13 @@ func TestTrafficSwitchSimpleNotReady(t *testing.T) {
 			updatedReplicas:    3,
 			readyReplicas:      2,
 		},
+		{
+			name:               "deployment scaled down",
+			resourcesUpdated:   true,
+			deploymentReplicas: 0,
+			updatedReplicas:    0,
+			readyReplicas:      0,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := StackSetContainer{

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -115,7 +115,7 @@ func (sc *StackContainer) HasTraffic() bool {
 
 func (sc *StackContainer) IsReady() bool {
 	// Stacks are considered ready when all subresources have been updated, and we have enough replicas
-	return sc.resourcesUpdated && sc.deploymentReplicas == sc.updatedReplicas && sc.deploymentReplicas == sc.readyReplicas
+	return sc.resourcesUpdated && sc.deploymentReplicas > 0 && sc.deploymentReplicas == sc.updatedReplicas && sc.deploymentReplicas == sc.readyReplicas
 }
 
 func (sc *StackContainer) MaxReplicas() int32 {


### PR DESCRIPTION
Stacks with 0 replicas are treated as ready, so we switch traffic immediately, which is obviously a problem.