### PR TITLE
Populate stack.status.desiredReplicas from the deployment

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -280,8 +280,7 @@ type StackStatus struct {
 	// managed by the stack.
 	// +optional
 	UpdatedReplicas int32 `json:"updatedReplicas"`
-	// DesiredReplicas is the number of desired replicas as defined by the
-	// optional HortizontalPodAutoscaler defined for the stack.
+	// DesiredReplicas is the number of desired replicas in the Deployment
 	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas"`
 	// Prescaling current prescaling information

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -320,7 +320,7 @@ func (sc *StackContainer) GenerateStackStatus() *zv1.StackStatus {
 		Replicas:             sc.createdReplicas,
 		ReadyReplicas:        sc.readyReplicas,
 		UpdatedReplicas:      sc.updatedReplicas,
-		DesiredReplicas:      sc.desiredReplicas,
+		DesiredReplicas:      sc.deploymentReplicas,
 		Prescaling:           prescaling,
 		NoTrafficSince:       wrapTime(sc.noTrafficSince),
 		LabelSelector:        labels.Set(sc.selector()).String(),

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -663,7 +663,7 @@ func TestGenerateStackStatus(t *testing.T) {
 				createdReplicas:                3,
 				readyReplicas:                  2,
 				updatedReplicas:                1,
-				desiredReplicas:                4,
+				deploymentReplicas:             4,
 				noTrafficSince:                 tc.noTrafficSince,
 				prescalingActive:               tc.prescalingActive,
 				prescalingReplicas:             tc.prescalingReplicas,

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -531,20 +531,6 @@ func TestStackUpdateFromResources(t *testing.T) {
 		require.EqualValues(t, 3, container.stackReplicas)
 	})
 
-	runTest("desired replicas are set to 0 if there's no HPA", func(t *testing.T, container *StackContainer) {
-		container.updateFromResources()
-		require.EqualValues(t, 0, container.desiredReplicas)
-	})
-	runTest("desired replicas are parsed from the HPA", func(t *testing.T, container *StackContainer) {
-		container.Resources.HPA = &autoscaling.HorizontalPodAutoscaler{
-			Status: autoscaling.HorizontalPodAutoscalerStatus{
-				DesiredReplicas: 7,
-			},
-		}
-		container.updateFromResources()
-		require.EqualValues(t, 7, container.desiredReplicas)
-	})
-
 	runTest("noTrafficSince can be unset", func(t *testing.T, container *StackContainer) {
 		container.updateFromResources()
 		require.EqualValues(t, time.Time{}, container.noTrafficSince)

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -100,9 +100,6 @@ type StackContainer struct {
 	// Current number of up-to-date replicas that the deployment has, from Deployment.status
 	updatedReplicas int32
 
-	// Current number of replicas that the HPA expects deployment to have, from HPA.status
-	desiredReplicas int32
-
 	// Traffic & scaling
 	currentActualTrafficWeight     float64
 	actualTrafficWeight            float64
@@ -434,10 +431,6 @@ func (sc *StackContainer) updateFromResources() {
 	}
 
 	// hpa
-	if sc.Resources.HPA != nil {
-		hpa := sc.Resources.HPA
-		sc.desiredReplicas = hpa.Status.DesiredReplicas
-	}
 	if sc.IsAutoscaled() {
 		hpaUpdated = sc.Resources.HPA != nil && IsResourceUpToDate(sc.Stack, sc.Resources.HPA.ObjectMeta)
 	} else {


### PR DESCRIPTION
Apparently this number was populated only from the HPA, and was left at 0 if HPA was unused. It's unclear whether something like this is useful to anyone, so let's populate it from `deployment.spec` instead. It'll show exactly the same, except for cases when the HPA controller fails, and all the cases where it's currently broken (e.g. no HPA).