### PR TITLE
More fixes for CRDs

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -71,6 +71,7 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  type: object
                 maxReplicas:
                   format: int32
                   type: integer
@@ -94,21 +95,24 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                  type: object
                                 type: array
                               matchLabels:
                                 additionalProperties:
                                   type: string
                                 type: object
+                            type: object
                           targetAverageValue:
-                            # quantity type is string or int
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
                           targetValue:
-                            # quantity type is string or int
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
                       object:
                         properties:
                           metricName:
@@ -121,20 +125,23 @@ spec:
                                 type: string
                               name:
                                 type: string
+                            type: object
                           targetValue:
-                            # quantity type is string or int
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
                       pods:
                         properties:
                           metricName:
                             type: string
                           targetAverageValue:
-                            # quantity type is string or int
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
                       resource:
                         properties:
                           name:
@@ -143,18 +150,19 @@ spec:
                             format: int32
                             type: integer
                           targetAverageValue:
-                            # quantity type is string or int
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
                       type:
                         type: string
+                    type: object
                   type: array
                 minReplicas:
                   format: int32
                   type: integer
-
-
+              type: object
             autoscaler:
               properties:
                 minReplicas:
@@ -187,10 +195,12 @@ spec:
                         - port
                         - path
                         - key
+                        type: object
                       average:
                         anyOf:
                         - type: integer
                         - type: string
+                        x-kubernetes-int-or-string: true
                       queue:
                         properties:
                           name:
@@ -200,9 +210,12 @@ spec:
                         required:
                         - name
                         - region
+                        type: object
                       averageUtilization:
                         type: integer
                         format: int32
+                    type: object
+              type: object
             service:
               properties:
                 metadata:
@@ -215,6 +228,7 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  type: object
                 ports:
                   type: array
                   items:
@@ -230,10 +244,12 @@ spec:
                       protocol:
                         type: string
                       targetPort:
-                        # TODO: int-or-string
                         anyOf:
-                        - type: string
                         - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+              type: object
             strategy:
               properties:
                 rollingUpdate:
@@ -264,6 +280,7 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  type: object
                 spec:
                   properties:
                     activeDeadlineSeconds:
@@ -289,6 +306,7 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
                                       matchFields:
                                         items:
@@ -301,10 +319,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
+                                    type: object
                                   weight:
                                     format: int32
                                     type: integer
+                                type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
                               properties:
@@ -322,6 +343,7 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
                                       matchFields:
                                         items:
@@ -334,8 +356,12 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
+                                    type: object
                                   type: array
+                              type: object
+                          type: object
                         podAffinity:
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
@@ -356,20 +382,24 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                              type: object
                                             type: array
                                           matchLabels:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                        type: object
                                       namespaces:
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
                                         type: string
+                                    type: object
                                   weight:
                                     format: int32
                                     type: integer
+                                type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
                               items:
@@ -387,18 +417,22 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
                                       matchLabels:
                                         additionalProperties:
                                           type: string
                                         type: object
+                                    type: object
                                   namespaces:
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
                                     type: string
+                                type: object
                               type: array
+                          type: object
                         podAntiAffinity:
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
@@ -419,20 +453,24 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                              type: object
                                             type: array
                                           matchLabels:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                        type: object
                                       namespaces:
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
                                         type: string
+                                    type: object
                                   weight:
                                     format: int32
                                     type: integer
+                                type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
                               items:
@@ -450,18 +488,23 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
                                       matchLabels:
                                         additionalProperties:
                                           type: string
                                         type: object
+                                    type: object
                                   namespaces:
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
                                     type: string
+                                type: object
                               type: array
+                          type: object
+                      type: object
                     automountServiceAccountToken:
                       type: boolean
                     containers:
@@ -492,12 +535,14 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
                                     fieldRef:
                                       properties:
                                         apiVersion:
                                           type: string
                                         fieldPath:
                                           type: string
+                                      type: object
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -506,6 +551,7 @@ spec:
                                           type: string
                                         resource:
                                           type: string
+                                      type: object
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -514,6 +560,9 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
+                                  type: object
+                              type: object
                             type: array
                           envFrom:
                             items:
@@ -524,6 +573,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
+                                  type: object
                                 prefix:
                                   type: string
                                 secretRef:
@@ -532,6 +582,8 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
+                                  type: object
+                              type: object
                             type: array
                           image:
                             type: string
@@ -547,6 +599,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                    type: object
                                   httpGet:
                                     properties:
                                       host:
@@ -558,25 +611,29 @@ spec:
                                               type: string
                                             value:
                                               type: string
+                                          type: object
                                         type: array
                                       path:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         type: string
+                                    type: object
                                   tcpSocket:
                                     properties:
                                       host:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
                               preStop:
                                 properties:
                                   exec:
@@ -585,6 +642,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                    type: object
                                   httpGet:
                                     properties:
                                       host:
