### PR TITLE
Increase event QPS as a quick workaround for deployment probers

### DIFF
--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -14,7 +14,7 @@ import (
 // CreateEventRecorder creates an event recorder to send custom events to Kubernetes to be recorded for targeted Kubernetes objects
 func CreateEventRecorder(kubeClient clientset.Interface) kube_record.EventRecorder {
 	eventBroadcaster := kube_record.NewBroadcasterWithCorrelatorOptions(kube_record.CorrelatorOptions{
-		QPS: 1. / 30.,
+		QPS: 10. / 60.,
 	})
 	eventBroadcaster.StartLogging(logrus.Infof)
 	if _, isfake := kubeClient.(*fake.Clientset); !isfake {


### PR DESCRIPTION
Since https://github.com/zalando-incubator/stackset-controller/issues/31 is not solved, our probers still have to rely on monitoring `Failed…` events to figure out if the stackset is healthy. We currently determine if the events are 'old enough' by using a 1 minute range, but since `EventBroadcaster` has some fancy QPS logic inside, it will start dropping event updates at some point. Let's increase it even further for now as a quick hack.