### PR TITLE
Stack's RouteGroups inherit annotations

### DIFF
--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -4,6 +4,7 @@ set -euf -o pipefail
 shopt -s nullglob
 
 CLUSTER_DOMAIN=${CLUSTER_DOMAIN:-""}
+CLUSTER_DOMAIN_INTERNAL=${CLUSTER_DOMAIN_INTERNAL:-""}
 CLUSTER_NAME=${CLUSTER_NAME:-""}
 # Set TEST_NAME to run a single test
 # eg.: TEST_NAME=TestIngressToRouteGroupSwitch ./e2e/run_e2e.sh
@@ -12,6 +13,11 @@ CONTROLLER_ID="ssc-e2e-$(dd if=/dev/urandom bs=8 count=1 2>/dev/null | hexdump -
 
 if [[ -z "${CLUSTER_DOMAIN}" ]]; then
   echo "Please specify the cluster domain via CLUSTER_DOMAIN."
+  exit 0
+fi
+
+if [[ -z "${CLUSTER_DOMAIN_INTERNAL}" ]]; then
+  echo "Please specify the cluster domain via CLUSTER_DOMAIN_INTERNAL."
   exit 0
 fi
 
@@ -45,6 +51,8 @@ sscPath=$(find build/ -name "stackset-controller" | head -n 1)
 command $sscPath --apiserver=http://127.0.0.1:8001 \
   --ingress-source-switch-ttl="1m" \
   --enable-routegroup-support \
+  --cluster-domain=${CLUSTER_DOMAIN} \
+  --cluster-domain=${CLUSTER_DOMAIN_INTERNAL} \
   --controller-id=$CONTROLLER_ID 2>$controllerLog&
 
 # Create the Kubernetes namespace to be used for this test run.

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -449,6 +449,9 @@ func (sc *StackContainer) GenerateRouteGroup() (*rgv1.RouteGroup, error) {
 		return result.Spec.Backends[i].Name < result.Spec.Backends[j].Name
 	})
 
+	// insert annotations
+	result.Annotations = mergeLabels(result.Annotations, sc.routeGroupSpec.Annotations)
+
 	return result, nil
 }
 

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -1080,6 +1080,11 @@ func TestStackSetGenerateRouteGroup(t *testing.T) {
 			},
 			Spec: zv1.StackSetSpec{
 				RouteGroup: &zv1.RouteGroupSpec{
+					EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
+						Annotations: map[string]string{
+							"routegroup": "annotation",
+						},
+					},
 					Hosts: []string{"example.org", "example.com"},
 					AdditionalBackends: []rgv1.RouteGroupBackend{
 						{
@@ -1121,6 +1126,9 @@ func TestStackSetGenerateRouteGroup(t *testing.T) {
 			Labels: map[string]string{
 				"stackset":       "foo",
 				"stackset-label": "foobar",
+			},
+			Annotations: map[string]string{
+				"routegroup": "annotation",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
The RouteGroups generated per Stack are not receiving the annotations
from StackSet's RouteGroups definition. It can lead to a wide range of
bug reports and is a non-expected behaviour.

This commit adds the procedure to copy the annotations from the
StackSet's RouteGroups spec and tests.