@@ -596,25 +654,30 @@ spec:
                                               type: string
                                             value:
                                               type: string
+                                          type: object
                                         type: array
                                       path:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         type: string
+                                    type: object
                                   tcpSocket:
                                     properties:
                                       host:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
                           livenessProbe:
                             properties:
                               exec:
@@ -623,6 +686,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               failureThreshold:
                                 format: int32
                                 type: integer
@@ -637,16 +701,18 @@ spec:
                                           type: string
                                         value:
                                           type: string
+                                      type: object
                                     type: array
                                   path:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     type: string
+                                type: object
                               initialDelaySeconds:
                                 format: int32
                                 type: integer
@@ -661,13 +727,15 @@ spec:
                                   host:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               timeoutSeconds:
                                 format: int32
                                 type: integer
+                            type: object
                           name:
                             type: string
                           ports:
@@ -685,6 +753,7 @@ spec:
                                   type: string
                                 protocol:
                                   type: string
+                              type: object
                             type: array
                           readinessProbe:
                             properties:
@@ -694,6 +763,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               failureThreshold:
                                 format: int32
                                 type: integer
@@ -708,16 +778,18 @@ spec:
                                           type: string
                                         value:
                                           type: string
+                                      type: object
                                     type: array
                                   path:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     type: string
+                                type: object
                               initialDelaySeconds:
                                 format: int32
                                 type: integer
@@ -732,29 +804,32 @@ spec:
                                   host:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               timeoutSeconds:
                                 format: int32
                                 type: integer
+                            type: object
                           resources:
                             properties:
                               limits:
                                 additionalProperties:
-                                  # quantity type is string or int
                                   anyOf:
-                                  - type: string
                                   - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
                                 type: object
                               requests:
                                 additionalProperties:
-                                  # quantity type is string or int
                                   anyOf:
-                                  - type: string
                                   - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
                                 type: object
+                            type: object
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -769,6 +844,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               privileged:
                                 type: boolean
                               readOnlyRootFilesystem:
@@ -791,6 +867,8 @@ spec:
                                     type: string
                                   user:
                                     type: string
+                                type: object
+                            type: object
                           stdin:
                             type: boolean
                           stdinOnce:
@@ -808,6 +886,7 @@ spec:
                                   type: string
                                 name:
                                   type: string
+                              type: object
                             type: array
                           volumeMounts:
                             items:
@@ -822,9 +901,11 @@ spec:
                                   type: boolean
                                 subPath:
                                   type: string
+                              type: object
                             type: array
                           workingDir:
                             type: string
+                        type: object
                       type: array
                     dnsConfig:
                       properties:
@@ -839,11 +920,13 @@ spec:
                                 type: string
                               value:
                                 type: string
+                            type: object
                           type: array
                         searches:
                           items:
                             type: string
                           type: array
+                      type: object
                     dnsPolicy:
                       type: string
                     hostAliases:
@@ -855,6 +938,7 @@ spec:
                             type: array
                           ip:
                             type: string
+                        type: object
                       type: array
                     hostIPC:
                       type: boolean
@@ -869,6 +953,7 @@ spec:
                         properties:
                           name:
                             type: string
+                        type: object
                       type: array
                     initContainers:
                       items:
@@ -898,12 +983,14 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
                                     fieldRef:
                                       properties:
                                         apiVersion:
                                           type: string
                                         fieldPath:
                                           type: string
+                                      type: object
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -912,6 +999,7 @@ spec:
                                           type: string
                                         resource:
                                           type: string
+                                      type: object
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -920,6 +1008,9 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
+                                  type: object
+                              type: object
                             type: array
                           envFrom:
                             items:
@@ -930,6 +1021,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
+                                  type: object
                                 prefix:
                                   type: string
                                 secretRef:
@@ -938,6 +1030,8 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
+                                  type: object
+                              type: object
                             type: array
                           image:
                             type: string
@@ -953,6 +1047,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                    type: object
                                   httpGet:
                                     properties:
                                       host:
@@ -964,25 +1059,29 @@ spec:
                                               type: string
                                             value:
                                               type: string
+                                          type: object
                                         type: array
                                       path:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         type: string
+                                    type: object
                                   tcpSocket:
                                     properties:
                                       host:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
                               preStop:
                                 properties:
                                   exec:
@@ -991,6 +1090,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                    type: object
                                   httpGet:
                                     properties:
                                       host:
@@ -1002,25 +1102,30 @@ spec:
                                               type: string
                                             value:
                                               type: string
+                                          type: object
                                         type: array
                                       path:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         type: string
+                                    type: object
                                   tcpSocket:
                                     properties:
                                       host:
                                         type: string
                                       port:
-                                        # TODO: int-or-string
                                         anyOf:
-                                        - type: string
                                         - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
                           livenessProbe:
                             properties:
                               exec:
@@ -1029,6 +1134,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               failureThreshold:
                                 format: int32
                                 type: integer
