### PR TITLE
Allow traffic switch before stack is 100% Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ spec:
     weight: 80
   - stackName: mystack-v2
     weight: 20
+  # optional percentage of required Replicas ready to allow traffic switch
+  # if none specified, defaults to 100
+  minReadyPercent: 90
   stackLifecycle:
     scaledownTTLSeconds: 300
     limit: 5 # maximum number of scaled down stacks to keep.

--- a/docs/stackset.yaml
+++ b/docs/stackset.yaml
@@ -13,6 +13,7 @@ spec:
     weight: 40
   - stackName: my-app-v2
     weight: 60
+  minReadyPercent: 90
   stackLifecycle:
     scaledownTTLSeconds: 300
     limit: 5

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -103,6 +103,10 @@ spec:
                 - backendPort
                 - hosts
                 type: object
+              minReadyPercent:
+                description: minReadyPercent sets the minimum percentage of Pods expected
+                  to be Ready to consider a Stack for traffic switch
+                type: integer
               routegroup:
                 description: RouteGroup is an alternative to ingress allowing more
                   advanced routing configuration while still maintaining the ability

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -61,6 +61,9 @@ type StackSetSpec struct {
 	// weights. It defines the desired traffic. Clients that
 	// orchestrate traffic switching should write this part.
 	Traffic []*DesiredTraffic `json:"traffic,omitempty"`
+	// minReadyPercent sets the minimum percentage of Pods expected
+	// to be Ready to consider a Stack for traffic switch
+	MinReadyPercent int `json:"minReadyPercent,omitempty"`
 }
 
 // EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached

--- a/pkg/core/test_helpers.go
+++ b/pkg/core/test_helpers.go
@@ -45,10 +45,14 @@ func testStack(name string) *testStackFactory {
 }
 
 func (f *testStackFactory) ready(replicas int32) *testStackFactory {
+	return f.partiallyReady(replicas, replicas)
+}
+
+func (f *testStackFactory) partiallyReady(readyReplicas, replicas int32) *testStackFactory {
 	f.container.resourcesUpdated = true
 	f.container.deploymentReplicas = replicas
-	f.container.updatedReplicas = replicas
-	f.container.readyReplicas = replicas
+	f.container.updatedReplicas = readyReplicas
+	f.container.readyReplicas = readyReplicas
 	return f
 }
 

--- a/pkg/core/traffic.go
+++ b/pkg/core/traffic.go
@@ -21,6 +21,16 @@ func allZero(weights map[string]float64) bool {
 	return true
 }
 
+// normalizeMinReadyPercent normalizes minimum percentage of Ready pods.
+// If value is under or equal to 0, or over or equal to 100, set it to 1.0
+// If value is between 0-100, it's then set as decimal
+func normalizeMinReadyPercent(minReadyPercent int) float64 {
+	if minReadyPercent >= 100 || minReadyPercent <= 0 {
+		return 1.0
+	}
+	return float64(minReadyPercent) / 100
+}
+
 // normalizeWeights normalizes a map of backend weights.
 // If all weights are zero the total weight of 100 is distributed equally
 // between all backends.
@@ -155,9 +165,11 @@ func (ssc *StackSetContainer) ManageTraffic(currentTimestamp time.Time) error {
 		}
 	}
 
+	minReadyPercent := normalizeMinReadyPercent(ssc.StackSet.Spec.MinReadyPercent)
 	for stackName, stack := range stacks {
 		stack.desiredTrafficWeight = desiredWeights[stackName]
 		stack.actualTrafficWeight = actualWeights[stackName]
+		stack.minReadyPercent = minReadyPercent
 	}
 
 	// Run the traffic reconciler which will update the actual weights according to the desired weights. The resulting


### PR DESCRIPTION
Given the need for switching traffic to a stack that isn't 100% ready yet,
the `minReadyPercent` StackSet field allows setting a minimum percentage
of ready replicas required to enable the traffic switch.

`minReadyPercent` is optional and expects values from 1 to 100. In case of
value equal to or under 0 or over 100, it's normalised to 100, which keeps
the original behaviour.