### PR TITLE
Fix the panic on ZMON metrics

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -984,6 +984,7 @@ func (c *StackSetController) ReconcileStackResources(ctx context.Context, ssc *c
 func (c *StackSetController) ReconcileStackSet(ctx context.Context, container *core.StackSetContainer) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			c.metricsReporter.ReportPanic()
 			c.stacksetLogger(container).Errorf("Encountered a panic while processing a stackset: %v\n%s", r, debug.Stack())
 			err = fmt.Errorf("panic: %v", r)
 		}

--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -3,6 +3,7 @@ package core
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -29,6 +30,10 @@ const (
 	zmonCheckTagAnnotationPrefix = "metric-config.external.zmon-check.zmon/tag-"
 	sqsQueueNameTag              = "queue-name"
 	sqsQueueRegionTag            = "region"
+)
+
+var (
+	errMissingZMONDefinition = errors.New("missing ZMON metric definition")
 )
 
 type MetricsList []autoscaling.MetricSpec
@@ -208,6 +213,11 @@ func zmonMetric(metrics zv1.AutoscalerMetrics, stackName, namespace string) (*au
 		return nil, nil, fmt.Errorf("average not specified")
 	}
 	average := metrics.Average.DeepCopy()
+
+	if metrics.ZMON == nil {
+		return nil, nil, errMissingZMONDefinition
+	}
+
 	aggregators := make([]string, 0, len(metrics.ZMON.Aggregators))
 	for _, agg := range metrics.ZMON.Aggregators {
 		aggregators = append(aggregators, string(agg))

--- a/pkg/core/autoscaler_test.go
+++ b/pkg/core/autoscaler_test.go
@@ -263,9 +263,25 @@ func TestPodJsonMetricInvalid(t *testing.T) {
 }
 
 func TestZMONMetricInvalid(t *testing.T) {
-	metrics := zv1.AutoscalerMetrics{Type: zv1.ZMONAutoscalerMetric, Average: nil}
-	_, _, err := zmonMetric(metrics, "stack-name", "namespace")
-	require.Errorf(t, err, "created metric with invalid configuration")
+	onemilli := resource.MustParse("1m")
+	for _, tc := range []struct {
+		name    string
+		metrics zv1.AutoscalerMetrics
+	}{
+		{
+			name:    "missing average",
+			metrics: zv1.AutoscalerMetrics{Type: zv1.ZMONAutoscalerMetric, Average: nil},
+		},
+		{
+			name:    "missing zmon definition",
+			metrics: zv1.AutoscalerMetrics{Type: zv1.ZMONAutoscalerMetric, Average: &onemilli},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := zmonMetric(tc.metrics, "stack-name", "namespace")
+			require.Errorf(t, err, "created metric with invalid configuration")
+		})
+	}
 }
 
 func TestIngressMetricInvalid(t *testing.T) {

--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -27,6 +27,7 @@ type MetricsReporter struct {
 	stackPrescalingActive     *prometheus.GaugeVec
 	stackPrescalingReplicas   *prometheus.GaugeVec
 	errorsCount               prometheus.Counter
+	panicsCount               prometheus.Counter
 }
 
 type resourceKey struct {
@@ -83,6 +84,12 @@ func NewMetricsReporter(registry prometheus.Registerer) (*MetricsReporter, error
 			Name:      "count",
 			Help:      "Number of errors encountered",
 		}),
+		panicsCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystemErrors,
+			Name:      "panic_count",
+			Help:      "Number of panics encountered",
+		}),
 	}
 
 	for _, metric := range []prometheus.Collector{
@@ -93,6 +100,7 @@ func NewMetricsReporter(registry prometheus.Registerer) (*MetricsReporter, error
 		result.stackPrescalingActive,
 		result.stackPrescalingReplicas,
 		result.errorsCount,
+		result.panicsCount,
 	} {
 		err := registry.Register(metric)
 		if err != nil {
@@ -203,4 +211,8 @@ func (reporter *MetricsReporter) removeStackMetrics(labels prometheus.Labels) {
 	reporter.stackReady.Delete(labels)
 	reporter.stackPrescalingActive.Delete(labels)
 	reporter.stackPrescalingReplicas.Delete(labels)
+}
+
+func (reporter *MetricsReporter) ReportPanic() {
+	reporter.panicsCount.Inc()
 }


### PR DESCRIPTION
Changes:
 * Don't crash if a single stackset causes a panic. This should be fairly safe because stacksets are completely independent from each other, and it would allow the rest of the updates to succeed.
 * Correctly validate a missing ZMON metric.