@@ -1043,16 +1149,18 @@ spec:
                                           type: string
                                         value:
                                           type: string
+                                      type: object
                                     type: array
                                   path:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     type: string
+                                type: object
                               initialDelaySeconds:
                                 format: int32
                                 type: integer
@@ -1067,13 +1175,15 @@ spec:
                                   host:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               timeoutSeconds:
                                 format: int32
                                 type: integer
+                            type: object
                           name:
                             type: string
                           ports:
@@ -1091,6 +1201,7 @@ spec:
                                   type: string
                                 protocol:
                                   type: string
+                              type: object
                             type: array
                           readinessProbe:
                             properties:
@@ -1100,6 +1211,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               failureThreshold:
                                 format: int32
                                 type: integer
@@ -1114,16 +1226,18 @@ spec:
                                           type: string
                                         value:
                                           type: string
+                                      type: object
                                     type: array
                                   path:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     type: string
+                                type: object
                               initialDelaySeconds:
                                 format: int32
                                 type: integer
@@ -1138,29 +1252,32 @@ spec:
                                   host:
                                     type: string
                                   port:
-                                    # TODO: int-or-string
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               timeoutSeconds:
                                 format: int32
                                 type: integer
+                            type: object
                           resources:
                             properties:
                               limits:
                                 additionalProperties:
-                                  # quantity type is string or int
                                   anyOf:
-                                  - type: string
                                   - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
                                 type: object
                               requests:
                                 additionalProperties:
-                                  # quantity type is string or int
                                   anyOf:
-                                  - type: string
                                   - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
                                 type: object
+                            type: object
                           securityContext:
                             properties:
                               allowPrivilegeEscalation:
@@ -1175,6 +1292,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                type: object
                               privileged:
                                 type: boolean
                               readOnlyRootFilesystem:
@@ -1197,6 +1315,8 @@ spec:
                                     type: string
                                   user:
                                     type: string
+                                type: object
+                            type: object
                           stdin:
                             type: boolean
                           stdinOnce:
@@ -1214,6 +1334,7 @@ spec:
                                   type: string
                                 name:
                                   type: string
+                              type: object
                             type: array
                           volumeMounts:
                             items:
@@ -1228,9 +1349,11 @@ spec:
                                   type: boolean
                                 subPath:
                                   type: string
+                              type: object
                             type: array
                           workingDir:
                             type: string
+                        type: object
                       type: array
                     nodeName:
                       type: string
@@ -1248,6 +1371,7 @@ spec:
                         properties:
                           conditionType:
                             type: string
+                        type: object
                       type: array
                     restartPolicy:
                       type: string
@@ -1276,6 +1400,7 @@ spec:
                               type: string
                             user:
                               type: string
+                          type: object
                         supplementalGroups:
                           items:
                             format: int64
@@ -1288,7 +1413,9 @@ spec:
                                 type: string
                               value:
                                 type: string
+                            type: object
                           type: array
+                      type: object
                     serviceAccount:
                       type: string
                     serviceAccountName:
@@ -1314,6 +1441,7 @@ spec:
                             type: integer
                           value:
                             type: string
+                        type: object
                       type: array
                     volumes:
                       items:
@@ -1329,6 +1457,7 @@ spec:
                                 type: boolean
                               volumeID:
                                 type: string
+                            type: object
                           azureDisk:
                             properties:
                               cachingMode:
@@ -1343,6 +1472,7 @@ spec:
                                 type: string
                               readOnly:
                                 type: boolean
+                            type: object
                           azureFile:
                             properties:
                               readOnly:
@@ -1351,6 +1481,7 @@ spec:
                                 type: string
                               shareName:
                                 type: string
+                            type: object
                           cephfs:
                             properties:
                               monitors:
@@ -1367,8 +1498,10 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               user:
                                 type: string
+                            type: object
                           cinder:
                             properties:
                               fsType:
@@ -1379,8 +1512,10 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               volumeID:
                                 type: string
+                            type: object
                           configMap:
                             properties:
                               defaultMode:
@@ -1396,11 +1531,13 @@ spec:
                                       type: integer
                                     path:
                                       type: string
+                                  type: object
                                 type: array
                               name:
                                 type: string
                               optional:
                                 type: boolean
+                            type: object
                           downwardAPI:
                             properties:
                               defaultMode:
@@ -1415,6 +1552,7 @@ spec:
                                           type: string
                                         fieldPath:
                                           type: string
+                                      type: object
                                     mode:
                                       format: int32
                                       type: integer
@@ -1428,13 +1566,17 @@ spec:
                                           type: string
                                         resource:
                                           type: string
+                                      type: object
+                                  type: object
                                 type: array
+                            type: object
                           emptyDir:
                             properties:
                               medium:
                                 type: string
                               sizeLimit:
                                 type: string
+                            type: object
                           fc:
                             properties:
                               fsType:
