### PR TITLE
Include Ingress annotation in e2e test

### DIFF
--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -15,7 +15,7 @@ func TestBrokenStacks(t *testing.T) {
 	t.Parallel()
 
 	stacksetName := "stackset-broken-stacks"
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(1, 30)
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).StackGC(1, 30)
 
 	firstVersion := "v1"
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)

--- a/cmd/e2e/generated_autoscaler_test.go
+++ b/cmd/e2e/generated_autoscaler_test.go
@@ -42,7 +42,7 @@ func TestGenerateAutoscaler(t *testing.T) {
 	}
 	require.Len(t, metrics, 3)
 
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().Autoscaler(1, 10, metrics)
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).Autoscaler(1, 10, metrics)
 	firstVersion := "v1"
 	spec := factory.Create(firstVersion)
 	err := createStackSet(stacksetName, 0, spec)

--- a/cmd/e2e/prescaling_test.go
+++ b/cmd/e2e/prescaling_test.go
@@ -11,7 +11,7 @@ import (
 func TestPrescalingWithoutHPA(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-prescale-no-hpa"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).Replicas(3)
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).StackGC(3, 15).Replicas(3)
 
 	// create stack with 3 replicas
 	firstStack := "v1"
@@ -81,7 +81,7 @@ func TestPrescalingWithoutHPA(t *testing.T) {
 func TestPrescalingWithHPA(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-prescale-hpa"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).StackGC(3, 15).
 		HPA(1, 10).Replicas(3)
 
 	// create first stack with 3 replicas
@@ -153,7 +153,7 @@ func TestPrescalingPreventDelete(t *testing.T) {
 	stackPrescalingTimeout := 5
 	t.Parallel()
 	stacksetName := "stackset-prevent-delete"
-	factory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress().Replicas(3)
+	factory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress(nil).Replicas(3)
 
 	// create stackset with first version
 	firstVersion := "v1"
@@ -234,7 +234,7 @@ func TestPrescalingWaitsForBackends(t *testing.T) {
 
 	t.Parallel()
 	stacksetName := "stackset-prescale-backends-wait"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress().StackGC(3, 15).Replicas(3)
+	specFactory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).StackGC(3, 15).Replicas(3)
 
 	// create stack with 3 replicas
 	firstStack := "v1"

--- a/cmd/e2e/traffic_switch_test.go
+++ b/cmd/e2e/traffic_switch_test.go
@@ -33,7 +33,7 @@ func TestTrafficSwitchStackset(t *testing.T) {
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
 	updatedVersion := "v2"
 	updatedStack := fmt.Sprintf("%s-%s", stacksetName, updatedVersion)
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil)
 	spec := factory.Create(firstVersion)
 	err := createStackSet(stacksetName, 0, spec)
 	require.NoError(t, err)

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -47,7 +47,7 @@ func TestStackTTLWithoutIngress(t *testing.T) {
 func TestStackTTLWithIngress(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-ingress"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 15).Ingress()
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(3, 15).Ingress(nil)
 
 	// Create 6 stacks each with an ingress
 	for i := 0; i < 6; i++ {
@@ -140,7 +140,7 @@ func TestStackTTLWithExternalIngress(t *testing.T) {
 func TestStackTTLForLatestStack(t *testing.T) {
 	t.Parallel()
 	stacksetName := "stackset-ttl-last-stack"
-	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress()
+	specFactory := NewTestStacksetSpecFactory(stacksetName).StackGC(1, 15).Ingress(nil)
 
 	// Create 2 stacks in total and wait for their deployments to come up
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
We had an issue where ingress annotations where dropped when we enabled StackSet CRD validation. Include setting an annotation in the e2e tests.

Also tests setting annotation on the optional service definition. 