### PR TITLE
Make setting controller-id optional

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -331,11 +331,12 @@ func stackSetStatusMatches(t *testing.T, stackSetName string, expectedStatus exp
 
 func stackObjectMeta(name string, prescalingTimeout int) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-		Annotations: map[string]string{
-			controller.StacksetControllerControllerAnnotationKey: controllerId,
-		},
+		Name:        name,
+		Namespace:   namespace,
+		Annotations: map[string]string{},
+	}
+	if controllerId != "" {
+		meta.Annotations[controller.StacksetControllerControllerAnnotationKey] = controllerId
 	}
 	if prescalingTimeout > 0 {
 		meta.Annotations[controller.PrescaleStacksAnnotationKey] = "yes"


### PR DESCRIPTION
Setting the `CONTROLLER_ID` is useful for running e2e tests with a custom stackset-controller. But for using the default controller in the cluster it should be possible to not set the ID at all. This we want when running stackset e2e in kubernetes-on-aws.