### PR TITLE
e2e: increase default wait timeout

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -27,7 +27,7 @@ import (
 type weightKind string
 
 const (
-	defaultWaitTimeout       = 30 * time.Second
+	defaultWaitTimeout       = 60 * time.Second
 	trafficSwitchWaitTimeout = 150 * time.Second
 
 	stacksetHeritageLabelKey = "stackset"


### PR DESCRIPTION
A lot of e2e runs fail and force us to retrigger. Since no one has time to investigate this properly, let's just mitigate this by increasing the default wait timeout.