### PR TITLE
Improvements for the external CRDs PR

### DIFF
--- a/cmd/e2e/traffic_switch_test.go
+++ b/cmd/e2e/traffic_switch_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// expectActualTrafficWeights waits until that both stackset.status and the ingress have the expected actual traffic weight,
+// and all stacks have their weights populated correctly
+func expectActualTrafficWeights(t *testing.T, stacksetName string, weights map[string]float64) {
+	err := trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, weights, nil).await()
+	require.NoError(t, err)
+	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, weights, nil).await()
+	require.NoError(t, err)
+}
+
+// expectStackTrafficWeights waits until the stack has the correct traffic weight values
+func expectStackTrafficWeights(t *testing.T, stackName string, actualTrafficWeight, desiredTrafficWeight float64) {
+	err := stackStatusMatches(t, stackName, expectedStackStatus{
+		actualTrafficWeight:  pfloat64(actualTrafficWeight),
+		desiredTrafficWeight: pfloat64(desiredTrafficWeight),
+	}).await()
+	require.NoError(t, err)
+}
+
 func TestTrafficSwitchIngress(t *testing.T) {
 	t.Parallel()
 
@@ -31,55 +49,101 @@ func TestTrafficSwitchIngress(t *testing.T) {
 	require.NoError(t, err)
 
 	initialWeights := map[string]float64{firstStack: 100}
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, initialWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, initialWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 100, 100)
+	expectStackTrafficWeights(t, updatedStack, 0, 0)
 
 	// Switch traffic 50/50
 	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
 	err = setDesiredTrafficWeightsIngress(stacksetName, desiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, desiredWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, desiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 50, 50)
+	expectStackTrafficWeights(t, updatedStack, 50, 50)
 
 	// Switch traffic 0/100
 	newDesiredWeights := map[string]float64{updatedStack: 100}
 	err = setDesiredTrafficWeightsIngress(stacksetName, newDesiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, desiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
+	expectStackTrafficWeights(t, firstStack, 0, 0)
+	expectStackTrafficWeights(t, updatedStack, 100, 100)
+}
+
+func TestTrafficSwitchIngressThenStackset(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "switch-traffic-stackset-to-ingress"
+	firstVersion := "v1"
+	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
+	updatedVersion := "v2"
+	updatedStack := fmt.Sprintf("%s-%s", stacksetName, updatedVersion)
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
+	spec := factory.Create(firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
 	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
+	_, err = waitForStack(t, stacksetName, firstVersion)
 	require.NoError(t, err)
+	spec = factory.Create(updatedVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, updatedVersion)
+	require.NoError(t, err)
+
+	_, err = waitForIngress(t, stacksetName)
+	require.NoError(t, err)
+
+	initialWeights := map[string]float64{firstStack: 100}
+	expectActualTrafficWeights(t, stacksetName, initialWeights)
+	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindDesired, initialWeights, nil).await()
+	require.NoError(t, err)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
+	require.NoError(t, err)
+
+	expectStackTrafficWeights(t, firstStack, 100, 100)
+	expectStackTrafficWeights(t, updatedStack, 0, 0)
+
+	// Switch traffic 50/50 via ingress
+	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
+	err = setDesiredTrafficWeightsIngress(stacksetName, desiredWeights)
+	require.NoError(t, err)
+	expectActualTrafficWeights(t, stacksetName, desiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
+	require.NoError(t, err)
+
+	expectStackTrafficWeights(t, firstStack, 50, 50)
+	expectStackTrafficWeights(t, updatedStack, 50, 50)
+
+	// Switch traffic 75/25 via stackset
+	newDesiredWeights := map[string]float64{firstStack: 75, updatedStack: 25}
+	err = setDesiredTrafficWeightsStackset(stacksetName, newDesiredWeights)
+	require.NoError(t, err)
+	expectActualTrafficWeights(t, stacksetName, newDesiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, false).await()
+	require.NoError(t, err)
+
+	expectStackTrafficWeights(t, firstStack, 75, 75)
+	expectStackTrafficWeights(t, updatedStack, 25, 25)
+
+	// Switch traffic 0/100
+	finalDesiredWeights := map[string]float64{updatedStack: 100}
+	err = setDesiredTrafficWeightsStackset(stacksetName, finalDesiredWeights)
+	require.NoError(t, err)
+	expectActualTrafficWeights(t, stacksetName, finalDesiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, false).await()
+	require.NoError(t, err)
+
+	expectStackTrafficWeights(t, firstStack, 0, 0)
+	expectStackTrafficWeights(t, updatedStack, 100, 100)
 }
 
 func TestTrafficSwitchStackset(t *testing.T) {
@@ -106,205 +170,36 @@ func TestTrafficSwitchStackset(t *testing.T) {
 	require.NoError(t, err)
 
 	initialWeights := map[string]float64{firstStack: 100}
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, initialWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, initialWeights)
+	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindDesired, initialWeights, nil).await()
+	require.NoError(t, err)
+	err = ingressTrafficAuthoritative(t, stacksetName, true).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 100, 100)
+	expectStackTrafficWeights(t, updatedStack, 0, 0)
 
 	// Switch traffic 50/50
 	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
 	err = setDesiredTrafficWeightsStackset(stacksetName, desiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, desiredWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, desiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, false).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 50, 50)
