### PR TITLE
Change references from Nginx to Skipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,13 @@ spec:
       podTemplate:
         spec:
           containers:
-          - name: nginx
-            image: nginx
+          - name: skipper
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+            args:
+            - skipper
+            - -inline-routes
+            - '* -> inlineContent("OK") -> <shunt>'
+            - -address=:80
             ports:
             - containerPort: 80
               name: ingress
@@ -135,8 +140,12 @@ spec:
   podTemplate:
     spec:
       containers:
-      - image: nginx
-        name: nginx
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+        args:
+        - skipper
+        - -inline-routes
+        - '* -> inlineContent("OK") -> <shunt>'
+        - -address=:80
         ports:
         - containerPort: 80
           name: ingress

--- a/cmd/e2e/basic_test.go
+++ b/cmd/e2e/basic_test.go
@@ -109,7 +109,7 @@ func (f *TestStacksetSpecFactory) Create(stackVersion string) zv1.StackSetSpec {
 				StackSpec: zv1.StackSpec{
 					Replicas: pint32(f.replicas),
 					PodTemplate: zv1.PodTemplateSpec{
-						Spec: nginxPod,
+						Spec: skipperPod,
 					},
 					Service: &zv1.StackServiceSpec{
 						EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -38,11 +38,17 @@ const (
 )
 
 var (
-	nginxPod = corev1.PodSpec{
+	skipperPod = corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
-				Name:  "nginx",
-				Image: "nginx",
+				Name:  "skipper",
+				Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
+				Args: []string{
+					"skipper",
+					"-inline-routes",
+					`* -> inlineContent("OK") -> <shunt>`,
+					"-address=:80",
+				},
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 80,

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -56,7 +56,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			Containers: []v1.Container{
 				{
 					Name:  "foo",
-					Image: "nginx",
+					Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			Containers: []v1.Container{
 				{
 					Name:  "bar",
-					Image: "nginx",
+					Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 				},
 			},
 		},

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -274,7 +274,7 @@ func TestCreateCurrentStack(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "foo",
-							Image: "nginx",
+							Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 						},
 					},
 				},

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -33,8 +33,13 @@ spec:
       podTemplate:
         spec:
           containers:
-          - name: nginx
-            image: nginx
+          - name: skipper
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+            args:
+            - skipper
+            - -inline-routes
+            - '* -> inlineContent("OK") -> <shunt>'
+            - -address=:80
             ports:
             - containerPort: 80
 ```
@@ -62,8 +67,13 @@ for the container:
 
 ```yaml
 containers:
-- name: nginx
-  image: nginx
+- name: skipper
+  image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+  args:
+  - skipper
+  - -inline-routes
+  - '* -> inlineContent("OK") -> <shunt>'
+  - -address=:80
   ports:
   - containerPort: 80
 ```
@@ -119,8 +129,15 @@ spec:
       podTemplate:
         spec:
           containers:
-          - name: nginx
-            image: nginx-with-metrics
+          - name: skipper
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+            args:
+            - skipper
+            - -inline-routes
+            - 'Path("/metrics") -> inlineContent("app_amazing_metric 42") -> <shunt>'
+            - -inline-routes
+            - '* -> inlineContent("OK") -> <shunt>'
+            - -address=:80
             ports:
             - containerPort: 8080
               name: ingress

--- a/docs/stackset.yaml
+++ b/docs/stackset.yaml
@@ -24,8 +24,13 @@ spec:
       podTemplate:
         spec:
           containers:
-          - name: nginx
-            image: nginx
+          - name: skipper
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+            args:
+            - skipper
+            - -inline-routes
+            - '* -> inlineContent("OK") -> <shunt>'
+            - -address=:80
             ports:
             - containerPort: 80
               name: ingress

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -30,8 +30,13 @@ spec:
             application: "e2e-deploy-sample"
         spec:
           containers:
-          - name: "e2e-deploy-sample"
-            image: nginx
+          - name: skipper
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.194
+            args:
+            - skipper
+            - -inline-routes
+            - '* -> inlineContent("OK") -> <shunt>'
+            - -address=:80
             ports:
             - containerPort: 80
             resources:

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -646,7 +646,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 								Containers: []v1.Container{
 									{
 										Name:  "foo",
-										Image: "nginx",
+										Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 									},
 								},
 							},
@@ -687,7 +687,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Name:  "foo",
-									Image: "nginx",
+									Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 								},
 							},
 						},
@@ -794,7 +794,7 @@ func TestGenerateHPA(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "foo",
-							Image: "nginx",
+							Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.194",
 						},
 					},
 				},


### PR DESCRIPTION
The e2e tests and documentation files are using Nginx docker image as an
example. It makes e2e test to pull multiple times this image from
Dockerhub. We are reaching their [rate-limit][0] and our e2e tests are
breaking frequently.

This commit changes all the references to the Nginx image to the skipper
image, including documentation.

[0]: https://docs.docker.com/docker-hub/download-rate-limit/