### PR TITLE
Sort RG backends to have stable RG generation

### DIFF
--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
@@ -389,6 +390,11 @@ func (sc *StackContainer) GenerateRouteGroup() (*rgv1.RouteGroup, error) {
 		}
 		result.Spec.Backends = append(result.Spec.Backends, backend)
 	}
+
+	// sort backends to ensure have a consistent generated RoutGroup resource
+	sort.Slice(result.Spec.Backends, func(i, j int) bool {
+		return result.Spec.Backends[i].Name < result.Spec.Backends[j].Name
+	})
 
 	return result, nil
 }

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -197,6 +197,14 @@ func (ssc *StackSetContainer) GenerateRouteGroup() (*rgv1.RouteGroup, error) {
 		result.Spec.Backends = append(result.Spec.Backends, additionalBackend)
 	}
 
+	// sort backends/defaultBackends to ensure have a consistent generated RoutGroup resource
+	sort.Slice(result.Spec.Backends, func(i, j int) bool {
+		return result.Spec.Backends[i].Name < result.Spec.Backends[j].Name
+	})
+	sort.Slice(result.Spec.DefaultBackends, func(i, j int) bool {
+		return result.Spec.DefaultBackends[i].BackendName < result.Spec.DefaultBackends[j].BackendName
+	})
+
 	return result, nil
 }
 

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -1084,14 +1083,6 @@ func TestStackSetGenerateRouteGroup(t *testing.T) {
 	}
 	routegroup, err := c.GenerateRouteGroup()
 	require.NoError(t, err)
-
-	// sort for stable comparison
-	sort.Slice(routegroup.Spec.Backends, func(i, j int) bool {
-		return routegroup.Spec.Backends[i].Name < routegroup.Spec.Backends[j].Name
-	})
-	sort.Slice(routegroup.Spec.DefaultBackends, func(i, j int) bool {
-		return routegroup.Spec.DefaultBackends[i].BackendName < routegroup.Spec.DefaultBackends[j].BackendName
-	})
 
 	expected := &rgv1.RouteGroup{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Sort the RouteGroup backends and default backends by name when generating RouteGroups to ensure that the generated resource doesn't change unless the input changes. Without this the controller may continuously update the resources without any functional change but emitting a lot of useless update events doing so.