### PR TITLE
Support RouteGroup autoscaler

### DIFF
--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -169,9 +169,10 @@ specify scaling based on the following metrics:
 3. `AmazonSQS`
 4. `PodJSON`
 5. `Ingress`
-6. `ZMON`
-7. `ScalingSchedule`
-8. `ClusterScalingSchedule`
+6. `RouteGroup`
+7. `ZMON`
+8. `ScalingSchedule`
+9. `ClusterScalingSchedule`
 
 _Note:_ Based on the metrics type specified you may need to also deploy the [kube-metrics-adapter](https://github.com/zalando-incubator/kube-metrics-adapter)
 in your cluster.
@@ -232,6 +233,18 @@ autoscaler:
   maxReplicas: 3
   metrics:
   - type: Ingress
+    average: 30
+```
+
+If using `RouteGroup` instead of `Ingress`, then the following config is the
+equivalent:
+
+```yaml
+autoscaler:
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: RouteGroup
     average: 30
 ```
 

--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -279,6 +279,7 @@ spec:
                           - AmazonSQS
                           - PodJSON
                           - Ingress
+                          - RouteGroup
                           - ZMON
                           - ScalingSchedule
                           - ClusterScalingSchedule

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -521,6 +521,7 @@ spec:
                                   - AmazonSQS
                                   - PodJSON
                                   - Ingress
+                                  - RouteGroup
                                   - ZMON
                                   - ScalingSchedule
                                   - ClusterScalingSchedule

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -264,7 +264,7 @@ type MetricsClusterScalingSchedule struct {
 }
 
 // AutoscalerMetricType is the type of the metric used for scaling.
-// +kubebuilder:validation:Enum=CPU;Memory;AmazonSQS;PodJSON;Ingress;ZMON;ScalingSchedule;ClusterScalingSchedule
+// +kubebuilder:validation:Enum=CPU;Memory;AmazonSQS;PodJSON;Ingress;RouteGroup;ZMON;ScalingSchedule;ClusterScalingSchedule
 type AutoscalerMetricType string
 
 const (
@@ -273,6 +273,7 @@ const (
 	AmazonSQSAutoscalerMetric    AutoscalerMetricType = "AmazonSQS"
 	PodJSONAutoscalerMetric      AutoscalerMetricType = "PodJSON"
 	IngressAutoscalerMetric      AutoscalerMetricType = "Ingress"
+	RouteGroupAutoscalerMetric   AutoscalerMetricType = "RouteGroup"
 	ZMONAutoscalerMetric         AutoscalerMetricType = "ZMON"
 	ClusterScalingScheduleMetric AutoscalerMetricType = "ClusterScalingSchedule"
 	ScalingScheduleMetric        AutoscalerMetricType = "ScalingSchedule"


### PR DESCRIPTION
Adds support for scaling based on RPS by referencing a `RouteGroup` similar to what is possible for `Ingress`.

Additionally it uses the dedicated backend label for ingress and routegroup HPA config as introduced with https://github.com/zalando-incubator/kube-metrics-adapter/pull/350

Depends on:
* https://github.com/zalando-incubator/kube-metrics-adapter/pull/349
* https://github.com/zalando-incubator/kube-metrics-adapter/pull/350