### PR TITLE
e2e: make wait and traffic timeout configurable

### DIFF
--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	rg "github.com/szuecs/routegroup-client/client/clientset/versioned"
@@ -25,6 +27,8 @@ var (
 	clusterDomainInternal                              = requiredEnvar("CLUSTER_DOMAIN_INTERNAL")
 	clusterDomains                                     = []string{clusterDomain, clusterDomainInternal}
 	controllerId                                       = os.Getenv("CONTROLLER_ID")
+	waitTimeout                                        = *flag.Duration("wait-timeout", 60*time.Second, "Waiting interval before getting the resource")
+	trafficSwitchWaitTimeout                           = *flag.Duration("traffic-switch-wait-timeout", 150*time.Second, "Waiting interval before getting the checking stackset new traffic")
 )
 
 func init() {

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -27,11 +27,13 @@ var (
 	clusterDomainInternal                              = requiredEnvar("CLUSTER_DOMAIN_INTERNAL")
 	clusterDomains                                     = []string{clusterDomain, clusterDomainInternal}
 	controllerId                                       = os.Getenv("CONTROLLER_ID")
-	waitTimeout                                        = *flag.Duration("wait-timeout", 60*time.Second, "Waiting interval before getting the resource")
-	trafficSwitchWaitTimeout                           = *flag.Duration("traffic-switch-wait-timeout", 150*time.Second, "Waiting interval before getting the checking stackset new traffic")
+	waitTimeout                                        time.Duration
+	trafficSwitchWaitTimeout                           time.Duration
 )
 
 func init() {
+	flag.DurationVar(&waitTimeout, "wait-timeout", 60*time.Second, "Waiting interval before getting the resource")
+	flag.DurationVar(&trafficSwitchWaitTimeout, "traffic-switch-wait-timeout", 150*time.Second, "Waiting interval before getting the checking stackset new traffic")
 	logrus.SetFormatter(&logrus.TextFormatter{ForceColors: true})
 }
 

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -27,9 +27,6 @@ import (
 type weightKind string
 
 const (
-	defaultWaitTimeout       = 60 * time.Second
-	trafficSwitchWaitTimeout = 150 * time.Second
-
 	stacksetHeritageLabelKey = "stackset"
 	stackVersionLabelKey     = "stack-version"
 
@@ -106,7 +103,7 @@ func newAwaiter(t *testing.T, description string) *awaiter {
 	return &awaiter{
 		t:           t,
 		description: description,
-		timeout:     defaultWaitTimeout,
+		timeout:     waitTimeout,
 	}
 }
 
@@ -183,7 +180,7 @@ type trafficAsserter func(map[string]float64) error
 
 func trafficWeightsUpdatedIngress(t *testing.T, ingressName string, kind weightKind, expectedWeights map[string]float64, asserter trafficAsserter) *awaiter {
 	removeZeroWeights(expectedWeights)
-	timeout := defaultWaitTimeout
+	timeout := waitTimeout
 	if kind == weightKindActual {
 		timeout = trafficSwitchWaitTimeout
 	}
@@ -232,12 +229,12 @@ func ingressTrafficAuthoritative(t *testing.T, ingressName string, expectedAutho
 		}
 
 		return false, nil
-	}).withTimeout(defaultWaitTimeout)
+	}).withTimeout(waitTimeout)
 }
 
 func trafficWeightsUpdatedStackset(t *testing.T, stacksetName string, kind weightKind, expectedWeights map[string]float64, asserter trafficAsserter) *awaiter {
 	removeZeroWeights(expectedWeights)
-	timeout := defaultWaitTimeout
+	timeout := waitTimeout
 	if kind == weightKindActual {
 		timeout = trafficSwitchWaitTimeout
 	}

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -9,6 +9,7 @@ CLUSTER_NAME=${CLUSTER_NAME:-""}
 # Set TEST_NAME to run a single test
 # eg.: TEST_NAME=TestIngressToRouteGroupSwitch ./e2e/run_e2e.sh
 TEST_NAME=${TEST_NAME:-""}
+TEST_ARGS=${@:-""}
 CONTROLLER_ID="ssc-e2e-$(dd if=/dev/urandom bs=8 count=1 2>/dev/null | hexdump -e '"%x"')"
 
 if [[ -z "${CLUSTER_DOMAIN}" ]]; then
@@ -60,9 +61,9 @@ zkubectl create ns $CONTROLLER_ID
 
 test_args="-test.v"
 if [[ -z "${TEST_NAME}" ]]; then
-  test_args="${test_args} -test.parallel 64"
+  test_args="${test_args} ${TEST_ARGS} -test.parallel 64"
 else
-  test_args="${test_args} -test.parallel 1 -test.run=${TEST_NAME}"
+  test_args="${test_args} ${TEST_ARGS} -test.parallel 1 -test.run=${TEST_NAME}"
 fi
 
 # Run the end-to-end tests against the controller we just deployed.


### PR DESCRIPTION
Use flags to configure e2e timeouts constants with default old values.
Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>