+	expectStackTrafficWeights(t, updatedStack, 50, 50)
 
 	// Switch traffic 0/100
 	newDesiredWeights := map[string]float64{updatedStack: 100}
 	err = setDesiredTrafficWeightsStackset(stacksetName, newDesiredWeights)
 	require.NoError(t, err)
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
+	expectActualTrafficWeights(t, stacksetName, newDesiredWeights)
+	err = ingressTrafficAuthoritative(t, stacksetName, false).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-}
-
-func TestTrafficSwitchDesiredStacksetActualIngress(t *testing.T) {
-	t.Parallel()
-
-	stacksetName := "switch-traffic-des-stackset-act-ing"
-	firstVersion := "v1"
-	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
-	updatedVersion := "v2"
-	updatedStack := fmt.Sprintf("%s-%s", stacksetName, updatedVersion)
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
-	spec := factory.Create(firstVersion)
-	err := createStackSet(stacksetName, 0, spec)
-	require.NoError(t, err)
-	_, err = waitForStack(t, stacksetName, firstVersion)
-	require.NoError(t, err)
-	spec = factory.Create(updatedVersion)
-	err = updateStackset(stacksetName, spec)
-	require.NoError(t, err)
-	_, err = waitForStack(t, stacksetName, updatedVersion)
-	require.NoError(t, err)
-
-	_, err = waitForIngress(t, stacksetName)
-	require.NoError(t, err)
-
-	initialWeights := map[string]float64{firstStack: 100}
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, initialWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-
-	// Switch traffic 50/50
-	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
-	err = setDesiredTrafficWeightsStackset(stacksetName, desiredWeights)
-	require.NoError(t, err)
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, desiredWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-
-	// Switch traffic 0/100
-	newDesiredWeights := map[string]float64{updatedStack: 100}
-	err = setDesiredTrafficWeightsStackset(stacksetName, newDesiredWeights)
-	require.NoError(t, err)
-	err = trafficWeightsUpdatedIngress(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-}
-
-func TestTrafficSwitchDesiredIngressActualStackset(t *testing.T) {
-	t.Parallel()
-
-	stacksetName := "switch-traffic-des-ing-act-stackset"
-	firstVersion := "v1"
-	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
-	updatedVersion := "v2"
-	updatedStack := fmt.Sprintf("%s-%s", stacksetName, updatedVersion)
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
-	spec := factory.Create(firstVersion)
-	err := createStackSet(stacksetName, 0, spec)
-	require.NoError(t, err)
-	_, err = waitForStack(t, stacksetName, firstVersion)
-	require.NoError(t, err)
-	spec = factory.Create(updatedVersion)
-	err = updateStackset(stacksetName, spec)
-	require.NoError(t, err)
-	_, err = waitForStack(t, stacksetName, updatedVersion)
-	require.NoError(t, err)
-
-	_, err = waitForIngress(t, stacksetName)
-	require.NoError(t, err)
-
-	initialWeights := map[string]float64{firstStack: 100}
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, initialWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-
-	// Switch traffic 50/50
-	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
-	err = setDesiredTrafficWeightsIngress(stacksetName, desiredWeights)
-	require.NoError(t, err)
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, desiredWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-
-	// Switch traffic 0/100
-	newDesiredWeights := map[string]float64{updatedStack: 100}
-	err = setDesiredTrafficWeightsIngress(stacksetName, newDesiredWeights)
-	require.NoError(t, err)
-	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
-	require.NoError(t, err)
-
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 0, 0)
+	expectStackTrafficWeights(t, updatedStack, 100, 100)
 }
 
 func TestTrafficSwitchStacksetExternalIngress(t *testing.T) {
@@ -331,16 +226,8 @@ func TestTrafficSwitchStacksetExternalIngress(t *testing.T) {
 	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, initialWeights, nil).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 100, 100)
+	expectStackTrafficWeights(t, updatedStack, 0, 0)
 
 	// Switch traffic 50/50
 	desiredWeights := map[string]float64{firstStack: 50, updatedStack: 50}
@@ -349,16 +236,8 @@ func TestTrafficSwitchStacksetExternalIngress(t *testing.T) {
 	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, desiredWeights, nil).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(50),
-		desiredTrafficWeight: pfloat64(50),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 50, 50)
+	expectStackTrafficWeights(t, updatedStack, 50, 50)
 
 	// Switch traffic 0/100
 	newDesiredWeights := map[string]float64{updatedStack: 100}
@@ -367,14 +246,6 @@ func TestTrafficSwitchStacksetExternalIngress(t *testing.T) {
 	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, newDesiredWeights, nil).await()
 	require.NoError(t, err)
 
