### PR TITLE
Bump go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zalando-incubator/stackset-controller
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible


### PR DESCRIPTION
This is mostly a dummy commit to fix our build pipeline. zappr didn't succeed in the last two PRs and hence the images aren't marked as compliant.