### PR TITLE
Fix label update on stackset ingress

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -694,7 +694,8 @@ func (c *StackSetController) AddUpdateStackSetIngress(ctx context.Context, stack
 
 	// Check if we need to update the Ingress
 	if existingHaveUpdateTimeStamp && equality.Semantic.DeepDerivative(ingress.Spec, existing.Spec) &&
-		equality.Semantic.DeepEqual(ingress.Annotations, existing.Annotations) {
+		equality.Semantic.DeepEqual(ingress.Annotations, existing.Annotations) &&
+		equality.Semantic.DeepEqual(ingress.Labels, existing.Labels) {
 		// add the annotation back after comparing
 		existing.Annotations[ControllerLastUpdatedAnnotationKey] = lastUpdateValue
 		return existing, nil
@@ -708,6 +709,8 @@ func (c *StackSetController) AddUpdateStackSetIngress(ctx context.Context, stack
 		updated.Annotations = make(map[string]string)
 	}
 	updated.Annotations[ControllerLastUpdatedAnnotationKey] = c.now()
+
+	updated.Labels = ingress.Labels
 
 	createdIngress, err := c.client.NetworkingV1().Ingresses(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 	if err != nil {

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -796,7 +796,8 @@ func (c *StackSetController) AddUpdateStackSetRouteGroup(ctx context.Context, st
 
 	// Check if we need to update the RouteGroup
 	if existingHaveUpdateTimeStamp && equality.Semantic.DeepDerivative(rg.Spec, existing.Spec) &&
-		equality.Semantic.DeepEqual(rg.Annotations, existing.Annotations) {
+		equality.Semantic.DeepEqual(rg.Annotations, existing.Annotations) &&
+		equality.Semantic.DeepEqual(rg.Labels, existing.Labels) {
 		// add the annotation back after comparing
 		existing.Annotations[ControllerLastUpdatedAnnotationKey] = lastUpdateValue
 		return existing, nil
@@ -810,6 +811,8 @@ func (c *StackSetController) AddUpdateStackSetRouteGroup(ctx context.Context, st
 		updated.Annotations = make(map[string]string)
 	}
 	updated.Annotations[ControllerLastUpdatedAnnotationKey] = c.now()
+
+	updated.Labels = rg.Labels
 
 	createdRg, err := c.client.RouteGroupV1().RouteGroups(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 	if err != nil {

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -906,6 +906,18 @@ func TestReconcileStackSetIngressSources(t *testing.T) {
 			},
 		},
 		{
+			name: "routegroup is updated if the labels change",
+			existingRg: &rgv1.RouteGroup{
+				ObjectMeta: stacksetOwned(testStackSet),
+			},
+			generatedRg: &rgv1.RouteGroup{
+				ObjectMeta: withLabels(stacksetOwned(testStackSet), map[string]string{"label1": "value1"}),
+			},
+			expectedRg: &rgv1.RouteGroup{
+				ObjectMeta: withAnnotations(withLabels(stacksetOwned(testStackSet), map[string]string{"label1": "value1"}), map[string]string{ControllerLastUpdatedAnnotationKey: timeNow}),
+			},
+		},
+		{
 			name: "ingress is not rolled back if the server injects some defaults",
 			existingIng: &networking.Ingress{
 				ObjectMeta: stacksetOwned(testStackSet),

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -894,6 +894,18 @@ func TestReconcileStackSetIngressSources(t *testing.T) {
 			},
 		},
 		{
+			name: "ingress is updated if the labels change",
+			existingIng: &networking.Ingress{
+				ObjectMeta: stacksetOwned(testStackSet),
+			},
+			generatedIng: &networking.Ingress{
+				ObjectMeta: withLabels(stacksetOwned(testStackSet), map[string]string{"label1": "value1"}),
+			},
+			expectedIng: &networking.Ingress{
+				ObjectMeta: withAnnotations(withLabels(stacksetOwned(testStackSet), map[string]string{"label1": "value1"}), map[string]string{ControllerLastUpdatedAnnotationKey: timeNow}),
+			},
+		},
+		{
 			name: "ingress is not rolled back if the server injects some defaults",
 			existingIng: &networking.Ingress{
 				ObjectMeta: stacksetOwned(testStackSet),
@@ -1335,5 +1347,17 @@ func withAnnotations(meta metav1.ObjectMeta, annotations map[string]string) meta
 	for k, v := range annotations {
 		updated.Annotations[k] = v
 	}
+	return *updated
+}
+
+func withLabels(meta metav1.ObjectMeta, labels map[string]string) metav1.ObjectMeta {
+	updated := meta.DeepCopy()
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	for k, v := range labels {
+		updated.Labels[k] = v
+	}
+
 	return *updated
 }


### PR DESCRIPTION
An [issue](https://github.bus.zalan.do/zooport/issues/issues/2677) was raised where the change of labels on the "parent" `Stackset` ingress was not reconciled with the existing object.

This fixes it by:
1. Updating the condition for reconciliation (to not ignore `ingress` update if a label has changed)
2. Updating labels on the "updating" `ingress` so they can be patched to the existing object in the cluster
3. Adding a unit test 

Update: The same was fixed for the stackset `RouteGroup` as well.