### PR TITLE
Use a much higher QPS values for E2E

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -4,4 +4,4 @@ MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 # add binary
 ADD build/linux/e2e /
 
-ENTRYPOINT ["/e2e"]
+ENTRYPOINT ["/e2e", "-test.parallel", "30"]

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -43,6 +43,9 @@ func createClients() (kubernetes.Interface, clientset.Interface, rg.Interface) {
 		panic(err)
 	}
 
+	cfg.QPS = 100
+	cfg.Burst = 100
+
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The defaults are super low, and lead to either E2E taking a ton of time or to occasional failures. Increase to more sensible values.