@@ -1452,6 +1594,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
                           flexVolume:
                             properties:
                               driver:
@@ -1468,12 +1611,15 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
+                            type: object
                           flocker:
                             properties:
                               datasetName:
                                 type: string
                               datasetUUID:
                                 type: string
+                            type: object
                           gcePersistentDisk:
                             properties:
                               fsType:
@@ -1485,6 +1631,7 @@ spec:
                                 type: string
                               readOnly:
                                 type: boolean
+                            type: object
                           gitRepo:
                             properties:
                               directory:
@@ -1493,6 +1640,7 @@ spec:
                                 type: string
                               revision:
                                 type: string
+                            type: object
                           glusterfs:
                             properties:
                               endpoints:
@@ -1501,12 +1649,14 @@ spec:
                                 type: string
                               readOnly:
                                 type: boolean
+                            type: object
                           hostPath:
                             properties:
                               path:
                                 type: string
                               type:
                                 type: string
+                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -1534,8 +1684,10 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               targetPortal:
                                 type: string
+                            type: object
                           name:
                             type: string
                           nfs:
@@ -1546,18 +1698,21 @@ spec:
                                 type: boolean
                               server:
                                 type: string
+                            type: object
                           persistentVolumeClaim:
                             properties:
                               claimName:
                                 type: string
                               readOnly:
                                 type: boolean
+                            type: object
                           photonPersistentDisk:
                             properties:
                               fsType:
                                 type: string
                               pdID:
                                 type: string
+                            type: object
                           portworxVolume:
                             properties:
                               fsType:
@@ -1566,6 +1721,7 @@ spec:
                                 type: boolean
                               volumeID:
                                 type: string
+                            type: object
                           projected:
                             properties:
                               defaultMode:
@@ -1586,11 +1742,13 @@ spec:
                                                 type: integer
                                               path:
                                                 type: string
+                                            type: object
                                           type: array
                                         name:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
                                     downwardAPI:
                                       properties:
                                         items:
@@ -1602,6 +1760,7 @@ spec:
                                                     type: string
                                                   fieldPath:
                                                     type: string
+                                                type: object
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -1615,7 +1774,10 @@ spec:
                                                     type: string
                                                   resource:
                                                     type: string
+                                                type: object
+                                            type: object
                                           type: array
+                                      type: object
                                     secret:
                                       properties:
                                         items:
@@ -1628,11 +1790,13 @@ spec:
                                                 type: integer
                                               path:
                                                 type: string
+                                            type: object
                                           type: array
                                         name:
                                           type: string
                                         optional:
                                           type: boolean
+                                      type: object
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -1642,7 +1806,10 @@ spec:
                                           type: integer
                                         path:
                                           type: string
+                                      type: object
+                                  type: object
                                 type: array
+                            type: object
                           quobyte:
                             properties:
                               group:
@@ -1655,6 +1822,7 @@ spec:
                                 type: string
                               volume:
                                 type: string
+                            type: object
                           rbd:
                             properties:
                               fsType:
@@ -1675,8 +1843,10 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               user:
                                 type: string
+                            type: object
                           scaleIO:
                             properties:
                               fsType:
@@ -1691,6 +1861,7 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -1701,6 +1872,7 @@ spec:
                                 type: string
                               volumeName:
                                 type: string
+                            type: object
                           secret:
                             properties:
                               defaultMode:
@@ -1716,11 +1888,13 @@ spec:
                                       type: integer
                                     path:
                                       type: string
+                                  type: object
                                 type: array
                               optional:
                                 type: boolean
                               secretName:
                                 type: string
+                            type: object
                           storageos:
                             properties:
                               fsType:
@@ -1731,10 +1905,12 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               volumeName:
                                 type: string
                               volumeNamespace:
                                 type: string
+                            type: object
                           vsphereVolume:
                             properties:
                               fsType:
@@ -1745,4 +1921,10 @@ spec:
                                 type: string
                               volumePath:
                                 type: string
+                            type: object
+                        type: object
                       type: array
+                  type: object
+              type: object
+          type: object
+      type: object

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -50,28 +50,32 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  type: object
                 hosts:
                   type: array
                   items:
                     type: string
                 backendPort:
-                  # TODO: int-or-string
                   anyOf:
-                  - type: string
                   - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
                 path:
                   type: string
               required:
               - backendPort
               - hosts
+              type: object
             externalIngress:
               properties:
                 backendPort:
                   anyOf:
-                  - type: string
                   - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
               required:
               - backendPort
+              type: object
             traffic:
               type: array
               items:
@@ -86,6 +90,7 @@ spec:
                     format: float64
                     minimum: 0
                     maximum: 100
+                type: object
             stackLifecycle:
               properties:
                 scaledownTTLSeconds:
@@ -95,6 +100,7 @@ spec:
                   type: integer
                   format: int32
                   minimum: 1
