### PR TITLE
Status should not be required in stacks

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -6428,7 +6428,6 @@ spec:
           type: object
       required:
       - spec
-      - status
       type: object
   version: v1
   versions:


### PR DESCRIPTION
Avoid having Status required as it breaks when deploying a resource without the status defined as the stackset controller does when initially creating stacks.