### PR TITLE
Add Update Strategy to the Stack

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -230,6 +231,9 @@ type StackSpec struct {
 	PodTemplate v1.PodTemplateSpec `json:"podTemplate"`
 
 	Autoscaler *Autoscaler `json:"autoscaler,omitempty"`
+
+	// Strategy describe the rollout strategy for the underlying deployment
+	Strategy *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
 // StackServiceSpec makes it possible to customize the service generated for

--- a/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -452,6 +453,11 @@ func (in *StackSpec) DeepCopyInto(out *StackSpec) {
 	if in.Autoscaler != nil {
 		in, out := &in.Autoscaler, &out.Autoscaler
 		*out = new(Autoscaler)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(appsv1.DeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -166,7 +166,12 @@ func (sc *StackContainer) GenerateDeployment() *appsv1.Deployment {
 		updatedReplicas = wrapReplicas(sc.deploymentReplicas)
 	}
 
-	return &appsv1.Deployment{
+	var strategy *appsv1.DeploymentStrategy
+	if stack.Spec.Strategy != nil {
+		strategy = stack.Spec.Strategy.DeepCopy()
+	}
+
+	deployment := &appsv1.Deployment{
 		ObjectMeta: sc.resourceMeta(),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: updatedReplicas,
@@ -176,6 +181,10 @@ func (sc *StackContainer) GenerateDeployment() *appsv1.Deployment {
 			Template: *templateInjectLabels(stack.Spec.PodTemplate.DeepCopy(), stack.Labels),
 		},
 	}
+	if strategy != nil {
+		deployment.Spec.Strategy = *strategy
+	}
+	return deployment
 }
 
 func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, error) {

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -92,6 +92,7 @@ func (ssc *StackSetContainer) NewStack() (*StackContainer, string) {
 					Service:                 service,
 					PodTemplate:             stackset.Spec.StackTemplate.Spec.PodTemplate,
 					Autoscaler:              stackset.Spec.StackTemplate.Spec.Autoscaler,
+					Strategy:                stackset.Spec.StackTemplate.Spec.Strategy,
 				},
 			},
 		}, stackVersion


### PR DESCRIPTION
This PR adds `UpdateStrategy` to the `StackSpec` which means an update strategy can be specified as part of the stack template which will be propagated to the deployment.