+              type: object
             stackTemplate:
               properties:
                 metadata:
@@ -107,11 +113,12 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                  type: object
                 spec:
                   properties:
                     version:
                       type: string
-                      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     strategy:
                       properties:
                         rollingUpdate:
@@ -145,6 +152,7 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                          type: object
                         maxReplicas:
                           format: int32
                           type: integer
@@ -168,21 +176,24 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                          type: object
                                         type: array
                                       matchLabels:
                                         additionalProperties:
                                           type: string
                                         type: object
+                                    type: object
                                   targetAverageValue:
-                                    # quantity type is string or int
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
                                   targetValue:
-                                    # quantity type is string or int
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               object:
                                 properties:
                                   metricName:
@@ -195,20 +206,23 @@ spec:
                                         type: string
                                       name:
                                         type: string
+                                    type: object
                                   targetValue:
-                                    # quantity type is string or int
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               pods:
                                 properties:
                                   metricName:
                                     type: string
                                   targetAverageValue:
-                                    # quantity type is string or int
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               resource:
                                 properties:
                                   name:
@@ -217,16 +231,19 @@ spec:
                                     format: int32
                                     type: integer
                                   targetAverageValue:
-                                    # quantity type is string or int
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
                               type:
                                 type: string
+                            type: object
                           type: array
                         minReplicas:
                           format: int32
                           type: integer
+                      type: object
                     autoscaler:
                       properties:
                         minReplicas:
@@ -259,10 +276,12 @@ spec:
                                 - path
                                 - key
                                 - name
+                                type: object
                               average:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                x-kubernetes-int-or-string: true
                               queue:
                                 properties:
                                   name:
@@ -272,9 +291,12 @@ spec:
                                 required:
                                 - name
                                 - region
+                                type: object
                               averageUtilization:
                                 type: integer
                                 format: int32
+                            type: object
+                      type: object
                     service:
                       properties:
                         metadata:
@@ -287,6 +309,7 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                          type: object
                         ports:
                           type: array
                           items:
@@ -302,10 +325,12 @@ spec:
                               protocol:
                                 type: string
                               targetPort:
-                                # TODO: int-or-string
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                      type: object
                     podTemplate:
                       properties:
                         metadata:
@@ -318,6 +343,7 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                          type: object
                         spec:
                           properties:
                             activeDeadlineSeconds:
@@ -343,6 +369,7 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
                                               matchFields:
                                                 items:
@@ -355,10 +382,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
+                                            type: object
                                           weight:
                                             format: int32
                                             type: integer
+                                        type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       properties:
@@ -376,6 +406,7 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
                                               matchFields:
                                                 items:
@@ -388,8 +419,12 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
+                                            type: object
                                           type: array
+                                      type: object
+                                  type: object
                                 podAffinity:
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -410,20 +445,24 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                      type: object
                                                     type: array
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                                type: object
                                               namespaces:
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
                                                 type: string
+                                            type: object
                                           weight:
                                             format: int32
                                             type: integer
+                                        type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
@@ -441,18 +480,22 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                            type: object
                                           namespaces:
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
                                             type: string
+                                        type: object
                                       type: array
+                                  type: object
                                 podAntiAffinity:
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
@@ -473,20 +516,24 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                      type: object
                                                     type: array
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                                type: object
                                               namespaces:
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
                                                 type: string
+                                            type: object
                                           weight:
                                             format: int32
                                             type: integer
+                                        type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
@@ -504,18 +551,23 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                  type: object
                                                 type: array
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                            type: object
                                           namespaces:
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
                                             type: string
+                                        type: object
                                       type: array
+                                  type: object
+                              type: object
                             automountServiceAccountToken:
                               type: boolean
                             containers:
@@ -546,12 +598,14 @@ spec:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
                                             fieldRef:
                                               properties:
                                                 apiVersion:
                                                   type: string
                                                 fieldPath:
                                                   type: string
+                                              type: object
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -560,6 +614,7 @@ spec:
                                                   type: string
                                                 resource:
                                                   type: string
+                                              type: object
                                             secretKeyRef:
                                               properties:
                                                 key:
@@ -568,6 +623,9 @@ spec:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
                                     type: array
                                   envFrom:
                                     items:
@@ -578,6 +636,7 @@ spec:
                                               type: string
                                             optional:
                                               type: boolean
+                                          type: object
                                         prefix:
                                           type: string
                                         secretRef:
@@ -586,6 +645,8 @@ spec:
                                               type: string
                                             optional:
                                               type: boolean
+                                          type: object
+                                      type: object
                                     type: array
                                   image:
                                     type: string
@@ -601,6 +662,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                            type: object
                                           httpGet:
                                             properties:
                                               host:
@@ -612,25 +674,29 @@ spec:
                                                       type: string
                                                     value:
                                                       type: string
+                                                  type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
                                       preStop:
                                         properties:
                                           exec:
