### PR TITLE
Update annotations in per-stack ingresses

### DIFF
--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/api/autoscaling/v2beta2"
 	apiv1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -213,7 +214,7 @@ func (c *StackSetController) ReconcileStackIngress(ctx context.Context, stack *z
 	}
 
 	// Check if we need to update the Ingress
-	if core.IsResourceUpToDate(stack, existing.ObjectMeta) {
+	if core.IsResourceUpToDate(stack, existing.ObjectMeta) && equality.Semantic.DeepEqual(ingress.Annotations, existing.Annotations) {
 		return nil
 	}
 

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -625,6 +625,9 @@ func TestReconcileStackIngress(t *testing.T) {
 		},
 	}
 
+	baseTestStackOwnedUpdatedAnnotations := *baseTestStackOwned.DeepCopy()
+	baseTestStackOwnedUpdatedAnnotations.Annotations["example"] = "updated"
+
 	for _, tc := range []struct {
 		name     string
 		stack    zv1.Stack
@@ -679,6 +682,28 @@ func TestReconcileStackIngress(t *testing.T) {
 				ObjectMeta: updatedTestStackOwned,
 				Spec: networking.IngressSpec{
 					Rules: exampleUpdatedRules,
+				},
+			},
+		},
+		{
+			name:  "ingress is updated if the expected annotations change",
+			stack: baseTestStack,
+			existing: &networking.Ingress{
+				ObjectMeta: baseTestStackOwned,
+				Spec: networking.IngressSpec{
+					Rules: exampleRules,
+				},
+			},
+			updated: &networking.Ingress{
+				ObjectMeta: baseTestStackOwnedUpdatedAnnotations,
+				Spec: networking.IngressSpec{
+					Rules: exampleRules,
+				},
+			},
+			expected: &networking.Ingress{
+				ObjectMeta: baseTestStackOwnedUpdatedAnnotations,
+				Spec: networking.IngressSpec{
+					Rules: exampleRules,
 				},
 			},
 		},


### PR DESCRIPTION
Per-stack ingresses should be updated when the annotations in `stackset.ingress.metadata` change as well, otherwise filter/predicate changes won't be propagated. We should probably handle label changes as well, but doing this correctly is way too annoying. :/