### PR TITLE
Stack ingresses: use an explicit cluster domain

### DIFF
--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	kingpin.Flag("controller-id", "ID of the controller used to determine ownership of StackSet resources").StringVar(&config.ControllerID)
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
 	kingpin.Flag("migrate-to", "Migrate desired traffic setting from Ingress to StackSet or from StackSet to Ingress").EnumVar(&config.MigrateTo, "ingress", "stackset")
-	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").Required().StringVar(&config.ClusterDomain)
+	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_DOMAIN").Required().StringVar(&config.ClusterDomain)
 	kingpin.Parse()
 
 	if config.Debug {

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -50,7 +50,7 @@ func main() {
 	kingpin.Flag("controller-id", "ID of the controller used to determine ownership of StackSet resources").StringVar(&config.ControllerID)
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
 	kingpin.Flag("migrate-to", "Migrate desired traffic setting from Ingress to StackSet or from StackSet to Ingress").EnumVar(&config.MigrateTo, "ingress", "stackset")
-	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").StringVar(&config.ClusterDomain)
+	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").Required().StringVar(&config.ClusterDomain)
 	kingpin.Parse()
 
 	if config.Debug {

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -33,6 +33,7 @@ var (
 		Interval                    time.Duration
 		APIServer                   *url.URL
 		MetricsAddress              string
+		ClusterDomain               string
 		NoTrafficScaledownTTL       time.Duration
 		ControllerID                string
 		MigrateTo                   string
@@ -49,6 +50,7 @@ func main() {
 	kingpin.Flag("controller-id", "ID of the controller used to determine ownership of StackSet resources").StringVar(&config.ControllerID)
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
 	kingpin.Flag("migrate-to", "Migrate desired traffic setting from Ingress to StackSet or from StackSet to Ingress").EnumVar(&config.MigrateTo, "ingress", "stackset")
+	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").StringVar(&config.ClusterDomain)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -71,6 +73,7 @@ func main() {
 		config.ControllerID,
 		config.MigrateTo,
 		config.BackendWeightsAnnotationKey,
+		config.ClusterDomain,
 		prometheus.DefaultRegisterer,
 		config.Interval,
 	)

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -53,6 +53,7 @@ type StackSetController struct {
 	controllerID                string
 	migrateTo                   string
 	backendWeightsAnnotationKey string
+	clusterDomain               string
 	interval                    time.Duration
 	stacksetEvents              chan stacksetEvent
 	stacksetStore               map[types.UID]zv1.StackSet
@@ -76,7 +77,7 @@ func (ee *eventedError) Error() string {
 }
 
 // NewStackSetController initializes a new StackSetController.
-func NewStackSetController(client clientset.Interface, controllerID, migrateTo, backendWeightsAnnotationKey string, registry prometheus.Registerer, interval time.Duration) (*StackSetController, error) {
+func NewStackSetController(client clientset.Interface, controllerID, migrateTo, backendWeightsAnnotationKey, clusterDomain string, registry prometheus.Registerer, interval time.Duration) (*StackSetController, error) {
 	metricsReporter, err := core.NewMetricsReporter(registry)
 	if err != nil {
 		return nil, err
@@ -88,6 +89,7 @@ func NewStackSetController(client clientset.Interface, controllerID, migrateTo, 
 		controllerID:                controllerID,
 		migrateTo:                   migrateTo,
 		backendWeightsAnnotationKey: backendWeightsAnnotationKey,
+		clusterDomain:               clusterDomain,
 		interval:                    interval,
 		stacksetEvents:              make(chan stacksetEvent, 1),
 		stacksetStore:               make(map[types.UID]zv1.StackSet),
@@ -358,7 +360,7 @@ func (c *StackSetController) collectResources() (map[types.UID]*core.StackSetCon
 			}
 		}
 
-		stacksetContainer := core.NewContainer(&stackset, reconciler, c.migrateTo == "stackset", c.backendWeightsAnnotationKey)
+		stacksetContainer := core.NewContainer(&stackset, reconciler, c.migrateTo == "stackset", c.backendWeightsAnnotationKey, c.clusterDomain)
 		stacksets[uid] = stacksetContainer
 	}
 

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -9,7 +9,6 @@ import (
 	ssfake "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned/fake"
 	zi "github.com/zalando-incubator/stackset-controller/pkg/client/clientset/versioned/typed/zalando.org/v1"
 	ssunified "github.com/zalando-incubator/stackset-controller/pkg/clientset"
-	"github.com/zalando-incubator/stackset-controller/pkg/traffic"
 	apps "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
@@ -40,7 +39,7 @@ func NewTestEnvironment() *testEnvironment {
 		ssClient:  ssfake.NewSimpleClientset(),
 	}
 
-	controller, err := NewStackSetController(client, "", "", traffic.DefaultBackendWeightsAnnotationKey, prometheus.NewPedanticRegistry(), time.Minute)
+	controller, err := NewStackSetController(client, "", "", "", prometheus.NewPedanticRegistry(), time.Minute)
 	if err != nil {
 		panic(err)
 	}

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -39,7 +39,7 @@ func NewTestEnvironment() *testEnvironment {
 		ssClient:  ssfake.NewSimpleClientset(),
 	}
 
-	controller, err := NewStackSetController(client, "", "", "", prometheus.NewPedanticRegistry(), time.Minute)
+	controller, err := NewStackSetController(client, "", "", "", "", prometheus.NewPedanticRegistry(), time.Minute)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/apply/deployment.yaml
+++ b/e2e/apply/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         image: "{{{IMAGE}}}"
         args:
           - "--controller-id={{{CONTROLLER_ID}}}"
+          - "--cluster-domain={{{CLUSTER_DOMAIN}}}"
         resources:
           limits:
             cpu: 10m

--- a/pkg/core/helpers.go
+++ b/pkg/core/helpers.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
@@ -48,21 +46,6 @@ func getStackGeneration(resource metav1.ObjectMeta) int64 {
 		return 0
 	}
 	return decodedGeneration
-}
-
-// createSubdomain creates a subdomain giving an existing domain by replacing
-// the first section of the domain. E.g. given the domain: my-app.example.org
-// and the subdomain part my-new-app the resulting domain will be
-// my-new-app.example.org.
-func createSubdomain(domain, subdomain string) (string, error) {
-	names := strings.SplitN(domain, ".", 2)
-	if len(names) != 2 {
-		return "", fmt.Errorf("unexpected domain format: %s", domain)
-	}
-
-	names[0] = subdomain
-
-	return strings.Join(names, "."), nil
 }
 
 func wrapTime(time time.Time) *metav1.Time {

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -278,10 +278,11 @@ func TestStackGenerateIngress(t *testing.T) {
 				Labels:      map[string]string{"ignored": "label"},
 				Annotations: map[string]string{"ingress": "annotation"},
 			},
-			Hosts: []string{"example.org", "example.com"},
+			Hosts: []string{"foo.example.org", "foo.example.com"},
 			Path:  "example",
 		},
-		backendPort: &backendPort,
+		backendPort:   &backendPort,
+		clusterDomain: "example.org",
 	}
 	ingress, err := c.GenerateIngress()
 	require.NoError(t, err)
@@ -295,23 +296,7 @@ func TestStackGenerateIngress(t *testing.T) {
 		Spec: extensions.IngressSpec{
 			Rules: []extensions.IngressRule{
 				{
-					Host: "foo-v1.org",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
-								{
-									Path: "example",
-									Backend: extensions.IngressBackend{
-										ServiceName: "foo-v1",
-										ServicePort: backendPort,
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Host: "foo-v1.com",
+					Host: "foo-v1.example.org",
 					IngressRuleValue: extensions.IngressRuleValue{
 						HTTP: &extensions.HTTPIngressRuleValue{
 							Paths: []extensions.HTTPIngressPath{

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -471,6 +471,18 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 	}
 }
 
+func TestStackSetUpdateFromResourcesClusterDomain(t *testing.T) {
+	c := dummyStacksetContainer()
+	c.clusterDomain = "foo.example.org"
+
+	err := c.UpdateFromResources()
+	require.NoError(t, err)
+
+	for _, sc := range c.StackContainers {
+		require.Equal(t, c.clusterDomain, sc.clusterDomain)
+	}
+}
+
 func TestStackUpdateFromResources(t *testing.T) {
 	runTest := func(name string, testFn func(t *testing.T, container *StackContainer)) {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -326,6 +326,7 @@ func dummyStacksetContainer() *StackSetContainer {
 				Stack: &zv1.Stack{},
 			},
 		},
+		stacksetManagesTraffic:      true,
 		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 }
@@ -353,7 +354,7 @@ func TestStackSetUpdateFromResourcesPopulatesIngress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec.Ingress = tc.ingress
-			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
+			err := c.UpdateFromResources()
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -397,7 +398,7 @@ func TestStackSetUpdateFromResourcesPopulatesBackendPort(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := dummyStacksetContainer()
 			c.StackSet.Spec = tc.spec
-			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
+			err := c.UpdateFromResources()
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -451,7 +452,7 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 				c.StackSet.Spec.Ingress = tc.ingress
 			}
 
-			err := c.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
+			err := c.UpdateFromResources()
 			require.NoError(t, err)
 
 			for _, sc := range c.StackContainers {
@@ -781,7 +782,7 @@ func TestUpdateTrafficFromStackSet(t *testing.T) {
 				backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 			}
 
-			err := ssc.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
+			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
 			require.True(t, ssc.stacksetManagesTraffic)
 
@@ -813,7 +814,7 @@ func TestStackSetExternalIngressForcesTrafficManagement(t *testing.T) {
 		backendWeightsAnnotationKey: traffic.DefaultBackendWeightsAnnotationKey,
 	}
 
-	err := ssc.UpdateFromResources(true, traffic.DefaultBackendWeightsAnnotationKey)
+	err := ssc.UpdateFromResources()
 	require.NoError(t, err)
 	require.True(t, ssc.stacksetManagesTraffic)
 	require.EqualValues(t, &backendPort, ssc.externalIngressBackendPort)
@@ -880,7 +881,7 @@ func TestUpdateTrafficFromIngress(t *testing.T) {
 				ssc.Ingress.Annotations[traffic.DefaultBackendWeightsAnnotationKey] = tc.actualWeights
 			}
 
-			err := ssc.UpdateFromResources(false, traffic.DefaultBackendWeightsAnnotationKey)
+			err := ssc.UpdateFromResources()
 			require.NoError(t, err)
 			require.False(t, ssc.stacksetManagesTraffic)
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -172,6 +172,16 @@ type StackResources struct {
 	Ingress    *extensions.Ingress
 }
 
+func NewContainer(stackset *zv1.StackSet, reconciler TrafficReconciler, stacksetManageTraffic bool, backendWeightsAnnotationKey string) *StackSetContainer {
+	return &StackSetContainer{
+		StackSet:                    stackset,
+		StackContainers:             map[types.UID]*StackContainer{},
+		TrafficReconciler:           reconciler,
+		stacksetManagesTraffic:      stacksetManageTraffic,
+		backendWeightsAnnotationKey: backendWeightsAnnotationKey,
+	}
+}
+
 func (ssc *StackSetContainer) stackByName(name string) *StackContainer {
 	for _, container := range ssc.StackContainers {
 		if container.Name() == name {
@@ -321,10 +331,7 @@ func (ssc *StackSetContainer) updateActualTrafficFromStackSet() error {
 }
 
 // UpdateFromResources populates stack state information (e.g. replica counts or traffic) from related resources
-func (ssc *StackSetContainer) UpdateFromResources(stacksetManageTraffic bool, backendWeightsAnnotationKey string) error {
-	ssc.stacksetManagesTraffic = stacksetManageTraffic
-	ssc.backendWeightsAnnotationKey = backendWeightsAnnotationKey
-
+func (ssc *StackSetContainer) UpdateFromResources() error {
 	if len(ssc.StackContainers) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Use an explicitly provided cluster domain when generating per-stack ingresses (so just `<stack-name>.<cluster-domain>` instead of going through all of the main ingress hostnames and generating `<stack-name>.<domain>`). The latter either produced identical results, duplicate entries or didn't work anyway.