### PR TITLE
Use immutable tag for e2e

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -42,7 +42,7 @@ var (
 		Containers: []corev1.Container{
 			{
 				Name:  "skipper",
-				Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+				Image: "registry.opensource.zalan.do/teapot/skipper:v0.13.21",
 				Args: []string{
 					"skipper",
 					"-inline-routes",

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: registry.opensource.zalan.do/teapot/skipper:v0.13.21
             args:
             - skipper
             - -inline-routes


### PR DESCRIPTION
On [#288][0] we changed the e2e to a mutable tag and it breaks the tests
on [kubernetes-on-aws][1] clusters:
```
error creating: pods "stackset..." is forbidden: image policy webhook
backend denied one or more images: Image
registry.opensource.zalan.do/teapot/skipper:latest not allowed as it
uses a mutable tag 'latest'
```

This commit reverts it to the current last version released on Skipper.

[0]: https://github.com/zalando-incubator/stackset-controller/pull/288/files#diff-da249a5fffc31461ef4d1678a049289e3dcc8971cd77539a884ae68f7d768c3eR45
[1]: https://github.com/zalando-incubator/kubernetes-on-aws/pull/3993