@@ -639,6 +705,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                            type: object
                                           httpGet:
                                             properties:
                                               host:
@@ -650,25 +717,30 @@ spec:
                                                       type: string
                                                     value:
                                                       type: string
+                                                  type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
                                   livenessProbe:
                                     properties:
                                       exec:
@@ -677,6 +749,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       failureThreshold:
                                         format: int32
                                         type: integer
@@ -691,16 +764,18 @@ spec:
                                                   type: string
                                                 value:
                                                   type: string
+                                              type: object
                                             type: array
                                           path:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           scheme:
                                             type: string
+                                        type: object
                                       initialDelaySeconds:
                                         format: int32
                                         type: integer
@@ -715,13 +790,15 @@ spec:
                                           host:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
                                       timeoutSeconds:
                                         format: int32
                                         type: integer
+                                    type: object
                                   name:
                                     type: string
                                   ports:
@@ -739,6 +816,7 @@ spec:
                                           type: string
                                         protocol:
                                           type: string
+                                      type: object
                                     type: array
                                   readinessProbe:
                                     properties:
@@ -748,6 +826,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       failureThreshold:
                                         format: int32
                                         type: integer
@@ -762,16 +841,18 @@ spec:
                                                   type: string
                                                 value:
                                                   type: string
+                                              type: object
                                             type: array
                                           path:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           scheme:
                                             type: string
+                                        type: object
                                       initialDelaySeconds:
                                         format: int32
                                         type: integer
@@ -786,29 +867,32 @@ spec:
                                           host:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
                                       timeoutSeconds:
                                         format: int32
                                         type: integer
+                                    type: object
                                   resources:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          # quantity type is string or int
                                           anyOf:
-                                          - type: string
                                           - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          # quantity type is string or int
                                           anyOf:
-                                          - type: string
                                           - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
                                         type: object
+                                    type: object
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -823,6 +907,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       privileged:
                                         type: boolean
                                       readOnlyRootFilesystem:
@@ -845,6 +930,8 @@ spec:
                                             type: string
                                           user:
                                             type: string
+                                        type: object
+                                    type: object
                                   stdin:
                                     type: boolean
                                   stdinOnce:
@@ -862,6 +949,7 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                      type: object
                                     type: array
                                   volumeMounts:
                                     items:
@@ -876,9 +964,11 @@ spec:
                                           type: boolean
                                         subPath:
                                           type: string
+                                      type: object
                                     type: array
                                   workingDir:
                                     type: string
+                                type: object
                               type: array
                             dnsConfig:
                               properties:
@@ -893,11 +983,13 @@ spec:
                                         type: string
                                       value:
                                         type: string
+                                    type: object
                                   type: array
                                 searches:
                                   items:
                                     type: string
                                   type: array
+                              type: object
                             dnsPolicy:
                               type: string
                             hostAliases:
@@ -909,6 +1001,7 @@ spec:
                                     type: array
                                   ip:
                                     type: string
+                                type: object
                               type: array
                             hostIPC:
                               type: boolean
@@ -923,6 +1016,7 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                type: object
                               type: array
                             initContainers:
                               items:
@@ -952,12 +1046,14 @@ spec:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
                                             fieldRef:
                                               properties:
                                                 apiVersion:
                                                   type: string
                                                 fieldPath:
                                                   type: string
+                                              type: object
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -966,6 +1062,7 @@ spec:
                                                   type: string
                                                 resource:
                                                   type: string
+                                              type: object
                                             secretKeyRef:
                                               properties:
                                                 key:
@@ -974,6 +1071,9 @@ spec:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
                                     type: array
                                   envFrom:
                                     items:
@@ -984,6 +1084,7 @@ spec:
                                               type: string
                                             optional:
                                               type: boolean
+                                          type: object
                                         prefix:
                                           type: string
                                         secretRef:
@@ -992,6 +1093,8 @@ spec:
                                               type: string
                                             optional:
                                               type: boolean
+                                          type: object
+                                      type: object
                                     type: array
                                   image:
                                     type: string
@@ -1007,6 +1110,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                            type: object
                                           httpGet:
                                             properties:
                                               host:
@@ -1018,25 +1122,29 @@ spec:
                                                       type: string
                                                     value:
                                                       type: string
+                                                  type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
                                       preStop:
                                         properties:
                                           exec:
@@ -1045,6 +1153,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                            type: object
                                           httpGet:
                                             properties:
                                               host:
@@ -1056,25 +1165,30 @@ spec:
                                                       type: string
                                                     value:
                                                       type: string
+                                                  type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
+                                            type: object
                                           tcpSocket:
                                             properties:
                                               host:
                                                 type: string
                                               port:
-                                                # TODO: int-or-string
                                                 anyOf:
-                                                - type: string
                                                 - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
                                   livenessProbe:
                                     properties:
                                       exec:
@@ -1083,6 +1197,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       failureThreshold:
                                         format: int32
                                         type: integer
