### PR TITLE
CRD: don't require StackSet.status

### DIFF
--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -7082,7 +7082,6 @@ spec:
           type: object
       required:
       - spec
-      - status
       type: object
   version: v1
   versions:


### PR DESCRIPTION
Just like in #211 for Stack, I don't think StackSet.status should be required on creation.