### PR TITLE
Enable scale command to be used for stacks

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -49,6 +49,7 @@ spec:
     scale:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.labelSelector
   # validation depends on Kubernetes >= v1.11.0
   validation:
     openAPIV3Schema:

--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -45,6 +45,10 @@ spec:
   subresources:
     # status enables the status subresource.
     status: {}
+    # scale enables the scale subresource.
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
   # validation depends on Kubernetes >= v1.11.0
   validation:
     openAPIV3Schema:

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -286,6 +286,9 @@ type StackStatus struct {
 	// NoTrafficSince is the timestamp defining the last time the stack was
 	// observed getting traffic.
 	NoTrafficSince *metav1.Time `json:"noTrafficSince,omitempty"`
+	// LabelSelector is the label selector used to find all pods managed by
+	// a stack.
+	LabelSelector string `json:"labelSelector,omitempty"`
 }
 
 // Prescaling hold prescaling information

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -600,6 +600,11 @@ func TestGenerateStackStatus(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &StackContainer{
+				Stack: &zv1.Stack{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{},
+					},
+				},
 				actualTrafficWeight:            tc.actualTrafficWeight,
 				desiredTrafficWeight:           tc.desiredTrafficWeight,
 				createdReplicas:                3,


### PR DESCRIPTION
This allows scaling stacks via:

```
kubectl scale stack <stackName> --replicas=n
```

This would not work for HPA enabled stacks so only useful if you don't have an HPA.

There is mentioned support for HPA in the docs: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource via the `LabelSelectorPath` value. But I don't understand yet how this works.