### PR TITLE
Sort stack cleanup candidates by NoTrafficSince

### DIFF
--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -89,5 +89,4 @@ func TestBrokenStacks(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-
 }

--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -84,9 +84,10 @@ func TestBrokenStacks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the unhealthy stack was deleted
-	for _, stack := range []string{firstStack, unhealthyStack} {
+	for _, stack := range []string{unhealthyStack, firstStack} {
 		err := resourceDeleted(t, "stack", stack, stackInterface()).withTimeout(time.Second * 60).await()
 		require.NoError(t, err)
 	}
+
 
 }

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -246,7 +246,6 @@ func trafficWeightsUpdatedStackset(t *testing.T, stacksetName string, kind weigh
 		if err != nil {
 			return false, err
 		}
-
 		actualWeights := getStacksetTrafficWeights(stackset, kind)
 
 		if asserter != nil {
@@ -391,6 +390,8 @@ func updateStackset(stacksetName string, spec zv1.StackSetSpec) error {
 		if err != nil {
 			return err
 		}
+		// Keep the desired traffic
+		spec.Traffic = ss.Spec.Traffic
 		ss.Spec = spec
 		_, err = stacksetInterface().Update(context.Background(), ss, metav1.UpdateOptions{})
 		if apiErrors.IsConflict(err) {

--- a/cmd/e2e/ttl_test.go
+++ b/cmd/e2e/ttl_test.go
@@ -111,7 +111,7 @@ func TestStackTTLWithExternalIngress(t *testing.T) {
 		require.NoError(t, err)
 		fullStackName := fmt.Sprintf("%s-%s", stacksetName, stackVersion)
 
-		// // once the stack is created switch full traffic to it
+		// once the stack is created switch full traffic to it
 		newWeight := map[string]float64{fullStackName: 100}
 		err = setDesiredTrafficWeightsStackset(stacksetName, newWeight)
 		require.NoError(t, err)

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -116,10 +116,9 @@ func (ssc *StackSetContainer) MarkExpiredStacks() {
 		return
 	}
 
-	// sort candidates by oldest
+	// sort condidates by when they last had traffic.
 	sort.Slice(gcCandidates, func(i, j int) bool {
-		// TODO: maybe we use noTrafficSince instead of CreationTimeStamp to decide oldest
-		return gcCandidates[i].Stack.CreationTimestamp.Time.Before(gcCandidates[j].Stack.CreationTimestamp.Time)
+		return gcCandidates[i].Stack.Status.NoTrafficSince.Time.Before(gcCandidates[j].Stack.Status.NoTrafficSince.Time)
 	})
 
 	excessStacks := len(gcCandidates) - historyLimit

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -119,16 +119,15 @@ func (ssc *StackSetContainer) MarkExpiredStacks() {
 	// sort condidates by when they last had traffic.
 	sort.Slice(gcCandidates, func(i, j int) bool {
 		// First check if NoTrafficSince is set. If not, fall back to the creation timestamp
-		iTime := gcCandidates[i].Stack.Status.NoTrafficSince
+		iTime := gcCandidates[i].noTrafficSince
 		if iTime.IsZero() {
-			iTime = &gcCandidates[i].Stack.CreationTimestamp
+			iTime = gcCandidates[i].Stack.CreationTimestamp.Time
 		}
 
-		jTime := gcCandidates[j].Stack.Status.NoTrafficSince
+		jTime := gcCandidates[j].noTrafficSince
 		if jTime.IsZero() {
-			jTime = &gcCandidates[j].Stack.CreationTimestamp
+			jTime = gcCandidates[j].Stack.CreationTimestamp.Time
 		}
-
 		return iTime.Before(jTime)
 	})
 

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -118,7 +118,18 @@ func (ssc *StackSetContainer) MarkExpiredStacks() {
 
 	// sort condidates by when they last had traffic.
 	sort.Slice(gcCandidates, func(i, j int) bool {
-		return gcCandidates[i].Stack.Status.NoTrafficSince.Time.Before(gcCandidates[j].Stack.Status.NoTrafficSince.Time)
+		// First check if NoTrafficSince is set. If not, fall back to the creation timestamp
+		iTime := gcCandidates[i].Stack.Status.NoTrafficSince
+		if iTime.IsZero() {
+			iTime = &gcCandidates[i].Stack.CreationTimestamp
+		}
+
+		jTime := gcCandidates[j].Stack.Status.NoTrafficSince
+		if jTime.IsZero() {
+			jTime = &gcCandidates[j].Stack.CreationTimestamp
+		}
+
+		return iTime.Before(jTime)
 	})
 
 	excessStacks := len(gcCandidates) - historyLimit

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -31,22 +31,22 @@ func TestExpiredStacks(t *testing.T) {
 		expected     map[string]bool
 	}{
 		{
-			name:    "test GC oldest stack",
+			name:    "test GC stack last received traffic",
 			limit:   1,
 			ingress: true,
 			stacks: []*StackContainer{
 				testStack("stack1").createdAt(now.Add(-1 * time.Hour)).noTrafficSince(now.Add(-1 * time.Hour)).stack(),
-				testStack("stack2").createdAt(now.Add(-2 * time.Hour)).noTrafficSince(now.Add(-1 * time.Hour)).stack(),
+				testStack("stack2").createdAt(now.Add(-2 * time.Hour)).noTrafficSince(now.Add(-2 * time.Hour)).stack(),
 			},
 			expected: map[string]bool{"stack2": true},
 		},
 		{
-			name:       "test GC oldest RouteGroup stack",
+			name:       "test GC RouteGroup stack last received traffic",
 			limit:      1,
 			routegroup: true,
 			stacks: []*StackContainer{
 				testStack("stack1").createdAt(now.Add(-1 * time.Hour)).noTrafficSince(now.Add(-1 * time.Hour)).stack(),
-				testStack("stack2").createdAt(now.Add(-2 * time.Hour)).noTrafficSince(now.Add(-1 * time.Hour)).stack(),
+				testStack("stack2").createdAt(now.Add(-2 * time.Hour)).noTrafficSince(now.Add(-2 * time.Hour)).stack(),
 			},
 			expected: map[string]bool{"stack2": true},
 		},

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -41,6 +41,16 @@ func TestExpiredStacks(t *testing.T) {
 			expected: map[string]bool{"stack2": true},
 		},
 		{
+			name:    "test GC stack last received traffic from oldest stack",
+			limit:   1,
+			ingress: true,
+			stacks: []*StackContainer{
+				testStack("stack1").createdAt(now.Add(-4 * time.Hour)).noTrafficSince(now.Add(-1 * time.Hour)).stack(),
+				testStack("stack2").createdAt(now.Add(-3 * time.Hour)).noTrafficSince(now.Add(-2 * time.Hour)).stack(),
+			},
+			expected: map[string]bool{"stack2": true},
+		},
+		{
 			name:       "test GC RouteGroup stack last received traffic",
 			limit:      1,
 			routegroup: true,


### PR DESCRIPTION
Currently old Stacks are cleaned up based on the CreationTimestamp. However, older stacks may have received traffic more recently compared to a newer stack. This change evaluates the stacks to be cleaned based on noTrafficSince instead of CreationTimestamp.

Signed-off-by: zlawrence <zak.lawrence@zalando.de>