### PR TITLE
Fix the overrides on 1.19, add E2E

### DIFF
--- a/cmd/e2e/basic_test.go
+++ b/cmd/e2e/basic_test.go
@@ -71,6 +71,10 @@ func (f *TestStacksetSpecFactory) Behavior(stabilizationWindowSeconds int32) *Te
 	return f
 }
 
+func (f *TestStacksetSpecFactory) StackName(version string) string {
+	return fmt.Sprintf("%s-%s", f.stacksetName, version)
+}
+
 func (f *TestStacksetSpecFactory) Ingress() *TestStacksetSpecFactory {
 	f.ingress = true
 	return f

--- a/cmd/e2e/custom_stack_resources_test.go
+++ b/cmd/e2e/custom_stack_resources_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
+)
+
+const (
+	customStackIngressRouteGroupAnnotation      = "custom-annotation"
+	customStackIngressRouteGroupAnnotationValue = "custom-annotation-value"
+)
+
+func TestStackIngressCustomAnnotations(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-ingress-custom-annotation"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
+	version := "v1"
+	spec := factory.Create(version)
+	spec.StackTemplate.Spec.IngressOverrides = &zv1.StackIngressRouteGroupOverrides{
+		EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
+			Annotations: map[string]string{customStackIngressRouteGroupAnnotation: customStackIngressRouteGroupAnnotationValue},
+		},
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	stackIngress, err := waitForIngress(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	require.EqualValues(t, customStackIngressRouteGroupAnnotationValue, stackIngress.Annotations[customStackIngressRouteGroupAnnotation])
+	require.NotContains(t, stackIngress.Annotations, userTestAnnotation)
+}
+
+func TestStackIngressCustomHosts(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-ingress-custom-hosts"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
+	version := "v1"
+	spec := factory.Create(version)
+	spec.StackTemplate.Spec.IngressOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Hosts: []string{
+			fmt.Sprintf("custom-$(STACK_NAME).%s", clusterDomain),
+		},
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	stackIngress, err := waitForIngress(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	require.Len(t, stackIngress.Spec.Rules, 1)
+	require.Equal(t, fmt.Sprintf("custom-%s.%s", factory.StackName("v1"), clusterDomain), stackIngress.Spec.Rules[0].Host)
+}
+
+func TestStackIngressEnabled(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-ingress-enabled"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress()
+	version := "v1"
+	spec := factory.Create(version)
+	boolTrue := true
+	spec.StackTemplate.Spec.IngressOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Enabled: &boolTrue,
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	_, err = waitForIngress(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	stack, err := waitForStack(t, stacksetName, version)
+	require.NoError(t, err)
+
+	boolFalse := false
+	stack.Spec.IngressOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Enabled: &boolFalse,
+	}
+	err = updateStack(factory.StackName(version), stack.Spec)
+	require.NoError(t, err)
+
+	err = resourceDeleted(t, "ingress", factory.StackName(version), ingressInterface()).await()
+	require.NoError(t, err)
+}
+
+func TestStackRouteGroupCustomAnnotations(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-routegroup-custom-annotation"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).RouteGroup()
+	version := "v1"
+	spec := factory.Create(version)
+	spec.StackTemplate.Spec.RouteGroupOverrides = &zv1.StackIngressRouteGroupOverrides{
+		EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
+			Annotations: map[string]string{customStackIngressRouteGroupAnnotation: customStackIngressRouteGroupAnnotationValue},
+		},
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	stackRoutegroup, err := waitForRouteGroup(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	require.EqualValues(t, customStackIngressRouteGroupAnnotationValue, stackRoutegroup.Annotations[customStackIngressRouteGroupAnnotation])
+	require.NotContains(t, stackRoutegroup.Annotations, userTestAnnotation)
+}
+
+func TestStackRouteGroupCustomHosts(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-routegroup-custom-hosts"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).RouteGroup()
+	version := "v1"
+	spec := factory.Create(version)
+	spec.StackTemplate.Spec.RouteGroupOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Hosts: []string{
+			fmt.Sprintf("custom-$(STACK_NAME).%s", clusterDomain),
+		},
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	stackRoutegroup, err := waitForRouteGroup(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	require.EqualValues(t, []string{fmt.Sprintf("custom-%s.%s", factory.StackName("v1"), clusterDomain)}, stackRoutegroup.Spec.Hosts)
+}
+
+func TestStackRoutegroupEnabled(t *testing.T) {
+	t.Parallel()
+	stacksetName := "stack-routegroup-enabled"
+
+	factory := NewTestStacksetSpecFactory(stacksetName).RouteGroup()
+	version := "v1"
+	spec := factory.Create(version)
+	boolTrue := true
+	spec.StackTemplate.Spec.RouteGroupOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Enabled: &boolTrue,
+	}
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+
+	_, err = waitForRouteGroup(t, factory.StackName(version))
+	require.NoError(t, err)
+
+	stack, err := waitForStack(t, stacksetName, version)
+	require.NoError(t, err)
+
+	boolFalse := false
+	stack.Spec.RouteGroupOverrides = &zv1.StackIngressRouteGroupOverrides{
+		Enabled: &boolFalse,
+	}
+	err = updateStack(factory.StackName(version), stack.Spec)
+	require.NoError(t, err)
+
+	err = resourceDeleted(t, "routegroup", factory.StackName(version), routegroupInterface()).await()
+	require.NoError(t, err)
+}

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -21,7 +21,9 @@ import (
 var (
 	kubernetesClient, stacksetClient, routegroupClient = createClients()
 	namespace                                          = requiredEnvar("E2E_NAMESPACE")
-	clusterDomains                                     = []string{requiredEnvar("CLUSTER_DOMAIN"), requiredEnvar("CLUSTER_DOMAIN_INTERNAL")}
+	clusterDomain                                      = requiredEnvar("CLUSTER_DOMAIN")
+	clusterDomainInternal                              = requiredEnvar("CLUSTER_DOMAIN_INTERNAL")
+	clusterDomains                                     = []string{clusterDomain, clusterDomainInternal}
 	controllerId                                       = os.Getenv("CONTROLLER_ID")
 )
 

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -395,6 +395,21 @@ func updateStackset(stacksetName string, spec zv1.StackSetSpec) error {
 	}
 }
 
+func updateStack(stackName string, spec zv1.StackSpec) error {
+	for {
+		stack, err := stackInterface().Get(context.Background(), stackName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		stack.Spec = spec
+		_, err = stackInterface().Update(context.Background(), stack, metav1.UpdateOptions{})
+		if apiErrors.IsConflict(err) {
+			continue
+		}
+		return err
+	}
+}
+
 func waitForStack(t *testing.T, stacksetName, stackVersion string) (*zv1.Stack, error) {
 	stackName := fmt.Sprintf("%s-%s", stacksetName, stackVersion)
 	err := resourceCreated(t, "stack", stackName, stackInterface()).await()

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -102,7 +102,7 @@ type StackIngressRouteGroupOverrides struct {
 
 	// Whether to enable per-stack ingresses or routegroups. Defaults to enabled if unset.
 	// +optional
-	Enabled *bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// Hostnames to use for the per-stack ingresses (or route groups). These must contain the special $(STACK_NAME)
 	// token, which will be replaced with the stack's name. Would be automatically generated based on the hosts in the


### PR DESCRIPTION
Follow-up to #329, add E2E tests.

This also fixes the issue with the overrides not working on 1.19 unless `enabled` is set in the template.