-	err = stackStatusMatches(t, firstStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(0),
-		desiredTrafficWeight: pfloat64(0),
-	}).await()
-	require.NoError(t, err)
-	err = stackStatusMatches(t, updatedStack, expectedStackStatus{
-		actualTrafficWeight:  pfloat64(100),
-		desiredTrafficWeight: pfloat64(100),
-	}).await()
-	require.NoError(t, err)
+	expectStackTrafficWeights(t, firstStack, 0, 0)
+	expectStackTrafficWeights(t, updatedStack, 100, 100)
 }

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
+	"strconv"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,8 @@ import (
 const (
 	StacksetHeritageLabelKey = "stackset"
 	StackVersionLabelKey     = "stack-version"
+
+	ingressTrafficAuthoritativeAnnotation = "zalando.org/traffic-authoritative"
 )
 
 var (
@@ -141,12 +144,16 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 		stackset.Labels,
 	)
 
+	trafficAuthoritative := map[string]string{
+		ingressTrafficAuthoritativeAnnotation: strconv.FormatBool(!ssc.stacksetManagesTraffic),
+	}
+
 	result := &extensions.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        stackset.Name,
 			Namespace:   stackset.Namespace,
 			Labels:      labels,
-			Annotations: mergeLabels(stackset.Spec.Ingress.Annotations),
+			Annotations: mergeLabels(stackset.Spec.Ingress.Annotations, trafficAuthoritative),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: stackset.APIVersion,
@@ -216,7 +223,11 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 	}
 
 	result.Annotations[backendWeightsAnnotationKey] = string(actualWeightsData)
-	result.Annotations[stackTrafficWeightsAnnotationKey] = string(desiredWeightData)
+	if ssc.stacksetManagesTraffic {
+		delete(result.Annotations, stackTrafficWeightsAnnotationKey)
+	} else {
+		result.Annotations[stackTrafficWeightsAnnotationKey] = string(desiredWeightData)
+	}
 
 	return result, nil
 }

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -266,3 +266,25 @@ func (ssc *StackSetContainer) GenerateStackSetStatus() *zv1.StackSetStatus {
 	result.Traffic = traffic
 	return result
 }
+
+func (ssc *StackSetContainer) GenerateStackSetTraffic() []*zv1.DesiredTraffic {
+	if !ssc.stacksetManagesTraffic {
+		return nil
+	}
+
+	if ssc.Ingress == nil && ssc.ExternalIngressBackendPort == nil {
+		return nil
+	}
+
+	var traffic []*zv1.DesiredTraffic
+	for _, sc := range ssc.StackContainers {
+		if sc.HasBackendPort() {
+			t := &zv1.DesiredTraffic{
+				StackName: sc.Name(),
+				Weight:    sc.desiredTrafficWeight,
+			}
+			traffic = append(traffic, t)
+		}
+	}
+	return traffic
+}

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -621,29 +621,29 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 		{
 			name: "desired and actual weights are parsed correctly",
 			desiredTraffic: []*zv1.DesiredTraffic{
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v1",
 					Weight:    float64(25),
 				},
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v2",
 					Weight:    float64(50),
 				},
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v3",
 					Weight:    float64(25),
 				},
 			},
 			actualTraffic: []*zv1.ActualTraffic{
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v1",
 					Weight:      float64(62.5),
 				},
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v2",
 					Weight:      float64(12.5),
 				},
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v3",
 					Weight:      float64(25),
 				},
@@ -654,29 +654,29 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 		{
 			name: "unknown stacks are removed, remaining weights are renormalised",
 			desiredTraffic: []*zv1.DesiredTraffic{
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v4",
 					Weight:    float64(50),
 				},
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v2",
 					Weight:    float64(25),
 				},
-				&zv1.DesiredTraffic{
+				{
 					StackName: "foo-v3",
 					Weight:    float64(25),
 				},
 			},
 			actualTraffic: []*zv1.ActualTraffic{
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v4",
 					Weight:      float64(50),
 				},
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v2",
 					Weight:      float64(12.5),
 				},
-				&zv1.ActualTraffic{
+				{
 					ServiceName: "foo-v3",
 					Weight:      float64(37.5),
 				},
@@ -724,6 +724,7 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 
 			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
+			require.True(t, ssc.stacksetManagesTraffic)
 			require.NotEmpty(t, ssc.StackSet.Status.Traffic, "stackset requires non empty traffic status")
 
 			for _, sc := range ssc.StackContainers {
@@ -797,6 +798,7 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 
 			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
+			require.False(t, ssc.stacksetManagesTraffic)
 
 			for _, sc := range ssc.StackContainers {
 				require.Equal(t, tc.expectedDesiredWeights[sc.Name()], sc.desiredTrafficWeight, "stack %s", sc.Stack.Name)


### PR DESCRIPTION
 * Add ssc.stacksetManagesTraffic, populate it correctly
 * core: don't touch ssc.Spec
 * core: remove unnecessary code
 * Don't write desired traffic to ingresses of stacksets that have been migrated to the new configuration, this will conflict with the admission controller changes
 * e2e: test the authoritative annotation
 * e2e: always test both stackset and ingress (for the actual traffic)
 * e2e: add some helper functions to simplify the code
 * e2e: drop two tests already covered by the existing tests
 * Desired traffic: write back to the stackset if it changes