### PR TITLE
Add support for multiple cluster domains

### DIFF
--- a/cmd/e2e/README.md
+++ b/cmd/e2e/README.md
@@ -4,8 +4,9 @@ The following environment variables should be set:
 
 1. `E2E_NAMESPACE` is the namespace where the tests should be run.
 2. `CLUSTER_DOMAIN` is the DNS domain managed in which ingresses should be created
-3. `CONTROLLER_ID` is set so that all stacks are only managed by the controller being currently tested.
-4. `KUBECONFIG` with the path to the kubeconfig file
+3. `CLUSTER_DOMAIN_INTERNAL` is the internal DNS domain managed in which ingresses should be created
+4. `CONTROLLER_ID` is set so that all stacks are only managed by the controller being currently tested.
+5. `KUBECONFIG` with the path to the kubeconfig file
 
 To run the tests run the command:
 
@@ -35,5 +36,5 @@ make
 4. rebuild e2e test and run e2e tests in `foo` namespace
 ```
 rm -f build/e2e; make build/e2e
-CLUSTER_DOMAIN=example.org CLUSTER_NAME=example E2E_NAMESPACE=foo CONTROLLER_ID=foo KUBECONFIG=$HOME/.kube/config ./build/e2e -test.v #-test.run=TestTrafficSwitch
+CLUSTER_DOMAIN=example.org CLUSTER_DOMAIN_INTERNAL=ingress.cluster.local CLUSTER_NAME=example E2E_NAMESPACE=foo CONTROLLER_ID=foo KUBECONFIG=$HOME/.kube/config ./build/e2e -test.v #-test.run=TestTrafficSwitch
 ```

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -21,7 +21,7 @@ import (
 var (
 	kubernetesClient, stacksetClient, routegroupClient = createClients()
 	namespace                                          = requiredEnvar("E2E_NAMESPACE")
-	clusterDomain                                      = requiredEnvar("CLUSTER_DOMAIN")
+	clusterDomains                                     = []string{requiredEnvar("CLUSTER_DOMAIN"), requiredEnvar("CLUSTER_DOMAIN_INTERNAL")}
 	controllerId                                       = os.Getenv("CONTROLLER_ID")
 )
 
@@ -94,6 +94,10 @@ func requiredEnvar(envar string) string {
 	return namespace
 }
 
-func hostname(stacksetName string) string {
-	return fmt.Sprintf("%s-%s.%s", namespace, stacksetName, clusterDomain)
+func hostnames(stacksetName string) []string {
+	names := make([]string, 0, len(clusterDomains))
+	for _, domain := range clusterDomains {
+		names = append(names, fmt.Sprintf("%s-%s.%s", namespace, stacksetName, domain))
+	}
+	return names
 }

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -34,7 +34,7 @@ var (
 		Interval                    time.Duration
 		APIServer                   *url.URL
 		MetricsAddress              string
-		ClusterDomain               string
+		ClusterDomains              []string
 		NoTrafficScaledownTTL       time.Duration
 		ControllerID                string
 		BackendWeightsAnnotationKey string
@@ -51,7 +51,7 @@ func main() {
 	kingpin.Flag("metrics-address", "defines where to serve metrics").Default(defaultMetricsAddress).StringVar(&config.MetricsAddress)
 	kingpin.Flag("controller-id", "ID of the controller used to determine ownership of StackSet resources").StringVar(&config.ControllerID)
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
-	kingpin.Flag("cluster-domain", "Main domain of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_DOMAIN").Required().StringVar(&config.ClusterDomain)
+	kingpin.Flag("cluster-domain", "Main domains of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_DOMAIN").Required().StringsVar(&config.ClusterDomains)
 	kingpin.Flag("enable-routegroup-support", "Enable support for RouteGroups on StackSets.").Default("false").BoolVar(&config.RouteGroupSupportEnabled)
 	kingpin.Flag("ingress-source-switch-ttl", "The ttl before an ingress source is deleted when replaced with another one e.g. switching from RouteGroup to Ingress or vice versa.").
 		Default(defaultIngressSourceSwitchTTL).DurationVar(&config.IngressSourceSwitchTTL)
@@ -76,7 +76,7 @@ func main() {
 		client,
 		config.ControllerID,
 		config.BackendWeightsAnnotationKey,
-		config.ClusterDomain,
+		config.ClusterDomains,
 		prometheus.DefaultRegisterer,
 		config.Interval,
 		config.RouteGroupSupportEnabled,

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -55,7 +55,7 @@ type StackSetController struct {
 	client                      clientset.Interface
 	controllerID                string
 	backendWeightsAnnotationKey string
-	clusterDomain               string
+	clusterDomains              []string
 	interval                    time.Duration
 	stacksetEvents              chan stacksetEvent
 	stacksetStore               map[types.UID]zv1.StackSet
@@ -87,7 +87,7 @@ func now() string {
 }
 
 // NewStackSetController initializes a new StackSetController.
-func NewStackSetController(client clientset.Interface, controllerID, backendWeightsAnnotationKey, clusterDomain string, registry prometheus.Registerer, interval time.Duration, routeGroupSupportEnabled bool, ingressSourceSwitchTTL time.Duration) (*StackSetController, error) {
+func NewStackSetController(client clientset.Interface, controllerID, backendWeightsAnnotationKey string, clusterDomains []string, registry prometheus.Registerer, interval time.Duration, routeGroupSupportEnabled bool, ingressSourceSwitchTTL time.Duration) (*StackSetController, error) {
 	metricsReporter, err := core.NewMetricsReporter(registry)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func NewStackSetController(client clientset.Interface, controllerID, backendWeig
 		client:                      client,
 		controllerID:                controllerID,
 		backendWeightsAnnotationKey: backendWeightsAnnotationKey,
-		clusterDomain:               clusterDomain,
+		clusterDomains:              clusterDomains,
 		interval:                    interval,
 		stacksetEvents:              make(chan stacksetEvent, 1),
 		stacksetStore:               make(map[types.UID]zv1.StackSet),
@@ -232,7 +232,7 @@ func (c *StackSetController) collectResources(ctx context.Context) (map[types.UI
 			}
 		}
 
-		stacksetContainer := core.NewContainer(&stackset, reconciler, c.backendWeightsAnnotationKey, c.clusterDomain)
+		stacksetContainer := core.NewContainer(&stackset, reconciler, c.backendWeightsAnnotationKey, c.clusterDomains)
 		stacksets[uid] = stacksetContainer
 	}
 

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -57,14 +57,13 @@ func NewTestEnvironment() *testEnvironment {
 		rgClient:  rgfake.NewSimpleClientset(),
 	}
 
-	controller, err := NewStackSetController(client, "", "", "", prometheus.NewPedanticRegistry(), time.Minute, true, time.Minute)
+	controller, err := NewStackSetController(client, "", "", nil, prometheus.NewPedanticRegistry(), time.Minute, true, time.Minute)
+	if err != nil {
+		panic(err)
+	}
 
 	controller.now = func() string {
 		return timeNow
-	}
-
-	if err != nil {
-		panic(err)
 	}
 
 	return &testEnvironment{

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -46,6 +46,8 @@ pipeline:
         value: "#{CDP_BUILD_VERSION}"
       - name: CLUSTER_DOMAIN
         value: stups-test.zalan.do
+      - name: CLUSTER_DOMAIN_INTERNAL
+        value: ingress.cluster.local
     end2end_tests:
       metadata:
         name: e2e
@@ -63,6 +65,8 @@ pipeline:
                 value: "#{CDP_BUILD_VERSION}"
               - name: CLUSTER_DOMAIN
                 value: stups-test.zalan.do
+              - name: CLUSTER_DOMAIN_INTERNAL
+                value: ingress.cluster.local
               - name: "E2E_NAMESPACE"
                 valueFrom:
                   fieldRef:

--- a/e2e/apply/deployment.yaml
+++ b/e2e/apply/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         args:
           - "--controller-id={{{CONTROLLER_ID}}}"
           - "--cluster-domain={{{CLUSTER_DOMAIN}}}"
+          - "--cluster-domain={{{CLUSTER_DOMAIN_INTERNAL}}}"
           - "--enable-routegroup-support"
           - "--ingress-source-switch-ttl=1m"
         resources:

--- a/go.sum
+++ b/go.sum
@@ -592,9 +592,11 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -670,6 +672,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -678,6 +681,7 @@ golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -685,6 +689,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -729,12 +734,18 @@ golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5 h1:UaoXseXAWUJUcuJ2E2oczJdLxAJXL0lOmVaBl7kuk+I=
@@ -763,7 +774,9 @@ google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
+google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -279,8 +279,8 @@ func TestStackGenerateIngress(t *testing.T) {
 			Hosts: []string{"foo.example.org", "foo.example.com"},
 			Path:  "example",
 		},
-		backendPort:   &backendPort,
-		clusterDomain: "example.org",
+		backendPort:    &backendPort,
+		clusterDomains: []string{"example.org"},
 	}
 	ingress, err := c.GenerateIngress()
 	require.NoError(t, err)

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -284,6 +284,11 @@ func (ssc *StackSetContainer) GenerateIngress() (*networking.Ingress, error) {
 		result.Spec.Rules = append(result.Spec.Rules, r)
 	}
 
+	// sort rules by host to have a consistent generated ingress resource.
+	sort.Slice(result.Spec.Rules, func(i, j int) bool {
+		return result.Spec.Rules[i].Host < result.Spec.Rules[j].Host
+	})
+
 	actualWeightsData, err := json.Marshal(&actualWeights)
 	if err != nil {
 		return nil, err

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -473,13 +473,13 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 
 func TestStackSetUpdateFromResourcesClusterDomain(t *testing.T) {
 	c := dummyStacksetContainer()
-	c.clusterDomain = "foo.example.org"
+	c.clusterDomains = []string{"foo.example.org"}
 
 	err := c.UpdateFromResources()
 	require.NoError(t, err)
 
 	for _, sc := range c.StackContainers {
-		require.Equal(t, c.clusterDomain, sc.clusterDomain)
+		require.Equal(t, c.clusterDomains, sc.clusterDomains)
 	}
 }
 
@@ -958,7 +958,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 		Spec: networking.IngressSpec{
 			Rules: []networking.IngressRule{
 				{
-					Host: "example.org",
+					Host: "example.com",
 					IngressRuleValue: networking.IngressRuleValue{
 						HTTP: &networking.HTTPIngressRuleValue{
 							Paths: []networking.HTTPIngressPath{
@@ -988,7 +988,7 @@ func TestStackSetGenerateIngress(t *testing.T) {
 					},
 				},
 				{
-					Host: "example.com",
+					Host: "example.org",
 					IngressRuleValue: networking.IngressRuleValue{
 						HTTP: &networking.HTTPIngressRuleValue{
 							Paths: []networking.HTTPIngressPath{

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -62,9 +62,9 @@ type StackSetContainer struct {
 	// traffic.DefaultBackendWeightsAnnotationKey
 	backendWeightsAnnotationKey string
 
-	// clusterDomain stores the main domain name of the cluster; per-stack ingress hostnames
-	// are not generated for names outside of it
-	clusterDomain string
+	// clusterDomains stores the main domain names of the cluster;
+	// per-stack ingress hostnames are not generated for names outside of them
+	clusterDomains []string
 }
 
 // StackContainer is a container for storing the full state of a Stack
@@ -86,7 +86,7 @@ type StackContainer struct {
 	routeGroupSpec *zv1.RouteGroupSpec
 	scaledownTTL   time.Duration
 	backendPort    *intstr.IntOrString
-	clusterDomain  string
+	clusterDomains []string
 
 	// Fields from the stack itself, with some defaults applied
 	stackReplicas int32
@@ -181,13 +181,13 @@ type StackResources struct {
 	RouteGroup *rgv1.RouteGroup
 }
 
-func NewContainer(stackset *zv1.StackSet, reconciler TrafficReconciler, backendWeightsAnnotationKey, clusterDomain string) *StackSetContainer {
+func NewContainer(stackset *zv1.StackSet, reconciler TrafficReconciler, backendWeightsAnnotationKey string, clusterDomains []string) *StackSetContainer {
 	return &StackSetContainer{
 		StackSet:                    stackset,
 		StackContainers:             map[types.UID]*StackContainer{},
 		TrafficReconciler:           reconciler,
 		backendWeightsAnnotationKey: backendWeightsAnnotationKey,
-		clusterDomain:               clusterDomain,
+		clusterDomains:              clusterDomains,
 	}
 }
 
@@ -309,7 +309,7 @@ func (ssc *StackSetContainer) UpdateFromResources() error {
 		sc.backendPort = backendPort
 		sc.routeGroupSpec = routeGroupSpec
 		sc.scaledownTTL = scaledownTTL
-		sc.clusterDomain = ssc.clusterDomain
+		sc.clusterDomains = ssc.clusterDomains
 		sc.updateFromResources()
 	}
 


### PR DESCRIPTION
This extends the `--cluster-domain` flag introduced in #202 to represent a list of cluster domains (define the flag multiple times to define more domains).
This allows generating per stack ingresses/routegroups for multiple types of cluster domains i.e. for a public name like `example.org` and for an internal name like `ingress.cluster.local` as defined in the Zalando Kubernetes infrastructure.

The per stack ingress/rouegroup will only contain hostnames for cluster domains which are defined on the stackset. I.e. if the clusters domains are defined as: `[example.org,ingress.cluster.local]` and a stackset defines only `app.ingress.cluster.local`, then the per stack ingress/routegroup will only have `<stack>.ingress.cluster.local` defined and vice versa.
