### PR TITLE
CRD spec: correctly validate quantities

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -106,11 +106,13 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
+                            pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                             x-kubernetes-int-or-string: true
                           targetValue:
                             anyOf:
                             - type: integer
                             - type: string
+                            pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                             x-kubernetes-int-or-string: true
                         type: object
                       object:
@@ -130,6 +132,7 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
+                            pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                             x-kubernetes-int-or-string: true
                         type: object
                       pods:
@@ -140,6 +143,7 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
+                            pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                             x-kubernetes-int-or-string: true
                         type: object
                       resource:
@@ -153,6 +157,7 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
+                            pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
@@ -200,6 +205,7 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
+                        pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                         x-kubernetes-int-or-string: true
                       queue:
                         properties:
@@ -820,6 +826,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                   x-kubernetes-int-or-string: true
                                 type: object
                               requests:
@@ -827,6 +834,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
@@ -1268,6 +1276,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                   x-kubernetes-int-or-string: true
                                 type: object
                               requests:
@@ -1275,6 +1284,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -187,11 +187,13 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                     x-kubernetes-int-or-string: true
                                   targetValue:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                     x-kubernetes-int-or-string: true
                                 type: object
                               object:
@@ -211,6 +213,7 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                     x-kubernetes-int-or-string: true
                                 type: object
                               pods:
@@ -221,6 +224,7 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                     x-kubernetes-int-or-string: true
                                 type: object
                               resource:
@@ -234,6 +238,7 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                     x-kubernetes-int-or-string: true
                                 type: object
                               type:
@@ -281,6 +286,7 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                 x-kubernetes-int-or-string: true
                               queue:
                                 properties:
@@ -883,6 +889,7 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                           x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
@@ -890,6 +897,7 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                           x-kubernetes-int-or-string: true
                                         type: object
                                     type: object
@@ -1331,6 +1339,7 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                           x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
@@ -1338,6 +1347,7 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
                                           x-kubernetes-int-or-string: true
                                         type: object
                                     type: object


### PR DESCRIPTION
We **must** have a strict regex for `resource.Quantity` fields, because invalid values there completely break the whole controller.