### PR TITLE
Add the type match label

### DIFF
--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -17,21 +17,24 @@ import (
 )
 
 const (
-	requestsPerSecondName        = "requests-per-second"
-	metricConfigJSONPath         = "metric-config.pods.%s.json-path/path"
-	metricConfigJSONKey          = "metric-config.pods.%s.json-path/json-key"
-	metricConfigJSONPort         = "metric-config.pods.%s.json-path/port"
-	sqsQueueLengthTag            = "sqs-queue-length"
-	zmonCheckMetricName          = "zmon-check"
-	zmonCheckCheckIDTag          = "check-id"
-	zmonCheckAggregatorsTag      = "aggregators"
-	zmonCheckDurationTag         = "duration"
-	zmonCheckStackTag            = "stack"
-	zmonCheckKeyAnnotation       = "metric-config.external.zmon-check.zmon/key"
-	zmonCheckTagAnnotationPrefix = "metric-config.external.zmon-check.zmon/tag-"
-	sqsQueueNameTag              = "queue-name"
-	sqsQueueRegionTag            = "region"
-	scalingScheduleAPIVersion    = "zalando.org/v1"
+	metricsTypeLabel                   = "type"
+	requestsPerSecondName              = "requests-per-second"
+	metricConfigJSONPath               = "metric-config.pods.%s.json-path/path"
+	metricConfigJSONKey                = "metric-config.pods.%s.json-path/json-key"
+	metricConfigJSONPort               = "metric-config.pods.%s.json-path/port"
+	zmonCheckMetricName                = "zmon-check"
+	zmonCheckMetricType                = "zmon"
+	zmonCheckCheckIDTag                = "check-id"
+	zmonCheckAggregatorsTag            = "aggregators"
+	zmonCheckDurationTag               = "duration"
+	zmonCheckStackTag                  = "stack"
+	zmonCheckKeyAnnotationFormat       = "metric-config.external.%s.zmon/key"
+	zmonCheckTagAnnotationPrefixFormat = "metric-config.external.%s.zmon/tag-"
+	sqsMetricType                      = "sqs-queue-length"
+	sqsMetricName                      = "sqs-queue-len"
+	sqsQueueNameTag                    = "queue-name"
+	sqsQueueRegionTag                  = "region"
+	scalingScheduleAPIVersion          = "zalando.org/v1"
 )
 
 var (
@@ -42,27 +45,90 @@ var (
 	errMissingClusterScalingScheduleName       = errors.New("missing ClusterScalingSchedule metric object name")
 )
 
-type MetricsList []autoscaling.MetricSpec
+type autoscalerMetricsList []zv1.AutoscalerMetrics
 
-func (l MetricsList) Len() int {
+func (l autoscalerMetricsList) Len() int {
 	return len(l)
 }
 
-func (l MetricsList) Swap(i, j int) {
+func (l autoscalerMetricsList) Swap(i, j int) {
 	temp := l[i]
 	l[i] = l[j]
 	l[j] = temp
 }
 
-func (l MetricsList) Less(i, j int) bool {
-	return l[i].Type < l[j].Type
+func (l autoscalerMetricsList) Less(i, j int) bool {
+	if l[i].Type != l[j].Type {
+		return l[i].Type < l[j].Type
+	}
+
+	if l[i].Average != nil && l[j].Average != nil {
+		iAverage, ok := l[i].Average.AsInt64()
+		if !ok {
+			iAverage = l[i].Average.AsDec().UnscaledBig().Int64()
+		}
+
+		jAverage, ok := l[j].Average.AsInt64()
+		if !ok {
+			jAverage = l[j].Average.AsDec().UnscaledBig().Int64()
+		}
+
+		if iAverage != jAverage {
+			return iAverage < jAverage
+		}
+	}
+
+	if l[i].AverageUtilization != nil && l[j].AverageUtilization != nil {
+		if *l[i].AverageUtilization != *l[j].AverageUtilization {
+			return *l[i].AverageUtilization < *l[j].AverageUtilization
+		}
+	}
+
+	// CPUAutoscalerMetric, MemoryAutoscalerMetric
+	if l[i].Container != "" && l[j].Container != "" {
+		return l[i].Container < l[j].Container
+	}
+
+	// AmazonSQSAutoscalerMetric
+	if l[i].Queue != nil && l[j].Queue != nil {
+		return l[i].Queue.Name < l[j].Queue.Name
+	}
+
+	// PodJSONAutoscalerMetric
+	if l[i].Endpoint != nil && l[j].Endpoint != nil {
+		return l[i].Endpoint.Name < l[j].Endpoint.Name
+	}
+	// ZMONAutoscalerMetric
+	if l[i].ZMON != nil && l[j].ZMON != nil {
+		return l[i].ZMON.CheckID < l[j].ZMON.CheckID
+	}
+	// ExternalRPSMetric
+	if l[i].RequestsPerSecond != nil && l[j].RequestsPerSecond != nil {
+		return strings.Join(l[i].RequestsPerSecond.Hostnames, ",") < strings.Join(l[j].RequestsPerSecond.Hostnames, ",")
+	}
+	// ClusterScalingScheduleMetric
+	if l[i].ClusterScalingSchedule != nil && l[j].ClusterScalingSchedule != nil {
+		return l[i].ClusterScalingSchedule.Name < l[j].ClusterScalingSchedule.Name
+	}
+
+	// ScalingScheduleMetric
+	if l[i].ScalingSchedule != nil && l[j].ScalingSchedule != nil {
+		return l[i].ScalingSchedule.Name < l[j].ScalingSchedule.Name
+	}
+
+	// IngressAutoscalerMetric, RouteGroupAutoscalerMetric are both
+	// checked just by the Average value.
+
+	return false
 }
 
-func convertCustomMetrics(stacksetName, stackName, namespace string, metrics []zv1.AutoscalerMetrics, trafficWeight float64) ([]autoscaling.MetricSpec, map[string]string, error) {
-	var resultMetrics MetricsList
+func convertCustomMetrics(stacksetName, stackName, namespace string, metrics autoscalerMetricsList, trafficWeight float64) ([]autoscaling.MetricSpec, map[string]string, error) {
+	var resultMetrics []autoscaling.MetricSpec
 	resultAnnotations := make(map[string]string)
 
-	for _, m := range metrics {
+	sort.Sort(metrics)
+
+	for i, m := range metrics {
 		var (
 			generated   *autoscaling.MetricSpec
 			annotations map[string]string
@@ -70,7 +136,7 @@ func convertCustomMetrics(stacksetName, stackName, namespace string, metrics []z
 		)
 		switch m.Type {
 		case zv1.AmazonSQSAutoscalerMetric:
-			generated, err = sqsMetric(m)
+			generated, err = sqsMetric(m, i)
 		case zv1.PodJSONAutoscalerMetric:
 			generated, annotations, err = podJsonMetric(m)
 		case zv1.IngressAutoscalerMetric:
@@ -78,7 +144,7 @@ func convertCustomMetrics(stacksetName, stackName, namespace string, metrics []z
 		case zv1.RouteGroupAutoscalerMetric:
 			generated, err = routegroupMetric(m, stacksetName, stackName)
 		case zv1.ZMONAutoscalerMetric:
-			generated, annotations, err = zmonMetric(m, stackName, namespace)
+			generated, annotations, err = zmonMetric(m, i, stackName, namespace)
 		case zv1.ScalingScheduleMetric:
 			generated, err = scalingScheduleMetric(m, stackName, namespace)
 		case zv1.ClusterScalingScheduleMetric:
@@ -102,7 +168,6 @@ func convertCustomMetrics(stacksetName, stackName, namespace string, metrics []z
 		}
 	}
 
-	sort.Sort(resultMetrics)
 	return resultMetrics, resultAnnotations, nil
 }
 
@@ -167,7 +232,7 @@ func cpuMetric(metrics zv1.AutoscalerMetrics) (*autoscaling.MetricSpec, error) {
 	}, nil
 }
 
-func sqsMetric(metrics zv1.AutoscalerMetrics) (*autoscaling.MetricSpec, error) {
+func sqsMetric(metrics zv1.AutoscalerMetrics, position int) (*autoscaling.MetricSpec, error) {
 	if metrics.Average == nil {
 		return nil, fmt.Errorf("average not specified")
 	}
@@ -179,9 +244,13 @@ func sqsMetric(metrics zv1.AutoscalerMetrics) (*autoscaling.MetricSpec, error) {
 		Type: autoscaling.ExternalMetricSourceType,
 		External: &autoscaling.ExternalMetricSource{
 			Metric: autoscaling.MetricIdentifier{
-				Name: sqsQueueLengthTag,
+				Name: fmt.Sprintf("%s-%d", sqsMetricName, position),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{sqsQueueNameTag: metrics.Queue.Name, sqsQueueRegionTag: metrics.Queue.Region},
+					MatchLabels: map[string]string{
+						metricsTypeLabel:  sqsMetricType,
+						sqsQueueNameTag:   metrics.Queue.Name,
+						sqsQueueRegionTag: metrics.Queue.Region,
+					},
 				},
 			},
 			Target: autoscaling.MetricTarget{
@@ -329,7 +398,7 @@ func externalRPSMetric(metrics zv1.AutoscalerMetrics, stackname string, weight f
 	return generated, annotations, nil
 }
 
-func zmonMetric(metrics zv1.AutoscalerMetrics, stackName, namespace string) (*autoscaling.MetricSpec, map[string]string, error) {
+func zmonMetric(metrics zv1.AutoscalerMetrics, position int, stackName, namespace string) (*autoscaling.MetricSpec, map[string]string, error) {
 	if metrics.Average == nil {
 		return nil, nil, fmt.Errorf("average not specified")
 	}
@@ -351,13 +420,16 @@ func zmonMetric(metrics zv1.AutoscalerMetrics, stackName, namespace string) (*au
 		return nil, nil, fmt.Errorf("could not hash metric name")
 	}
 
+	metricName := fmt.Sprintf("%s-%d", zmonCheckMetricName, position)
+
 	generated := &autoscaling.MetricSpec{
 		Type: autoscaling.ExternalMetricSourceType,
 		External: &autoscaling.ExternalMetricSource{
 			Metric: autoscaling.MetricIdentifier{
-				Name: zmonCheckMetricName,
+				Name: metricName,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
+						metricsTypeLabel:     zmonCheckMetricType,
 						zmonCheckCheckIDTag:  metrics.ZMON.CheckID,
 						zmonCheckDurationTag: metrics.ZMON.Duration,
 						// uniquely identifies the metric to this
@@ -378,10 +450,10 @@ func zmonMetric(metrics zv1.AutoscalerMetrics, stackName, namespace string) (*au
 	}
 
 	annotations := map[string]string{
-		zmonCheckKeyAnnotation: metrics.ZMON.Key,
+		fmt.Sprintf(zmonCheckKeyAnnotationFormat, metricName): metrics.ZMON.Key,
 	}
 	for k, v := range metrics.ZMON.Tags {
-		annotations[zmonCheckTagAnnotationPrefix+k] = v
+		annotations[fmt.Sprintf(zmonCheckTagAnnotationPrefixFormat, metricName)+k] = v
 	}
 	return generated, annotations, nil
 }

--- a/pkg/core/autoscaler_test.go
+++ b/pkg/core/autoscaler_test.go
@@ -72,19 +72,34 @@ func generateAutoscalerSQS(minReplicas, maxReplicas, utilization int32, queueNam
 func generateAutoscalerZMON(minReplicas, maxReplicas, utilization int32, checkID, key, application, duration string, aggregators []zv1.ZMONMetricAggregatorType) StackContainer {
 	container := generateAutoscalerStub(minReplicas, maxReplicas)
 	container.Stack.Spec.StackSpec.Autoscaler.Metrics = append(
-		container.Stack.Spec.StackSpec.Autoscaler.Metrics, zv1.AutoscalerMetrics{
-			Type: zv1.ZMONAutoscalerMetric,
-			ZMON: &zv1.MetricsZMON{
-				CheckID:     checkID,
-				Key:         key,
-				Duration:    duration,
-				Aggregators: aggregators,
-				Tags: map[string]string{
-					"application": application,
+		container.Stack.Spec.StackSpec.Autoscaler.Metrics, []zv1.AutoscalerMetrics{
+			{
+				Type: zv1.ZMONAutoscalerMetric,
+				ZMON: &zv1.MetricsZMON{
+					CheckID:     checkID,
+					Key:         key,
+					Duration:    duration,
+					Aggregators: aggregators,
+					Tags: map[string]string{
+						"application": application,
+					},
 				},
+				Average: resource.NewQuantity(int64(utilization), resource.DecimalSI),
 			},
-			Average: resource.NewQuantity(int64(utilization), resource.DecimalSI),
-		},
+			{
+				Type: zv1.ZMONAutoscalerMetric,
+				ZMON: &zv1.MetricsZMON{
+					CheckID:     checkID + "-2",
+					Key:         key + "-2",
+					Duration:    duration,
+					Aggregators: aggregators,
+					Tags: map[string]string{
+						"application": application + "-2",
+					},
+				},
+				Average: resource.NewQuantity(int64(utilization), resource.DecimalSI),
+			},
+		}...,
 	)
 	return container
 }
@@ -234,8 +249,8 @@ func TestStackSetController_ReconcileAutoscalersSQS(t *testing.T) {
 	require.Len(t, hpa.Spec.Metrics, 1, "expected HPA to have 1 metric. instead got %d", len(hpa.Spec.Metrics))
 	externalMetric := hpa.Spec.Metrics[0]
 	require.Equal(t, externalMetric.Type, autoscaling.ExternalMetricSourceType)
-	require.Equal(t, externalMetric.External.Metric.Name, "sqs-queue-length")
-	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels["queue-name"], "test-queue")
+	require.Equal(t, externalMetric.External.Metric.Name, fmt.Sprintf("%s-0", sqsMetricName))
+	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels[metricsTypeLabel], sqsMetricType)
 	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels["queue-name"], "test-queue")
 	require.Equal(t, externalMetric.External.Target.AverageValue.Value(), int64(80))
 }
@@ -294,15 +309,30 @@ func TestStackSetController_ReconcileAutoscalersZMON(t *testing.T) {
 	require.NotNil(t, hpa, "hpa not generated")
 	require.Equal(t, int32(1), *hpa.Spec.MinReplicas, "min replicas not generated correctly")
 	require.Equal(t, int32(10), hpa.Spec.MaxReplicas, "max replicas generated incorrectly")
-	require.Len(t, hpa.Spec.Metrics, 1, "expected HPA to have 1 metric. instead got %d", len(hpa.Spec.Metrics))
+	require.Len(t, hpa.Spec.Metrics, 2, "expected HPA to have 1 metric. instead got %d", len(hpa.Spec.Metrics))
+
 	externalMetric := hpa.Spec.Metrics[0]
+	metricName0 := fmt.Sprintf("%s-0", zmonCheckMetricName)
 	require.Equal(t, externalMetric.Type, autoscaling.ExternalMetricSourceType)
-	require.Equal(t, externalMetric.External.Metric.Name, zmonCheckMetricName)
+	require.Equal(t, externalMetric.External.Metric.Name, metricName0)
+	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels[metricsTypeLabel], zmonCheckMetricType)
 	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels[zmonCheckCheckIDTag], "1234")
 	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels[zmonCheckDurationTag], "10m")
 	require.Equal(t, externalMetric.External.Metric.Selector.MatchLabels[zmonCheckAggregatorsTag], "avg,max")
-	require.Equal(t, hpa.Annotations[zmonCheckKeyAnnotation], "key")
-	require.Equal(t, hpa.Annotations[zmonCheckTagAnnotationPrefix+"application"], "app")
+	require.Equal(t, hpa.Annotations[fmt.Sprintf(zmonCheckKeyAnnotationFormat, metricName0)], "key")
+	require.Equal(t, hpa.Annotations[fmt.Sprintf(zmonCheckTagAnnotationPrefixFormat, metricName0)+"application"], "app")
+	require.Equal(t, externalMetric.External.Target.AverageValue.Value(), int64(80))
+
+	externalMetric2 := hpa.Spec.Metrics[1]
+	metricName1 := fmt.Sprintf("%s-1", zmonCheckMetricName)
+	require.Equal(t, externalMetric2.Type, autoscaling.ExternalMetricSourceType)
+	require.Equal(t, externalMetric2.External.Metric.Name, metricName1)
+	require.Equal(t, externalMetric2.External.Metric.Selector.MatchLabels[metricsTypeLabel], zmonCheckMetricType)
+	require.Equal(t, externalMetric2.External.Metric.Selector.MatchLabels[zmonCheckCheckIDTag], "1234-2")
+	require.Equal(t, externalMetric2.External.Metric.Selector.MatchLabels[zmonCheckDurationTag], "10m")
+	require.Equal(t, externalMetric2.External.Metric.Selector.MatchLabels[zmonCheckAggregatorsTag], "avg,max")
+	require.Equal(t, hpa.Annotations[fmt.Sprintf(zmonCheckKeyAnnotationFormat, metricName1)], "key-2")
+	require.Equal(t, hpa.Annotations[fmt.Sprintf(zmonCheckTagAnnotationPrefixFormat, metricName1)+"application"], "app-2")
 	require.Equal(t, externalMetric.External.Target.AverageValue.Value(), int64(80))
 }
 
@@ -512,7 +542,7 @@ func TestZMONMetricInvalid(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := zmonMetric(tc.metrics, "stack-name", "namespace")
+			_, _, err := zmonMetric(tc.metrics, 0, "stack-name", "namespace")
 			require.Errorf(t, err, "created metric with invalid configuration")
 		})
 	}
@@ -586,11 +616,600 @@ func TestSortingMetrics(t *testing.T) {
 	hpa, err := container.GenerateHPA()
 	require.NoError(t, err, "failed to create an HPA")
 	require.NotNil(t, hpa, "hpa not generated")
-	require.Len(t, hpa.Spec.Metrics, 4)
+	require.Len(t, hpa.Spec.Metrics, len(metrics))
 	require.EqualValues(t, autoscaling.ExternalMetricSourceType, hpa.Spec.Metrics[0].Type)
-	require.EqualValues(t, autoscaling.ObjectMetricSourceType, hpa.Spec.Metrics[1].Type)
-	require.EqualValues(t, autoscaling.PodsMetricSourceType, hpa.Spec.Metrics[2].Type)
-	require.EqualValues(t, autoscaling.ResourceMetricSourceType, hpa.Spec.Metrics[3].Type)
+	require.EqualValues(t, autoscaling.ResourceMetricSourceType, hpa.Spec.Metrics[1].Type)
+	require.EqualValues(t, autoscaling.ObjectMetricSourceType, hpa.Spec.Metrics[2].Type)
+	require.EqualValues(t, autoscaling.PodsMetricSourceType, hpa.Spec.Metrics[3].Type)
+}
+
+func decimalQuantity(d int) *resource.Quantity {
+	parsedDecimal := resource.MustParse(fmt.Sprintf("%d", d))
+	return &parsedDecimal
+}
+
+func TestSortingDuplicatedMetrics(t *testing.T) {
+	container := generateAutoscalerStub(1, 10)
+	metrics := []zv1.AutoscalerMetrics{
+		{
+			Type:               zv1.CPUAutoscalerMetric,
+			AverageUtilization: pint32(60),
+			Container:          "sidecar",
+		},
+		{
+			Type:               zv1.MemoryAutoscalerMetric,
+			AverageUtilization: pint32(60),
+			Container:          "sidecar",
+		},
+		{
+			Type:    zv1.ZMONAutoscalerMetric,
+			Average: decimalQuantity(20),
+			ZMON: &zv1.MetricsZMON{
+				CheckID: "2",
+				Key:     "test2",
+			},
+		},
+		{
+			Type:    zv1.ZMONAutoscalerMetric,
+			Average: decimalQuantity(10),
+			ZMON: &zv1.MetricsZMON{
+				CheckID: "3",
+				Key:     "test3",
+			},
+		},
+		{
+			Type:    zv1.ZMONAutoscalerMetric,
+			Average: decimalQuantity(10),
+			ZMON: &zv1.MetricsZMON{
+				CheckID: "1",
+				Key:     "test",
+			},
+		},
+		{
+			Type:               zv1.CPUAutoscalerMetric,
+			AverageUtilization: pint32(50),
+		},
+		{
+			Type:    zv1.AmazonSQSAutoscalerMetric,
+			Average: decimalQuantity(10),
+			Queue: &zv1.MetricsQueue{
+				Name:   "test2",
+				Region: "region",
+			},
+		},
+		{
+			Type:    zv1.AmazonSQSAutoscalerMetric,
+			Average: decimalQuantity(10),
+			Queue: &zv1.MetricsQueue{
+				Name:   "test",
+				Region: "region",
+			},
+		},
+		{
+			Type:               zv1.CPUAutoscalerMetric,
+			AverageUtilization: pint32(40),
+		},
+		{
+			Type:    zv1.PodJSONAutoscalerMetric,
+			Average: decimalQuantity(10),
+			Endpoint: &zv1.MetricsEndpoint{
+				Name: "podjson3",
+				Path: "/metrics",
+				Port: 1222,
+				Key:  "test.abc",
+			},
+		},
+		{
+			Type:    zv1.PodJSONAutoscalerMetric,
+			Average: decimalQuantity(20),
+			Endpoint: &zv1.MetricsEndpoint{
+				Name: "podjson2",
+				Path: "/metrics",
+				Port: 1222,
+				Key:  "test.abc",
+			},
+		},
+		{
+			Type:    zv1.PodJSONAutoscalerMetric,
+			Average: decimalQuantity(10),
+			Endpoint: &zv1.MetricsEndpoint{
+				Name: "podjson",
+				Path: "/metrics",
+				Port: 1222,
+				Key:  "test.abc",
+			},
+		},
+		{
+			Type:               zv1.MemoryAutoscalerMetric,
+			AverageUtilization: pint32(50),
+		},
+		{
+			Type:               zv1.MemoryAutoscalerMetric,
+			AverageUtilization: pint32(40),
+		},
+		{
+			Type:               zv1.MemoryAutoscalerMetric,
+			AverageUtilization: pint32(60),
+			Container:          "main",
+		},
+		{
+			Type:               zv1.CPUAutoscalerMetric,
+			AverageUtilization: pint32(60),
+			Container:          "main",
+		},
+		{
+			Type:    zv1.IngressAutoscalerMetric,
+			Average: decimalQuantity(100),
+		},
+		{
+			Type:    zv1.IngressAutoscalerMetric,
+			Average: decimalQuantity(80),
+		},
+		{
+			Type:    zv1.RouteGroupAutoscalerMetric,
+			Average: decimalQuantity(100),
+		},
+		{
+			Type:    zv1.RouteGroupAutoscalerMetric,
+			Average: decimalQuantity(80),
+		},
+		{
+			Type:    zv1.ClusterScalingScheduleMetric,
+			Average: decimalQuantity(100),
+			ClusterScalingSchedule: &zv1.MetricsClusterScalingSchedule{
+				Name: "EventB",
+			},
+		},
+		{
+			Type:    zv1.ClusterScalingScheduleMetric,
+			Average: decimalQuantity(80),
+			ClusterScalingSchedule: &zv1.MetricsClusterScalingSchedule{
+				Name: "EventB",
+			},
+		},
+		{
+			Type:    zv1.ClusterScalingScheduleMetric,
+			Average: decimalQuantity(100),
+			ClusterScalingSchedule: &zv1.MetricsClusterScalingSchedule{
+				Name: "EventA",
+			},
+		},
+		{
+			Type:    zv1.ScalingScheduleMetric,
+			Average: decimalQuantity(100),
+			ScalingSchedule: &zv1.MetricsScalingSchedule{
+				Name: "EventB",
+			},
+		},
+		{
+			Type:    zv1.ScalingScheduleMetric,
+			Average: decimalQuantity(80),
+			ScalingSchedule: &zv1.MetricsScalingSchedule{
+				Name: "EventB",
+			},
+		},
+		{
+			Type:    zv1.ScalingScheduleMetric,
+			Average: decimalQuantity(100),
+			ScalingSchedule: &zv1.MetricsScalingSchedule{
+				Name: "EventA",
+			},
+		},
+	}
+
+	metricsHash, _ := metricHash(container.Stack.ObjectMeta.Namespace, container.Stack.ObjectMeta.Name)
+
+	expectedMetrics := []autoscaling.MetricSpec{
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s-0", sqsMetricName),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							sqsQueueNameTag:   "test",
+							sqsQueueRegionTag: "region",
+							metricsTypeLabel:  sqsMetricType,
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s-1", sqsMetricName),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							sqsQueueNameTag:   "test2",
+							sqsQueueRegionTag: "region",
+							metricsTypeLabel:  sqsMetricType,
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ResourceMetricSourceType,
+			Resource: &autoscaling.ResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(40),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ResourceMetricSourceType,
+			Resource: &autoscaling.ResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(50),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ContainerResourceMetricSourceType,
+			ContainerResource: &autoscaling.ContainerResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(60),
+				},
+				Container: "main",
+			},
+		},
+		{
+			Type: autoscaling.ContainerResourceMetricSourceType,
+			ContainerResource: &autoscaling.ContainerResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(60),
+				},
+				Container: "sidecar",
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ClusterScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventB",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventB",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(80),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ClusterScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventA",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventA",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ClusterScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventB",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventB",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s,%s", requestsPerSecondName, container.Stack.ObjectMeta.Name),
+				},
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "Ingress",
+					Name:       container.stacksetName,
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(80),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s,%s", requestsPerSecondName, container.Stack.ObjectMeta.Name),
+				},
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "Ingress",
+					Name:       container.stacksetName,
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ResourceMetricSourceType,
+			Resource: &autoscaling.ResourceMetricSource{
+				Name: corev1.ResourceMemory,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(40),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ResourceMetricSourceType,
+			Resource: &autoscaling.ResourceMetricSource{
+				Name: corev1.ResourceMemory,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(50),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ContainerResourceMetricSourceType,
+			ContainerResource: &autoscaling.ContainerResourceMetricSource{
+				Name: corev1.ResourceMemory,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(60),
+				},
+				Container: "main",
+			},
+		},
+		{
+			Type: autoscaling.ContainerResourceMetricSourceType,
+			ContainerResource: &autoscaling.ContainerResourceMetricSource{
+				Name: corev1.ResourceMemory,
+				Target: autoscaling.MetricTarget{
+					Type:               autoscaling.UtilizationMetricType,
+					AverageUtilization: pint32(60),
+				},
+				Container: "sidecar",
+			},
+		},
+		{
+			Type: autoscaling.PodsMetricSourceType,
+			Pods: &autoscaling.PodsMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: "podjson",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.PodsMetricSourceType,
+			Pods: &autoscaling.PodsMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: "podjson3",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.PodsMetricSourceType,
+			Pods: &autoscaling.PodsMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: "podjson2",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(20),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: requestsPerSecondName,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"backend": container.Stack.ObjectMeta.Name,
+						},
+					},
+				},
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					APIVersion: "zalando.org/v1",
+					Kind:       "RouteGroup",
+					Name:       container.stacksetName,
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(80),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: requestsPerSecondName,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"backend": container.Stack.ObjectMeta.Name,
+						},
+					},
+				},
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					APIVersion: "zalando.org/v1",
+					Kind:       "RouteGroup",
+					Name:       container.stacksetName,
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventB",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventB",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(80),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventA",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventA",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "ScalingSchedule",
+					APIVersion: scalingScheduleAPIVersion,
+					Name:       "EventB",
+				},
+				Metric: autoscaling.MetricIdentifier{
+					Name: "EventB",
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(100),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s-23", zmonCheckMetricName),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							zmonCheckCheckIDTag:  "1",
+							zmonCheckDurationTag: "",
+							zmonCheckStackTag:    metricsHash,
+							metricsTypeLabel:     zmonCheckMetricType,
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s-24", zmonCheckMetricName),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							zmonCheckCheckIDTag:  "3",
+							zmonCheckDurationTag: "",
+							zmonCheckStackTag:    metricsHash,
+							metricsTypeLabel:     zmonCheckMetricType,
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(10),
+				},
+			},
+		},
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: fmt.Sprintf("%s-25", zmonCheckMetricName),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							zmonCheckCheckIDTag:  "2",
+							zmonCheckDurationTag: "",
+							zmonCheckStackTag:    metricsHash,
+							metricsTypeLabel:     zmonCheckMetricType,
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: decimalQuantity(20),
+				},
+			},
+		},
+	}
+
+	container.Stack.Spec.Autoscaler.Metrics = metrics
+	hpa, err := container.GenerateHPA()
+	require.NoError(t, err, "failed to create an HPA")
+	require.NotNil(t, hpa, "hpa not generated")
+	require.Len(t, hpa.Spec.Metrics, len(metrics))
+	for i, expected := range expectedMetrics {
+		t.Run(fmt.Sprintf("Testing position %d", i), func(t *testing.T) {
+			require.EqualValues(t, expected, hpa.Spec.Metrics[i])
+		})
+	}
 }
 
 func pint32(val int) *int32 {

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -241,7 +241,8 @@ func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, e
 	result.Spec.MinReplicas = autoscalerSpec.MinReplicas
 	result.Spec.MaxReplicas = autoscalerSpec.MaxReplicas
 
-	metrics, annotations, err := convertCustomMetrics(sc.stacksetName, sc.Name(), sc.Namespace(), autoscalerSpec.Metrics, trafficWeight)
+	metrics, annotations, err := convertCustomMetrics(sc.stacksetName, sc.Name(), sc.Namespace(), autoscalerMetricsList(autoscalerSpec.Metrics), trafficWeight)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using the `autoscaler` we are still letting `kube-metrics-adapter`
to rely in the metric name. This commit adds the `type` label to the
ZMON and SQS queue len metrics. It also sorts the metrics before
generating them, based on different criteria.

Previously, sort was based just on the HPA metric type. Now sort is done
by `StackSet`'s `autoscaler` metric type and once it conflicts
`Average`, `AverageUtilization`, etc. It guarantees we support multiple
metrics of the same type and do not regenerate the HPA if Kubernetes
sends the metrics in a different order.