@@ -1097,16 +1212,18 @@ spec:
                                                   type: string
                                                 value:
                                                   type: string
+                                              type: object
                                             type: array
                                           path:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           scheme:
                                             type: string
+                                        type: object
                                       initialDelaySeconds:
                                         format: int32
                                         type: integer
@@ -1121,13 +1238,15 @@ spec:
                                           host:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
                                       timeoutSeconds:
                                         format: int32
                                         type: integer
+                                    type: object
                                   name:
                                     type: string
                                   ports:
@@ -1145,6 +1264,7 @@ spec:
                                           type: string
                                         protocol:
                                           type: string
+                                      type: object
                                     type: array
                                   readinessProbe:
                                     properties:
@@ -1154,6 +1274,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       failureThreshold:
                                         format: int32
                                         type: integer
@@ -1168,16 +1289,18 @@ spec:
                                                   type: string
                                                 value:
                                                   type: string
+                                              type: object
                                             type: array
                                           path:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           scheme:
                                             type: string
+                                        type: object
                                       initialDelaySeconds:
                                         format: int32
                                         type: integer
@@ -1192,29 +1315,32 @@ spec:
                                           host:
                                             type: string
                                           port:
-                                            # TODO: int-or-string
                                             anyOf:
-                                            - type: string
                                             - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
                                       timeoutSeconds:
                                         format: int32
                                         type: integer
+                                    type: object
                                   resources:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          # quantity type is string or int
                                           anyOf:
-                                          - type: string
                                           - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          # quantity type is string or int
                                           anyOf:
-                                          - type: string
                                           - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
                                         type: object
+                                    type: object
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1229,6 +1355,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                        type: object
                                       privileged:
                                         type: boolean
                                       readOnlyRootFilesystem:
@@ -1251,6 +1378,8 @@ spec:
                                             type: string
                                           user:
                                             type: string
+                                        type: object
+                                    type: object
                                   stdin:
                                     type: boolean
                                   stdinOnce:
@@ -1268,6 +1397,7 @@ spec:
                                           type: string
                                         name:
                                           type: string
+                                      type: object
                                     type: array
                                   volumeMounts:
                                     items:
@@ -1282,9 +1412,11 @@ spec:
                                           type: boolean
                                         subPath:
                                           type: string
+                                      type: object
                                     type: array
                                   workingDir:
                                     type: string
+                                type: object
                               type: array
                             nodeName:
                               type: string
@@ -1302,6 +1434,7 @@ spec:
                                 properties:
                                   conditionType:
                                     type: string
+                                type: object
                               type: array
                             restartPolicy:
                               type: string
@@ -1330,6 +1463,7 @@ spec:
                                       type: string
                                     user:
                                       type: string
+                                  type: object
                                 supplementalGroups:
                                   items:
                                     format: int64
@@ -1342,7 +1476,9 @@ spec:
                                         type: string
                                       value:
                                         type: string
+                                    type: object
                                   type: array
+                              type: object
                             serviceAccount:
                               type: string
                             serviceAccountName:
@@ -1368,6 +1504,7 @@ spec:
                                     type: integer
                                   value:
                                     type: string
+                                type: object
                               type: array
                             volumes:
                               items:
@@ -1383,6 +1520,7 @@ spec:
                                         type: boolean
                                       volumeID:
                                         type: string
+                                    type: object
                                   azureDisk:
                                     properties:
                                       cachingMode:
@@ -1397,6 +1535,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
+                                    type: object
                                   azureFile:
                                     properties:
                                       readOnly:
@@ -1405,6 +1544,7 @@ spec:
                                         type: string
                                       shareName:
                                         type: string
+                                    type: object
                                   cephfs:
                                     properties:
                                       monitors:
@@ -1421,8 +1561,10 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       user:
                                         type: string
+                                    type: object
                                   cinder:
                                     properties:
                                       fsType:
@@ -1433,8 +1575,10 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       volumeID:
                                         type: string
+                                    type: object
                                   configMap:
                                     properties:
                                       defaultMode:
@@ -1450,11 +1594,13 @@ spec:
                                               type: integer
                                             path:
                                               type: string
+                                          type: object
                                         type: array
                                       name:
                                         type: string
                                       optional:
                                         type: boolean
+                                    type: object
                                   downwardAPI:
                                     properties:
                                       defaultMode:
@@ -1469,6 +1615,7 @@ spec:
                                                   type: string
                                                 fieldPath:
                                                   type: string
+                                              type: object
                                             mode:
                                               format: int32
                                               type: integer
@@ -1482,13 +1629,17 @@ spec:
                                                   type: string
                                                 resource:
                                                   type: string
+                                              type: object
+                                          type: object
                                         type: array
+                                    type: object
                                   emptyDir:
                                     properties:
                                       medium:
                                         type: string
                                       sizeLimit:
                                         type: string
