### PR TITLE
Fix ingress api-version

### DIFF
--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -166,7 +166,7 @@ func ingressMetric(metrics zv1.AutoscalerMetrics, ingressName, backendName strin
 		Object: &autoscaling.ObjectMetricSource{
 			MetricName: fmt.Sprintf("%s,%s", requestsPerSecondName, backendName),
 			Target: autoscaling.CrossVersionObjectReference{
-				APIVersion: "networking/v1beta1",
+				APIVersion: "networking.k8s.io/v1beta1",
 				Kind:       "Ingress",
 				Name:       ingressName,
 			},


### PR DESCRIPTION
Follow up to #225 

This fixes the apiversion for ingress such that it will work with kube-metrics-adapter. Without the HPA will report errors like:

```
- lastTransitionTime: "2020-07-21T15:04:57Z"
    message: 'the HPA was unable to compute the replica count: unable to get metric
      requests-per-second,x: Ingress on default x/unable
      to fetch metrics from custom metrics API: unable to map kind Ingress.networking
      to resource: no matches for kind "Ingress" in group "networking"'
    reason: FailedGetObjectMetric
    status: "False"
    type: ScalingActive
```