### PR TITLE
README and example deployment alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ by the `Stack` and will be cleaned up if the stack is deleted.
 
 ## Setup
 
+Use an existing cluster or create a test cluster with [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+```bash
+kind create cluster --name testcluster001
+```
+
 The `stackset-controller` can be run as a deployment in the cluster.
 See [deployment.yaml](/docs/deployment.yaml).
 
@@ -246,13 +252,15 @@ The controller depends on the [StackSet](/docs/stackset_crd.yaml) and
 You must install these into your cluster before running the controller:
 
 ```bash
-$ kubectl apply -f docs/stackset_crd.yaml -f docs/stackset_stack_crd.yaml
+$ kubectl apply -f docs/stackset_crd.yaml -f docs/stack_crd.yaml
 ```
 
 After the CRDs are installed the controller can be deployed:
 
+*please adjust the controller version and cluster-domain to your environment*
+
 ```bash
-$ kubectl apply -f docs/deployment.yaml
+$ kubectl apply -f docs/rbac.yaml -f docs/deployment.yaml
 ```
 
 ### Custom configuration
@@ -291,7 +299,7 @@ And soon after you will see the first `Stack` of the `my-app`
 stackset:
 
 ```bash
-$ kubectl get stacksetstacks
+$ kubectl get stacks
 NAME                  CREATED AT
 my-app-v1             30s
 ```
@@ -319,7 +327,7 @@ Imagine you want to roll out a new version of your stackset. You can do this
 by changing the `StackSet` resource. E.g. by changing the version:
 
 ```bash
-$ kubectl patch apps my-app --type='json' -p='[{"op": "replace", "path": "/spec/stackTemplate/spec/version", "value": "v2"}]'
+$ kubectl patch stackset my-app --type='json' -p='[{"op": "replace", "path": "/spec/stackTemplate/spec/version", "value": "v2"}]'
 stackset.zalando.org/my-app patched
 ```
 

--- a/docs/deployment.yaml
+++ b/docs/deployment.yaml
@@ -20,7 +20,9 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: zalando-incubator/stackset-controller:v0.0.1
+        image: registry.opensource.zalan.do/teapot/stackset-controller:v1.3.37
+        # please adjust this for your environment
+        args: ["--cluster-domain=kubernetes.local"]
         resources:
           limits:
             cpu: 10m

--- a/docs/deployment.yaml
+++ b/docs/deployment.yaml
@@ -22,7 +22,9 @@ spec:
       - name: stackset-controller
         image: registry.opensource.zalan.do/teapot/stackset-controller:v1.3.37
         # please adjust this for your environment
-        args: ["--cluster-domain=kubernetes.local"]
+        # the cluster-domain must match the application domain suffix
+        # Example application domain: my-app.example.org
+        args: ["--cluster-domain=example.org"]
         resources:
           limits:
             cpu: 10m

--- a/docs/rbac.yaml
+++ b/docs/rbac.yaml
@@ -48,6 +48,17 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - services

--- a/docs/stackset.yaml
+++ b/docs/stackset.yaml
@@ -4,8 +4,15 @@ metadata:
   name: my-app
 spec:
   ingress:
-    hosts: [my-app.example.org, alt.name.org]
+    hosts:
+      - my-app.example.org
+      - alt.name.org
     backendPort: 80
+  traffic:
+  - stackName: my-app-v1
+    weight: 40
+  - stackName: my-app-v2
+    weight: 60
   stackLifecycle:
     scaledownTTLSeconds: 300
     limit: 5

--- a/docs/stackset.yaml
+++ b/docs/stackset.yaml
@@ -11,7 +11,7 @@ spec:
     limit: 5
   stackTemplate:
     spec:
-      version: v2
+      version: v1
       replicas: 3
       horizontalPodAutoscaler:
         minReplicas: 3

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -322,6 +323,8 @@ func (sc *StackContainer) stackHostnames(spec ingressOrRouteGroupSpec, overrides
 			for _, domain := range sc.clusterDomains {
 				if strings.HasSuffix(host, domain) {
 					result.Insert(fmt.Sprintf("%s.%s", sc.Name(), domain))
+				} else {
+					log.Debugf("Ingress host: %s suffix did not match cluster-domain %s", host, domain)
 				}
 			}
 		}


### PR DESCRIPTION
Hello everyone,

I tried to use the stackset controller but had no luck so far.
It is maybe because of my changes but I did not get further without them.

I am now at a point where everything seems to be running but the traffic switch is not working.
I suspect that the controller do not recognize the new version as ready and therefore do not do the switch.

In general I also noticed some differences of the output of commands in my test setup (see below).

```bash
kubectl get ingress,service,deployment.apps,hpa -l stackset=my-app
```
will return only one ingress - maybe that is the issue?

```
NAME                               CLASS    HOSTS                             ADDRESS   PORTS   AGE
ingress.networking.k8s.io/my-app   <none>   alt.name.org,my-app.example.org             80      102s

NAME                TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
service/my-app-v1   ClusterIP   10.96.55.11   <none>        80/TCP    103s

NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/my-app-v1   3/3     3            3           103s

NAME                                            REFERENCE              TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/my-app-v1   Deployment/my-app-v1   <unknown>/50%   3         10        3          103s
```

Different result for the traffic command as well

```bash
./build/traffic my-app
```

```
STACK        DESIRED TRAFFIC    ACTUAL TRAFFIC
my-app-v1    50.0%              100.0%
my-app-v2    50.0%              0.0%
```

The traffic switch command seems to work but after some seconds it switch back to the result above (50% / 50%)

```bash
./build/traffic my-app my-app-v2 100
STACK        DESIRED TRAFFIC    ACTUAL TRAFFIC
my-app-v1    0.0%               100.0%
my-app-v2    100.0%             0.0%
```

Both versions seems to run:

```bash
NAME                         READY   STATUS    RESTARTS   AGE
my-app-v1-658884746f-kkq92   1/1     Running   0          6m4s
my-app-v1-658884746f-kv9jc   1/1     Running   0          6m4s
my-app-v1-658884746f-msjqg   1/1     Running   0          6m4s
my-app-v2-547f574-85tmm      1/1     Running   0          3m34s
my-app-v2-547f574-mlcxd      1/1     Running   0          3m34s
my-app-v2-547f574-qrjw5      1/1     Running   0          3m34s
```

I am also able to reach both versions over the internal service (curl my-app-v1.default = OK, curl my-app-v2.default = OK)

The ingress configuration also did not changed all the time (besides the resourceVersion).
I checked the configuration after the creation of the stackset, after the apply of the patch command and after the traffic switch command.

Thanks for making stackset open source curious to hear idea how I can get it working.

Best,
Patrick