### PR TITLE
fix migrations to stackset

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -884,6 +884,8 @@ func (c *StackSetController) ReconcileStackResources(ssc *core.StackSetContainer
 
 // ReconcileStackSet reconciles all the things from a stackset
 func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer) error {
+	container.BackendWeightsAnnotationKey = c.backendWeightsAnnotationKey
+
 	// Create current stack, if needed. Proceed on errors.
 	err := c.CreateCurrentStack(container)
 	if err != nil {
@@ -892,7 +894,7 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 	}
 
 	// Update statuses from external resources (ingresses, deployments, etc). Abort on errors.
-	err = container.UpdateFromResources(c.backendWeightsAnnotationKey)
+	err = container.UpdateFromResources()
 	if err != nil {
 		return err
 	}

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -884,8 +884,6 @@ func (c *StackSetController) ReconcileStackResources(ssc *core.StackSetContainer
 
 // ReconcileStackSet reconciles all the things from a stackset
 func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer) error {
-	container.BackendWeightsAnnotationKey = c.backendWeightsAnnotationKey
-
 	// Create current stack, if needed. Proceed on errors.
 	err := c.CreateCurrentStack(container)
 	if err != nil {
@@ -894,7 +892,7 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 	}
 
 	// Update statuses from external resources (ingresses, deployments, etc). Abort on errors.
-	err = container.UpdateFromResources(c.migrateTo == "stackset")
+	err = container.UpdateFromResources(c.migrateTo == "stackset", c.backendWeightsAnnotationKey)
 	if err != nil {
 		return err
 	}

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -893,6 +893,8 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 		c.stacksetLogger(container).Errorf("Unable to create stack: %v", err)
 	}
 
+	container.StacksetManagesTraffic = c.migrateTo == "stackset"
+
 	// Update statuses from external resources (ingresses, deployments, etc). Abort on errors.
 	err = container.UpdateFromResources()
 	if err != nil {

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -893,10 +893,8 @@ func (c *StackSetController) ReconcileStackSet(container *core.StackSetContainer
 		c.stacksetLogger(container).Errorf("Unable to create stack: %v", err)
 	}
 
-	container.StacksetManagesTraffic = c.migrateTo == "stackset"
-
 	// Update statuses from external resources (ingresses, deployments, etc). Abort on errors.
-	err = container.UpdateFromResources()
+	err = container.UpdateFromResources(c.migrateTo == "stackset")
 	if err != nil {
 		return err
 	}

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -146,7 +146,7 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 	)
 
 	trafficAuthoritative := map[string]string{
-		ingressTrafficAuthoritativeAnnotation: strconv.FormatBool(!ssc.StacksetManagesTraffic),
+		ingressTrafficAuthoritativeAnnotation: strconv.FormatBool(!ssc.stacksetManagesTraffic),
 	}
 
 	result := &extensions.Ingress{
@@ -224,7 +224,7 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 	}
 
 	result.Annotations[ssc.BackendWeightsAnnotationKey] = string(actualWeightsData)
-	if ssc.StacksetManagesTraffic {
+	if ssc.stacksetManagesTraffic {
 		delete(result.Annotations, traffic.StackTrafficWeightsAnnotationKey)
 	} else {
 		result.Annotations[traffic.StackTrafficWeightsAnnotationKey] = string(desiredWeightData)
@@ -272,7 +272,7 @@ func (ssc *StackSetContainer) GenerateStackSetStatus() *zv1.StackSetStatus {
 }
 
 func (ssc *StackSetContainer) GenerateStackSetTraffic() []*zv1.DesiredTraffic {
-	if !ssc.StacksetManagesTraffic {
+	if !ssc.stacksetManagesTraffic {
 		return nil
 	}
 

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -223,7 +223,7 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 		return nil, err
 	}
 
-	result.Annotations[ssc.BackendWeightsAnnotationKey] = string(actualWeightsData)
+	result.Annotations[ssc.backendWeightsAnnotationKey] = string(actualWeightsData)
 	if ssc.stacksetManagesTraffic {
 		delete(result.Annotations, traffic.StackTrafficWeightsAnnotationKey)
 	} else {

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+	"github.com/zalando-incubator/stackset-controller/pkg/traffic"
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -223,11 +224,11 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 		return nil, err
 	}
 
-	result.Annotations[BackendWeightsAnnotationKey] = string(actualWeightsData)
+	result.Annotations[ssc.BackendWeightsAnnotationKey] = string(actualWeightsData)
 	if ssc.stacksetManagesTraffic {
-		delete(result.Annotations, stackTrafficWeightsAnnotationKey)
+		delete(result.Annotations, traffic.StackTrafficWeightsAnnotationKey)
 	} else {
-		result.Annotations[stackTrafficWeightsAnnotationKey] = string(desiredWeightData)
+		result.Annotations[traffic.StackTrafficWeightsAnnotationKey] = string(desiredWeightData)
 	}
 
 	return result, nil

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -57,7 +57,6 @@ func (ssc *StackSetContainer) NewStack() (*StackContainer, string) {
 	observedStackVersion := stackset.Status.ObservedStackVersion
 	stackVersion := currentStackVersion(stackset)
 	stackName := generateStackName(stackset, stackVersion)
-
 	stack := ssc.stackByName(stackName)
 
 	// If the current stack doesn't exist, check that we haven't created it before. We shouldn't recreate
@@ -147,7 +146,7 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 	)
 
 	trafficAuthoritative := map[string]string{
-		ingressTrafficAuthoritativeAnnotation: strconv.FormatBool(!ssc.stacksetManagesTraffic),
+		ingressTrafficAuthoritativeAnnotation: strconv.FormatBool(!ssc.StacksetManagesTraffic),
 	}
 
 	result := &extensions.Ingress{
@@ -225,7 +224,7 @@ func (ssc *StackSetContainer) GenerateIngress() (*extensions.Ingress, error) {
 	}
 
 	result.Annotations[ssc.BackendWeightsAnnotationKey] = string(actualWeightsData)
-	if ssc.stacksetManagesTraffic {
+	if ssc.StacksetManagesTraffic {
 		delete(result.Annotations, traffic.StackTrafficWeightsAnnotationKey)
 	} else {
 		result.Annotations[traffic.StackTrafficWeightsAnnotationKey] = string(desiredWeightData)
@@ -273,7 +272,7 @@ func (ssc *StackSetContainer) GenerateStackSetStatus() *zv1.StackSetStatus {
 }
 
 func (ssc *StackSetContainer) GenerateStackSetTraffic() []*zv1.DesiredTraffic {
-	if !ssc.stacksetManagesTraffic {
+	if !ssc.StacksetManagesTraffic {
 		return nil
 	}
 

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -102,7 +102,7 @@ func TestExpiredStacks(t *testing.T) {
 					},
 				},
 				StackContainers:             map[types.UID]*StackContainer{},
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 			c.StackSet.Spec.StackLifecycle.Limit = &tc.limit
 			for _, stack := range tc.stacks {
@@ -297,7 +297,7 @@ func TestStackSetNewStack(t *testing.T) {
 			stackset := &StackSetContainer{
 				StackSet:                    tc.stackset,
 				StackContainers:             tc.stacks,
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 			newStack, newStackName := stackset.NewStack()
 			require.EqualValues(t, tc.expectedStack, newStack)
@@ -326,7 +326,7 @@ func dummyStacksetContainer() *StackSetContainer {
 				Stack: &zv1.Stack{},
 			},
 		},
-		BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 }
 
@@ -353,7 +353,7 @@ func TestStackSetUpdateFromResourcesPopulatesIngress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec.Ingress = tc.ingress
-			err := c.UpdateFromResources(true)
+			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -397,7 +397,7 @@ func TestStackSetUpdateFromResourcesPopulatesBackendPort(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec = tc.spec
-			err := c.UpdateFromResources(true)
+			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -451,7 +451,7 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 				c.StackSet.Spec.Ingress = tc.ingress
 			}
 
-			err := c.UpdateFromResources(true)
+			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -792,10 +792,10 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 					"v2": stack2,
 					"v3": stack3,
 				},
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
-			err := ssc.UpdateFromResources(true)
+			err := ssc.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
 			require.NoError(t, err)
 			require.True(t, ssc.stacksetManagesTraffic)
 
@@ -824,10 +824,10 @@ func TestStackSetExternalIngressForcesTrafficManagement(t *testing.T) {
 		StackContainers: map[types.UID]*StackContainer{
 			"v1": testStack("foo-v1").stack(),
 		},
-		BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 
-	err := ssc.UpdateFromResources(true)
+	err := ssc.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
 	require.NoError(t, err)
 	require.True(t, ssc.stacksetManagesTraffic)
 	require.EqualValues(t, &backendPort, ssc.externalIngressBackendPort)
@@ -884,7 +884,7 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 					"v2": stack2,
 					"v3": stack3,
 				},
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
 			if tc.desiredWeights != "" {
@@ -894,7 +894,7 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 				ssc.Ingress.Annotations[traffic.DefaultBackendWeightsAnnotationKey] = tc.actualWeights
 			}
 
-			err := ssc.UpdateFromResources(false)
+			err := ssc.UpdateFromResources(false, traffic.DefaultBackendWeightsAnnotationKey)
 			require.NoError(t, err)
 			require.False(t, ssc.stacksetManagesTraffic)
 
@@ -921,7 +921,7 @@ func TestGenerateStackSetStatus(t *testing.T) {
 			"v4": testStack("v4").stack(),
 			"v5": testStack("v5").ready(3).traffic(20, 10).stack(),
 		},
-		BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 
 	expected := &zv1.StackSetStatus{
@@ -1006,7 +1006,7 @@ func TestGenerateStackSetTraffic(t *testing.T) {
 					"v5": testStack("v5").ready(3).traffic(20, 10).stack(),
 				},
 				stacksetManagesTraffic:      tc.managesTraffic,
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
 			require.Equal(t, tc.expected, c.GenerateStackSetTraffic())
@@ -1068,7 +1068,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 					"v4": testStack("foo-v4").traffic(0, 0).stack(),
 				},
 				stacksetManagesTraffic:      tc.stacksetManagesTraffic,
-				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 			ingress, err := c.GenerateIngress()
 			require.NoError(t, err)
@@ -1174,7 +1174,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 func TestStackSetGenerateIngressNone(t *testing.T) {
 	c := &StackSetContainer{
 		StackSet:                    &zv1.StackSet{},
-		BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
+		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 	ingress, err := c.GenerateIngress()
 	require.NoError(t, err)

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -353,7 +353,7 @@ func TestStackSetUpdateFromResourcesPopulatesIngress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec.Ingress = tc.ingress
-			err := c.UpdateFromResources()
+			err := c.UpdateFromResources(true)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -397,7 +397,7 @@ func TestStackSetUpdateFromResourcesPopulatesBackendPort(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec = tc.spec
-			err := c.UpdateFromResources()
+			err := c.UpdateFromResources(true)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -451,7 +451,7 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 				c.StackSet.Spec.Ingress = tc.ingress
 			}
 
-			err := c.UpdateFromResources()
+			err := c.UpdateFromResources(true)
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -795,9 +795,9 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
-			err := ssc.UpdateFromResources()
+			err := ssc.UpdateFromResources(true)
 			require.NoError(t, err)
-			require.True(t, ssc.StacksetManagesTraffic)
+			require.True(t, ssc.stacksetManagesTraffic)
 
 			for _, sc := range ssc.StackContainers {
 				require.Equal(t, tc.expectedDesiredWeights[sc.Name()], sc.desiredTrafficWeight, "desired stack %s", sc.Stack.Name)
@@ -827,9 +827,9 @@ func TestStackSetExternalIngressForcesTrafficManagement(t *testing.T) {
 		BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 
-	err := ssc.UpdateFromResources()
+	err := ssc.UpdateFromResources(true)
 	require.NoError(t, err)
-	require.True(t, ssc.StacksetManagesTraffic)
+	require.True(t, ssc.stacksetManagesTraffic)
 	require.EqualValues(t, &backendPort, ssc.externalIngressBackendPort)
 }
 
@@ -894,9 +894,9 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 				ssc.Ingress.Annotations[traffic.DefaultBackendWeightsAnnotationKey] = tc.actualWeights
 			}
 
-			err := ssc.UpdateFromResources()
+			err := ssc.UpdateFromResources(false)
 			require.NoError(t, err)
-			require.False(t, ssc.StacksetManagesTraffic)
+			require.False(t, ssc.stacksetManagesTraffic)
 
 			for _, sc := range ssc.StackContainers {
 				require.Equal(t, tc.expectedDesiredWeights[sc.Name()], sc.desiredTrafficWeight, "stack %s", sc.Stack.Name)
@@ -1005,7 +1005,7 @@ func TestGenerateStackSetTraffic(t *testing.T) {
 					"v4": testStack("v4").stack(),
 					"v5": testStack("v5").ready(3).traffic(20, 10).stack(),
 				},
-				StacksetManagesTraffic:      tc.managesTraffic,
+				stacksetManagesTraffic:      tc.managesTraffic,
 				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
@@ -1067,7 +1067,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 					"v3": testStack("foo-v3").traffic(0.625, 0.625).stack(),
 					"v4": testStack("foo-v4").traffic(0, 0).stack(),
 				},
-				StacksetManagesTraffic:      tc.stacksetManagesTraffic,
+				stacksetManagesTraffic:      tc.stacksetManagesTraffic,
 				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 			ingress, err := c.GenerateIngress()

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -797,7 +797,7 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 
 			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
-			require.True(t, ssc.stacksetManagesTraffic)
+			require.True(t, ssc.StacksetManagesTraffic)
 
 			for _, sc := range ssc.StackContainers {
 				require.Equal(t, tc.expectedDesiredWeights[sc.Name()], sc.desiredTrafficWeight, "desired stack %s", sc.Stack.Name)
@@ -829,7 +829,7 @@ func TestStackSetExternalIngressForcesTrafficManagement(t *testing.T) {
 
 	err := ssc.UpdateFromResources()
 	require.NoError(t, err)
-	require.True(t, ssc.stacksetManagesTraffic)
+	require.True(t, ssc.StacksetManagesTraffic)
 	require.EqualValues(t, &backendPort, ssc.externalIngressBackendPort)
 }
 
@@ -896,7 +896,7 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 
 			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
-			require.False(t, ssc.stacksetManagesTraffic)
+			require.False(t, ssc.StacksetManagesTraffic)
 
 			for _, sc := range ssc.StackContainers {
 				require.Equal(t, tc.expectedDesiredWeights[sc.Name()], sc.desiredTrafficWeight, "stack %s", sc.Stack.Name)
@@ -1005,7 +1005,7 @@ func TestGenerateStackSetTraffic(t *testing.T) {
 					"v4": testStack("v4").stack(),
 					"v5": testStack("v5").ready(3).traffic(20, 10).stack(),
 				},
-				stacksetManagesTraffic:      tc.managesTraffic,
+				StacksetManagesTraffic:      tc.managesTraffic,
 				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
@@ -1067,7 +1067,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 					"v3": testStack("foo-v3").traffic(0.625, 0.625).stack(),
 					"v4": testStack("foo-v4").traffic(0, 0).stack(),
 				},
-				stacksetManagesTraffic:      tc.stacksetManagesTraffic,
+				StacksetManagesTraffic:      tc.stacksetManagesTraffic,
 				BackendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 			ingress, err := c.GenerateIngress()

--- a/pkg/core/traffic.go
+++ b/pkg/core/traffic.go
@@ -4,11 +4,6 @@ import (
 	"time"
 )
 
-const (
-	stackTrafficWeightsAnnotationKey = "zalando.org/stack-traffic-weights"
-	BackendWeightsAnnotationKey      = "zalando.org/backend-weights"
-)
-
 type TrafficReconciler interface {
 	// Handle the traffic switching and/or scaling logic.
 	Reconcile(stacks map[string]*StackContainer, currentTimestamp time.Time) error

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -55,10 +55,10 @@ type StackSetContainer struct {
 	// Whether the stackset should be authoritative for the traffic, and not the ingress
 	stacksetManagesTraffic bool
 
-	// BackendWeightsAnnotationKey to store the runtime decision
+	// backendWeightsAnnotationKey to store the runtime decision
 	// which annotation is used, defaults to
 	// traffic.DefaultBackendWeightsAnnotationKey
-	BackendWeightsAnnotationKey string
+	backendWeightsAnnotationKey string
 }
 
 // StackContainer is a container for storing the full state of a Stack
@@ -199,7 +199,7 @@ func (ssc *StackSetContainer) updateDesiredTrafficFromIngress() error {
 }
 
 func (ssc *StackSetContainer) updateActualTrafficFromIngress() error {
-	actual, err := ssc.getNormalizedTrafficFromIngress(ssc.BackendWeightsAnnotationKey)
+	actual, err := ssc.getNormalizedTrafficFromIngress(ssc.backendWeightsAnnotationKey)
 	if err != nil {
 		return fmt.Errorf("failed to get current actual Stack traffic weights: %v", err)
 	}
@@ -324,8 +324,10 @@ func (ssc *StackSetContainer) updateActualTrafficFromStackSet() error {
 }
 
 // UpdateFromResources populates stack state information (e.g. replica counts or traffic) from related resources
-func (ssc *StackSetContainer) UpdateFromResources(stacksetManageTraffic bool) error {
+func (ssc *StackSetContainer) UpdateFromResources(stacksetManageTraffic bool, backendWeightsAnnotationKey string) error {
 	ssc.stacksetManagesTraffic = stacksetManageTraffic
+	ssc.backendWeightsAnnotationKey = backendWeightsAnnotationKey
+
 	if len(ssc.StackContainers) == 0 {
 		return nil
 	}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -53,7 +53,7 @@ type StackSetContainer struct {
 	externalIngressBackendPort *intstr.IntOrString
 
 	// Whether the stackset should be authoritative for the traffic, and not the ingress
-	StacksetManagesTraffic bool
+	stacksetManagesTraffic bool
 
 	// BackendWeightsAnnotationKey to store the runtime decision
 	// which annotation is used, defaults to
@@ -324,7 +324,8 @@ func (ssc *StackSetContainer) updateActualTrafficFromStackSet() error {
 }
 
 // UpdateFromResources populates stack state information (e.g. replica counts or traffic) from related resources
-func (ssc *StackSetContainer) UpdateFromResources() error {
+func (ssc *StackSetContainer) UpdateFromResources(stacksetManageTraffic bool) error {
+	ssc.stacksetManagesTraffic = stacksetManageTraffic
 	if len(ssc.StackContainers) == 0 {
 		return nil
 	}
@@ -364,7 +365,7 @@ func (ssc *StackSetContainer) UpdateFromResources() error {
 			if err != nil {
 				return err
 			}
-			ssc.StacksetManagesTraffic = true
+			ssc.stacksetManagesTraffic = true
 		} else {
 			if err := ssc.updateDesiredTrafficFromIngress(); err != nil {
 				return err

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -53,7 +53,7 @@ type StackSetContainer struct {
 	externalIngressBackendPort *intstr.IntOrString
 
 	// Whether the stackset should be authoritative for the traffic, and not the ingress
-	stacksetManagesTraffic bool
+	StacksetManagesTraffic bool
 
 	// BackendWeightsAnnotationKey to store the runtime decision
 	// which annotation is used, defaults to
@@ -364,7 +364,7 @@ func (ssc *StackSetContainer) UpdateFromResources() error {
 			if err != nil {
 				return err
 			}
-			ssc.stacksetManagesTraffic = true
+			ssc.StacksetManagesTraffic = true
 		} else {
 			if err := ssc.updateDesiredTrafficFromIngress(); err != nil {
 				return err

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	stacksetHeritageLabelKey           = "stackset"
-	stackTrafficWeightsAnnotationKey   = "zalando.org/stack-traffic-weights"
+	StackTrafficWeightsAnnotationKey   = "zalando.org/stack-traffic-weights"
 	DefaultBackendWeightsAnnotationKey = "zalando.org/backend-weights"
 )
 
@@ -62,7 +62,7 @@ func (t *Switcher) Switch(stackset, stack, namespace string, weight float64) ([]
 		annotation := map[string]map[string]map[string]string{
 			"metadata": map[string]map[string]string{
 				"annotations": map[string]string{
-					stackTrafficWeightsAnnotationKey: string(stackWeightsData),
+					StackTrafficWeightsAnnotationKey: string(stackWeightsData),
 				},
 			},
 		}
@@ -139,7 +139,7 @@ func (t *Switcher) getIngressTraffic(name, namespace string, stacks []zv1.Stack)
 	}
 
 	desiredTraffic := make(map[string]float64, len(stacks))
-	if weights, ok := ingress.Annotations[stackTrafficWeightsAnnotationKey]; ok {
+	if weights, ok := ingress.Annotations[StackTrafficWeightsAnnotationKey]; ok {
 		err := json.Unmarshal([]byte(weights), &desiredTraffic)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get current desired Stack traffic weights: %v", err)


### PR DESCRIPTION
fix: `--migrate-to=stackset` crashed if there was not ownerReference set 
fix: have only one place for the const definition, such that overrides also work as expected

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>