### PR TITLE
Revert dedicated backend label in ingress HPA

### DIFF
--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -230,12 +230,13 @@ func ingressMetric(metrics zv1.AutoscalerMetrics, ingressName, backendName strin
 		Type: autoscaling.ObjectMetricSourceType,
 		Object: &autoscaling.ObjectMetricSource{
 			Metric: autoscaling.MetricIdentifier{
-				Name: requestsPerSecondName,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"backend": backendName,
-					},
-				},
+				Name: fmt.Sprintf("%s,%s", requestsPerSecondName, backendName),
+				// TODO:
+				// Selector: &metav1.LabelSelector{
+				// 	MatchLabels: map[string]string{
+				// 		"backend": backendName,
+				// 	},
+				// },
 			},
 			DescribedObject: autoscaling.CrossVersionObjectReference{
 				APIVersion: "networking.k8s.io/v1",

--- a/pkg/core/autoscaler_test.go
+++ b/pkg/core/autoscaler_test.go
@@ -249,8 +249,8 @@ func TestStackSetController_ReconcileAutoscalersIngress(t *testing.T) {
 	ingressMetrics := hpa.Spec.Metrics[0]
 	require.Equal(t, autoscaling.ObjectMetricSourceType, ingressMetrics.Type)
 	require.Equal(t, int64(80), ingressMetrics.Object.Target.AverageValue.Value())
-	require.Equal(t, ingressMetrics.Object.Metric.Name, "requests-per-second")
-	require.Equal(t, ingressMetrics.Object.Metric.Selector.MatchLabels, map[string]string{"backend": "stackset-v1"})
+	require.Equal(t, ingressMetrics.Object.Metric.Name, "requests-per-second,stackset-v1")
+	// require.Equal(t, ingressMetrics.Object.Metric.Selector.MatchLabels, map[string]string{"backend": "stackset-v1"})
 }
 
 func TestStackSetController_ReconcileAutoscalersRouteGroup(t *testing.T) {


### PR DESCRIPTION
Reverting part of #343 where label based backend identification was introduced. Select backend based on label does not work in the kube-metrics-adapter as it was not fully implemented in https://github.com/zalando-incubator/kube-metrics-adapter/pull/350

Without this multiple stacks can cause the RPS based metrics to flap because the kube-metrics-adapter randomly returns one of the stacks without considering the backend label value.

This does not fix RouteGroup as that depends on the broken label based identifier.