### PR TITLE
autoscaler: ensure HPA min replicas is not below Stack replicas

### DIFF
--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/core/autoscaler_test.go
+++ b/pkg/core/autoscaler_test.go
@@ -503,3 +503,16 @@ func TestStackSetController_ReconcileHPA(t *testing.T) {
 	require.Equal(t, int32(1), *hpa.Spec.MinReplicas, "min replicas not generated correctly")
 	require.Equal(t, int32(10), hpa.Spec.MaxReplicas, "max replicas generated incorrectly")
 }
+
+func TestStackSetController_ReconcileHPA_MinReplicasNotLessThanStackReplicas(t *testing.T) {
+	ssc := generateHPA(1, 10)
+
+	stackReplicas := int32(5)
+	ssc.Stack.Spec.Replicas = &stackReplicas
+
+	hpa, err := ssc.GenerateHPA()
+	require.NoError(t, err, "failed to create an HPA")
+	require.NotNil(t, hpa, "hpa not generated")
+
+	require.Equal(t, int32(5), *hpa.Spec.MinReplicas, "min replicas does not match stack replicas")
+}

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -262,6 +262,11 @@ func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, e
 		result.Spec.Behavior = hpaSpec.Behavior
 	}
 
+	// Ensure HPA min replicas is not below Stack replicas in case Stack was scaled
+	if sc.Stack.Spec.Replicas != nil && (result.Spec.MinReplicas == nil || *result.Spec.MinReplicas < *sc.Stack.Spec.Replicas) {
+		result.Spec.MinReplicas = sc.Stack.Spec.Replicas
+	}
+
 	// If prescaling is enabled, ensure we have at least `precalingReplicas` pods
 	if sc.prescalingActive && (result.Spec.MinReplicas == nil || *result.Spec.MinReplicas < sc.prescalingReplicas) {
 		pr := sc.prescalingReplicas


### PR DESCRIPTION
Users may scale stack manually via `kubectl scale stack` which updates Stack `spec.replicas` but it would not work when HPA is present and has lower minReplicas value.

This change ensures that Stack's HPA min replicas is not below Stack `spec.replicas` (if present).

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>