+                                    type: object
                                   fc:
                                     properties:
                                       fsType:
@@ -1506,6 +1657,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                    type: object
                                   flexVolume:
                                     properties:
                                       driver:
@@ -1522,12 +1674,15 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
+                                    type: object
                                   flocker:
                                     properties:
                                       datasetName:
                                         type: string
                                       datasetUUID:
                                         type: string
+                                    type: object
                                   gcePersistentDisk:
                                     properties:
                                       fsType:
@@ -1539,6 +1694,7 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
+                                    type: object
                                   gitRepo:
                                     properties:
                                       directory:
@@ -1547,6 +1703,7 @@ spec:
                                         type: string
                                       revision:
                                         type: string
+                                    type: object
                                   glusterfs:
                                     properties:
                                       endpoints:
@@ -1555,12 +1712,14 @@ spec:
                                         type: string
                                       readOnly:
                                         type: boolean
+                                    type: object
                                   hostPath:
                                     properties:
                                       path:
                                         type: string
                                       type:
                                         type: string
+                                    type: object
                                   iscsi:
                                     properties:
                                       chapAuthDiscovery:
@@ -1588,8 +1747,10 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       targetPortal:
                                         type: string
+                                    type: object
                                   name:
                                     type: string
                                   nfs:
@@ -1600,18 +1761,21 @@ spec:
                                         type: boolean
                                       server:
                                         type: string
+                                    type: object
                                   persistentVolumeClaim:
                                     properties:
                                       claimName:
                                         type: string
                                       readOnly:
                                         type: boolean
+                                    type: object
                                   photonPersistentDisk:
                                     properties:
                                       fsType:
                                         type: string
                                       pdID:
                                         type: string
+                                    type: object
                                   portworxVolume:
                                     properties:
                                       fsType:
@@ -1620,6 +1784,7 @@ spec:
                                         type: boolean
                                       volumeID:
                                         type: string
+                                    type: object
                                   projected:
                                     properties:
                                       defaultMode:
@@ -1640,11 +1805,13 @@ spec:
                                                         type: integer
                                                       path:
                                                         type: string
+                                                    type: object
                                                   type: array
                                                 name:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
                                             downwardAPI:
                                               properties:
                                                 items:
@@ -1656,6 +1823,7 @@ spec:
                                                             type: string
                                                           fieldPath:
                                                             type: string
+                                                        type: object
                                                       mode:
                                                         format: int32
                                                         type: integer
@@ -1669,7 +1837,10 @@ spec:
                                                             type: string
                                                           resource:
                                                             type: string
+                                                        type: object
+                                                    type: object
                                                   type: array
+                                              type: object
                                             secret:
                                               properties:
                                                 items:
@@ -1682,11 +1853,13 @@ spec:
                                                         type: integer
                                                       path:
                                                         type: string
+                                                    type: object
                                                   type: array
                                                 name:
                                                   type: string
                                                 optional:
                                                   type: boolean
+                                              type: object
                                             serviceAccountToken:
                                               properties:
                                                 audience:
@@ -1696,7 +1869,10 @@ spec:
                                                   type: integer
                                                 path:
                                                   type: string
+                                              type: object
+                                          type: object
                                         type: array
+                                    type: object
                                   quobyte:
                                     properties:
                                       group:
@@ -1709,6 +1885,7 @@ spec:
                                         type: string
                                       volume:
                                         type: string
+                                    type: object
                                   rbd:
                                     properties:
                                       fsType:
@@ -1729,8 +1906,10 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       user:
                                         type: string
+                                    type: object
                                   scaleIO:
                                     properties:
                                       fsType:
@@ -1745,6 +1924,7 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       sslEnabled:
                                         type: boolean
                                       storageMode:
@@ -1755,6 +1935,7 @@ spec:
                                         type: string
                                       volumeName:
                                         type: string
+                                    type: object
                                   secret:
                                     properties:
                                       defaultMode:
@@ -1770,11 +1951,13 @@ spec:
                                               type: integer
                                             path:
                                               type: string
+                                          type: object
                                         type: array
                                       optional:
                                         type: boolean
                                       secretName:
                                         type: string
+                                    type: object
                                   storageos:
                                     properties:
                                       fsType:
@@ -1785,10 +1968,12 @@ spec:
                                         properties:
                                           name:
                                             type: string
+                                        type: object
                                       volumeName:
                                         type: string
                                       volumeNamespace:
                                         type: string
+                                    type: object
                                   vsphereVolume:
                                     properties:
                                       fsType:
@@ -1799,4 +1984,12 @@ spec:
                                         type: string
                                       volumePath:
                                         type: string
+                                    type: object
+                                type: object
                               type: array
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+      type: object


### PR DESCRIPTION
All objects with a `properties` field have been given an `type: object` field to pass schema validation.
Also all types of `IntStr` need the field `x-kubernetes-int-or-str` and the types specified in that order.