### PR TITLE
Stackset schema: validate stackTemplate.metadata

### DIFF
--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -96,6 +96,16 @@ spec:
                   minimum: 1
             stackTemplate:
               properties:
+                metadata:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                 spec:
                   properties:
                     version:


### PR DESCRIPTION
Using wrong values here will render the controller inoperable, so we must validate it.