### PR TITLE
Use cdp-runtime for the build prod step

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -84,8 +84,10 @@ pipeline:
 - id: buildprod
   when:
     branch: master
-  overlay: ci/golang
-  vm: large
+  vm_config:
+    type: linux
+    image: "cdp-runtime/go"
+    size: large
   type: script
   env:
     GOFLAGS: "-mod=readonly"


### PR DESCRIPTION
The production build from #411 failed because the CDP step was using the legacy golang overlay instead of the new cdp-runtime.

This fixes it by using the cdp-runtime which will also introduce the latest Go version :)