### PR TITLE
Make RG fields required

### DIFF
--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -203,6 +203,8 @@ spec:
                     type: array
                 required:
                 - backendPort
+                - hosts
+                - routes
                 type: object
               stackLifecycle:
                 description: StackLifecycle defines the cleanup rules for old stacks.

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -117,14 +117,14 @@ type StackSetExternalIngressSpec struct {
 type RouteGroupSpec struct {
 	EmbeddedObjectMetaWithAnnotations `json:"metadata,omitempty"`
 	// Hosts is the list of hostnames to add to the routegroup.
-	Hosts []string `json:"hosts,omitempty"`
+	Hosts []string `json:"hosts"`
 	// AdditionalBackends is the list of additional backends to use for
 	// routing.
 	// +optional
 	AdditionalBackends []rg.RouteGroupBackend `json:"additionalBackends,omitempty"`
 	// Routes is the list of routes to be applied to the routegroup.
 	// +kubebuilder:validation:MinItems=1
-	Routes      []rg.RouteGroupRouteSpec `json:"routes,omitempty"`
+	Routes      []rg.RouteGroupRouteSpec `json:"routes"`
 	BackendPort int                      `json:"backendPort"`
 }
 


### PR DESCRIPTION
Make relevant RouteGroup fields required in CRD spec.

Turns out if they're annotated with `omitempty` then they are treated as optional. We want these fields to be required.