### PR TITLE
Look at the RouteGroup/Ingress UpdateTimestamp rather than CreationTimestamp

### DIFF
--- a/cmd/e2e/ingress_source_switch_test.go
+++ b/cmd/e2e/ingress_source_switch_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
+	"github.com/zalando-incubator/stackset-controller/controller"
+)
+
+const (
+	// The e2e env IngressSourceSwitchTTL
+	IngressSourceSwitchTTL = time.Minute
+)
+
+func TestIngressSourceSwitch(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "ingress-source-switch-stackset"
+	firstVersion := "v1"
+
+	// create stackset with ingress
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil)
+	spec := factory.Create(firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+	ingress, err := waitForIngress(t, stacksetName)
+	require.NoError(t, err)
+	require.Contains(t, ingress.Annotations, controller.ControllerLastUpdatedAnnotationKey)
+	require.NotEqual(t, "", ingress.Annotations[controller.ControllerLastUpdatedAnnotationKey])
+
+	// update stackset adding a routegroup
+	updatedVersion := "v2"
+	spec = factory.RouteGroup().Create(updatedVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	rg, err := waitForRouteGroup(t, stacksetName)
+	require.NoError(t, err)
+	firstRgUpdatedTimestamp := ingress.Annotations[controller.ControllerLastUpdatedAnnotationKey]
+	require.Contains(t, rg.Annotations, controller.ControllerLastUpdatedAnnotationKey)
+	require.NotEqual(t, "", firstRgUpdatedTimestamp)
+	secondIngress, err := waitForIngress(t, stacksetName)
+	require.Equal(t, secondIngress.Annotations[controller.ControllerLastUpdatedAnnotationKey], ingress.Annotations[controller.ControllerLastUpdatedAnnotationKey])
+	require.NoError(t, err)
+
+	// update the routegroup and delete the ingress
+	lastVersion := "v3"
+	lastSpec := spec
+	lastSpec.StackTemplate.Spec.Version = lastVersion
+	lastSpec.RouteGroup.AdditionalBackends = []v1.RouteGroupBackend{{Name: "shunt", Type: v1.ShuntRouteGroupBackend}}
+	lastSpec.Ingress = nil
+	err = updateStackset(stacksetName, lastSpec)
+	require.NoError(t, err)
+	lastRg, err := waitForUpdatedRouteGroup(t, rg.Name, rg.Annotations[controller.ControllerLastUpdatedAnnotationKey])
+	require.NoError(t, err)
+	require.NotEqual(t, lastRg.Annotations[controller.ControllerLastUpdatedAnnotationKey], firstRgUpdatedTimestamp)
+	// If the ingress is not deleted right away, then, it respects the
+	// TTL.
+	err = resourceDeleted(t, "ingress", stacksetName, ingressInterface()).await()
+	require.Error(t, err)
+
+	// make sure the ingress is finally deleted after twice the TTL
+	a := resourceDeleted(t, "ingress", stacksetName, ingressInterface())
+	a.timeout += IngressSourceSwitchTTL * 2
+	err = a.await()
+	require.NoError(t, err)
+}
+
+func TestIngressToRouteGroupSwitch(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "ingress-to-routegroup-switch"
+	firstVersion := "v1"
+
+	// create stackset with ingress and routegroup
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).RouteGroup()
+	spec := factory.Create(firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+	rg, err := waitForRouteGroup(t, stacksetName)
+	require.NoError(t, err)
+
+	// Wait the IngressSourceSwitchTTL to make sure the ingress is
+	// created a time long enough ago.
+	time.Sleep(IngressSourceSwitchTTL)
+
+	// update the routegroup and delete the ingress
+	lastVersion := "v2"
+	lastSpec := spec
+	lastSpec.StackTemplate.Spec.Version = lastVersion
+	lastSpec.RouteGroup.AdditionalBackends = []v1.RouteGroupBackend{{Name: "shunt", Type: v1.ShuntRouteGroupBackend}}
+	lastSpec.Ingress = nil
+	err = updateStackset(stacksetName, lastSpec)
+	require.NoError(t, err)
+	_, err = waitForUpdatedRouteGroup(t, rg.Name, rg.Annotations[controller.ControllerLastUpdatedAnnotationKey])
+	require.NoError(t, err)
+
+	// make sure ingress is not deleted before IngressSourceSwitchTTL
+	err = resourceDeleted(t, "ingress", stacksetName, ingressInterface()).await()
+	require.Error(t, err)
+}
+
+func TestRouteGroupToIngressSwitch(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "routegroup-to-ingress-switch"
+	firstVersion := "v1"
+
+	// create stackset with ingress and routegroup
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress(nil).RouteGroup()
+	spec := factory.Create(firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+	ing, err := waitForIngress(t, stacksetName)
+	require.NoError(t, err)
+
+	// Wait the IngressSourceSwitchTTL to make sure the RouteGroup is
+	// created a time long enough ago.
+	time.Sleep(IngressSourceSwitchTTL)
+
+	// update the Ingress and delete the RouteGroup
+	lastVersion := "v2"
+	lastSpec := spec
+	lastSpec.StackTemplate.Spec.Version = lastVersion
+	lastSpec.Ingress.Annotations["a-random-annotation"] = "a-random-annotation-value"
+	lastSpec.RouteGroup = nil
+	err = updateStackset(stacksetName, lastSpec)
+	require.NoError(t, err)
+	_, err = waitForUpdatedIngress(t, ing.Name, ing.Annotations[controller.ControllerLastUpdatedAnnotationKey])
+	require.NoError(t, err)
+
+	// make sure ingress is not deleted before IngressSourceSwitchTTL
+	err = resourceDeleted(t, "routegroup", stacksetName, routegroupInterface()).await()
+	require.Error(t, err)
+}

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -24,6 +24,13 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+var (
+	timeNow = time.Now().Format(time.RFC3339)
+	// ttl for the test environment is time.Minute, here
+	// timeOldEnough is set to twice this value.
+	timeOldEnough = time.Now().Add(-2 * time.Minute).Format(time.RFC3339)
+)
+
 type testClient struct {
 	kubernetes.Interface
 	ssClient ssinterface.Interface
@@ -51,6 +58,11 @@ func NewTestEnvironment() *testEnvironment {
 	}
 
 	controller, err := NewStackSetController(client, "", "", "", prometheus.NewPedanticRegistry(), time.Minute, true, time.Minute)
+
+	controller.now = func() string {
+		return timeNow
+	}
+
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/apply/deployment.yaml
+++ b/e2e/apply/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           - "--controller-id={{{CONTROLLER_ID}}}"
           - "--cluster-domain={{{CLUSTER_DOMAIN}}}"
           - "--enable-routegroup-support"
+          - "--ingress-source-switch-ttl=1m"
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
The HTTP resources (Ingresses and RouteGroups) migration, introduced on
the [#251][0], checks for the `CreationTimestamp` attribute of the
resources. When the migration follows the path of:

1. adding a new resource (does not matter if it's an Ingress or
   RouteGroup) with a new hostname for migration and testing purposes;
2. validating the configuration of the new resource.
3. dropping the old resource in favor of the new one. For that the new
   resource receives the actual hostname.

the controller does not respect the [`IngressSourceSwitchTTL`][1]
duration as expected. During the 3rd step, the `CreationTimestamp`
attribute of the new resource tends to be greater than the
`IngressSourceSwitchTTL` configuration, due to the time spent in the 2nd
step. That leads to the almost instantaneous deletion of the old
resource, without considering the configured TTL for routes propagation.

This commit introduces a new annotation to the above-mentioned
resources: `stackset-controller.zalando.org/updated-timestamp`. This
annotation is responsible for tracking the last time the controller
updated a resource. Also, it changes the migration process introduced
on the [#251][0] to compare `IngressSourceSwitchTTL` with the newly
added annotation instead of the `CreationTimestamp` attribute. This way,
the change of hostname on the new resource, during the 3rd step, resets
the timer to delete the old resource and guarantees route propagation.

Also, it adds a new e2e test file. This new test create the above
mentioned migration process and verifies that the controller delete the
old resources after the `IngressSourceSwitchTTL` duration.

As a minor change, this commit also updates the `run_e2e.sh` script,
allowing one to define the environment variable `TEST_NAME`. It will set
the maximum parallelism to 1 and run the given test name.

[0]: #251
[1]: https://github.com/zalando-incubator/stackset-controller/blob/e72232e799e5ff8ba5b51d29dc5ddff153907162/cmd/stackset-controller/main.go#L42