### PR TITLE
Address staticcheck warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
-    - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
-      env:
-        GOLANGCI_RELEASE: v1.46.2
+    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - run: make check
     - run: make test
     - run: make build.docker

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,15 @@
 run:
-  skip-files:
-  - 'pkg/core/conversion.go'
-  - 'pkg/core/generated.conversion.go'
-linters-settings:
-  revive:
-    confidence: 0.9
+  concurrency: 4
 
 linters:
   disable-all: true
   enable:
-    - staticcheck
-    - ineffassign
-    - revive
-    - goimports
-    - errcheck
-issues:
-  exclude-rules:
-    # Exclude some staticcheck messages
-    - linters:
-        - staticcheck
-      text: "SA9003:"
+  - deadcode
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  - varcheck

--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -28,7 +27,7 @@ func TestBrokenStacks(t *testing.T) {
 	unhealthyVersion := "v2"
 	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
 	spec = factory.Create(unhealthyVersion)
-	spec.StackTemplate.Spec.Service.Ports = []v1.ServicePort{
+	spec.StackTemplate.Spec.Service.Ports = []corev1.ServicePort{
 		{
 			Protocol:   corev1.ProtocolTCP,
 			TargetPort: intstr.FromString("foobar"),

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -16,7 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,7 +48,7 @@ var (
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 					},
 				},
 				Resources: corev1.ResourceRequirements{
@@ -366,19 +365,13 @@ func createStackSet(stacksetName string, prescalingTimeout int, spec zv1.StackSe
 
 func stacksetExists(stacksetName string) bool {
 	_, err := stacksetInterface().Get(context.Background(), stacksetName, metav1.GetOptions{})
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func stackExists(stacksetName, stackVersion string) bool {
 	fullStackName := fmt.Sprintf("%s-%s", stacksetName, stackVersion)
 	_, err := stackInterface().Get(context.Background(), fullStackName, metav1.GetOptions{})
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func updateStackset(stacksetName string, spec zv1.StackSetSpec) error {
@@ -466,7 +459,7 @@ func waitForUpdatedRouteGroup(t *testing.T, name string, oldTimestamp string) (*
 	err := newAwaiter(t, fmt.Sprintf("updated RouteGroup %s", name)).withPoll(func() (bool, error) {
 		rg, err := routegroupInterface().Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
-			return apiErrors.IsNotFound(err.(error)), err.(error)
+			return apiErrors.IsNotFound(err), err
 		}
 		return rg.Annotations[controller.ControllerLastUpdatedAnnotationKey] != oldTimestamp, nil
 	}).await()
@@ -480,7 +473,7 @@ func waitForUpdatedIngress(t *testing.T, name string, oldTimestamp string) (*net
 	err := newAwaiter(t, fmt.Sprintf("updated Ingress %s", name)).withPoll(func() (bool, error) {
 		ing, err := ingressInterface().Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
-			return apiErrors.IsNotFound(err.(error)), err.(error)
+			return apiErrors.IsNotFound(err), err
 		}
 		return ing.Annotations[controller.ControllerLastUpdatedAnnotationKey] != oldTimestamp, nil
 	}).await()

--- a/cmd/traffic/main.go
+++ b/cmd/traffic/main.go
@@ -72,9 +72,7 @@ func main() {
 }
 
 func printTrafficTable(stacks []traffic.StackTrafficWeight) {
-	var w *tabwriter.Writer
-
-	w = tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
 	fmt.Fprintf(w, "%s\t%s\t%s\n", "STACK", "DESIRED TRAFFIC", "ACTUAL TRAFFIC")
 
 	for _, stack := range stacks {

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -20,7 +20,6 @@ import (
 	"github.com/zalando-incubator/stackset-controller/pkg/core"
 	"github.com/zalando-incubator/stackset-controller/pkg/recorder"
 	"golang.org/x/sync/errgroup"
-	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -39,9 +38,6 @@ const (
 	ResetHPAMinReplicasDelayAnnotationKey     = "alpha.stackset-controller.zalando.org/reset-hpa-min-replicas-delay"
 	StacksetControllerControllerAnnotationKey = "stackset-controller.zalando.org/controller"
 	ControllerLastUpdatedAnnotationKey        = "stackset-controller.zalando.org/updated-timestamp"
-
-	stackTrafficWeightsAnnotationKey = "zalando.org/stack-traffic-weights"
-	ingressAuthorativeAnnotationKey  = "zalando.org/traffic-authoritative"
 
 	reasonFailedManageStackSet = "FailedManageStackSet"
 
@@ -162,6 +158,7 @@ func (c *StackSetController) Run(ctx context.Context) {
 			var reconcileGroup errgroup.Group
 			for stackset, container := range stackContainers {
 				container := container
+				stackset := stackset
 
 				reconcileGroup.Go(func() error {
 					if _, ok := c.stacksetStore[stackset]; ok {
@@ -443,7 +440,7 @@ func (c *StackSetController) errorEventf(object runtime.Object, reason string, e
 	default:
 		c.recorder.Eventf(
 			object,
-			apiv1.EventTypeWarning,
+			v1.EventTypeWarning,
 			reason,
 			err.Error())
 		return &eventedError{err: err}
@@ -612,7 +609,7 @@ func (c *StackSetController) CreateCurrentStack(ctx context.Context, ssc *core.S
 
 	c.recorder.Eventf(
 		ssc.StackSet,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"CreatedStack",
 		"Created stack %s",
 		newStack.Name())
@@ -650,7 +647,7 @@ func (c *StackSetController) CleanupOldStacks(ctx context.Context, ssc *core.Sta
 		}
 		c.recorder.Eventf(
 			ssc.StackSet,
-			apiv1.EventTypeNormal,
+			v1.EventTypeNormal,
 			"DeletedExcessStack",
 			"Deleted excess stack %s",
 			stack.Name)
@@ -680,7 +677,7 @@ func (c *StackSetController) AddUpdateStackSetIngress(ctx context.Context, stack
 		}
 		c.recorder.Eventf(
 			stackset,
-			apiv1.EventTypeNormal,
+			v1.EventTypeNormal,
 			"CreatedIngress",
 			"Created Ingress %s",
 			ingress.Name)
@@ -718,7 +715,7 @@ func (c *StackSetController) AddUpdateStackSetIngress(ctx context.Context, stack
 	}
 	c.recorder.Eventf(
 		stackset,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"UpdatedIngress",
 		"Updated Ingress %s",
 		ingress.Name)
@@ -755,7 +752,7 @@ func (c *StackSetController) deleteIngress(ctx context.Context, stackset *zv1.St
 	}
 	c.recorder.Eventf(
 		stackset,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"DeletedIngress",
 		"Deleted Ingress %s",
 		existing.Namespace)
@@ -782,7 +779,7 @@ func (c *StackSetController) AddUpdateStackSetRouteGroup(ctx context.Context, st
 		}
 		c.recorder.Eventf(
 			stackset,
-			apiv1.EventTypeNormal,
+			v1.EventTypeNormal,
 			"CreatedRouteGroup",
 			"Created RouteGroup %s",
 			rg.Name)
@@ -820,7 +817,7 @@ func (c *StackSetController) AddUpdateStackSetRouteGroup(ctx context.Context, st
 	}
 	c.recorder.Eventf(
 		stackset,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"UpdatedRouteGroup",
 		"Updated RouteGroup %s",
 		rg.Name)
@@ -857,7 +854,7 @@ func (c *StackSetController) deleteRouteGroup(ctx context.Context, stackset *zv1
 	}
 	c.recorder.Eventf(
 		stackset,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"DeletedRouteGroup",
 		"Deleted RouteGroup %s",
 		rg.Namespace)
@@ -934,7 +931,7 @@ func (c *StackSetController) ReconcileStackSetResources(ctx context.Context, ssc
 
 		c.recorder.Eventf(
 			ssc.StackSet,
-			apiv1.EventTypeNormal,
+			v1.EventTypeNormal,
 			"TrafficSwitched",
 			"Switched traffic: %s",
 			strings.Join(changeMessages, ", "))
@@ -959,7 +956,7 @@ func (c *StackSetController) ReconcileStackSetDesiredTraffic(ctx context.Context
 	}
 	c.recorder.Eventf(
 		updated,
-		apiv1.EventTypeNormal,
+		v1.EventTypeNormal,
 		"UpdatedStackSet",
 		"Updated StackSet %s",
 		updated.Name)

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -73,14 +73,6 @@ func objectMetaInjectLabels(objectMeta metav1.ObjectMeta, labels map[string]stri
 	return objectMeta
 }
 
-func embeddedToObjectMeta(embedded zv1.EmbeddedObjectMeta) metav1.ObjectMeta {
-	c := embedded.DeepCopy()
-	return metav1.ObjectMeta{
-		Annotations: c.Annotations,
-		Labels:      c.Labels,
-	}
-}
-
 func (sc *StackContainer) resourceMeta() metav1.ObjectMeta {
 	resourceLabels := mapCopy(sc.Stack.Labels)
 


### PR DESCRIPTION
Address staticcheck issues

```
staticcheck ./...
cmd/e2e/broken_stack_test.go:9:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
	cmd/e2e/broken_stack_test.go:10:2: other import of "k8s.io/api/core/v1"
cmd/e2e/test_utils.go:18:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
	cmd/e2e/test_utils.go:19:2: other import of "k8s.io/api/core/v1"
cmd/e2e/test_utils.go:369:2: should use 'return err == nil' instead of 'if err != nil { return false }; return true' (S1008)
cmd/e2e/test_utils.go:378:2: should use 'return err == nil' instead of 'if err != nil { return false }; return true' (S1008)
cmd/e2e/test_utils.go:469:32: type assertion to the same type: err already has type error (S1040)
cmd/e2e/test_utils.go:469:46: type assertion to the same type: err already has type error (S1040)
cmd/e2e/test_utils.go:483:32: type assertion to the same type: err already has type error (S1040)
cmd/e2e/test_utils.go:483:46: type assertion to the same type: err already has type error (S1040)
cmd/traffic/main.go:75:2: should merge variable declaration with assignment on next line (S1021)
controller/stackset.go:23:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
	controller/stackset.go:24:2: other import of "k8s.io/api/core/v1"
controller/stackset.go:43:2: const stackTrafficWeightsAnnotationKey is unused (U1000)
controller/stackset.go:44:2: const ingressAuthorativeAnnotationKey is unused (U1000)
pkg/core/stack_resources.go:76:6: func embeddedToObjectMeta is unused (U1000)
```

Also updates the golangci configuration so it will find such issues in the future.