### PR TITLE
Use opensource multi-arch skipper image on ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: ghcr.io/zalando/skipper:latest
             args:
             - skipper
             - -inline-routes
@@ -143,7 +143,7 @@ spec:
   podTemplate:
     spec:
       containers:
-        image: registry.opensource.zalan.do/teapot/skipper:latest
+        image: ghcr.io/zalando/skipper:latest
         args:
         - skipper
         - -inline-routes

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -38,7 +38,7 @@ var (
 		Containers: []corev1.Container{
 			{
 				Name:  "skipper",
-				Image: "registry.opensource.zalan.do/teapot/skipper:v0.13.21",
+				Image: "ghcr.io/zalando/skipper:v0.15.33",
 				Args: []string{
 					"skipper",
 					"-inline-routes",

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -56,7 +56,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			Containers: []v1.Container{
 				{
 					Name:  "foo",
-					Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+					Image: "ghcr.io/zalando/skipper:latest",
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func TestReconcileStackDeployment(t *testing.T) {
 			Containers: []v1.Container{
 				{
 					Name:  "bar",
-					Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+					Image: "ghcr.io/zalando/skipper:latest",
 				},
 			},
 		},

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -273,7 +273,7 @@ func TestCreateCurrentStack(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "foo",
-							Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+							Image: "ghcr.io/zalando/skipper:latest",
 						},
 					},
 				},

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -34,7 +34,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: ghcr.io/zalando/skipper:latest
             args:
             - skipper
             - -inline-routes
@@ -70,7 +70,7 @@ for the container:
 ```yaml
 containers:
 - name: skipper
-  image: registry.opensource.zalan.do/teapot/skipper:latest
+  image: ghcr.io/zalando/skipper:latest
   args:
   - skipper
   - -inline-routes
@@ -132,7 +132,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: ghcr.io/zalando/skipper:latest
             args:
             - skipper
             - -inline-routes
@@ -448,7 +448,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: ghcr.io/zalando/skipper:latest
             args:
             - skipper
             - -inline-routes

--- a/docs/stackset.yaml
+++ b/docs/stackset.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:latest
+            image: ghcr.io/zalando/skipper:latest
             args:
             - skipper
             - -inline-routes

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
           - name: skipper
-            image: registry.opensource.zalan.do/teapot/skipper:v0.13.21
+            image: ghcr.io/zalando/skipper:v0.15.33
             args:
             - skipper
             - -inline-routes

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -975,7 +975,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 								Containers: []v1.Container{
 									{
 										Name:  "foo",
-										Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+										Image: "ghcr.io/zalando/skipper:latest",
 									},
 								},
 							},
@@ -1017,7 +1017,7 @@ func TestStackGenerateDeployment(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Name:  "foo",
-									Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+									Image: "ghcr.io/zalando/skipper:latest",
 								},
 							},
 						},
@@ -1113,7 +1113,7 @@ func TestGenerateHPA(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "foo",
-							Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+							Image: "ghcr.io/zalando/skipper:latest",
 						},
 					},
 				},


### PR DESCRIPTION
Since https://github.com/zalando/skipper/issues/2114 there's a multi-arch image being pushed to ghcr.io which is public: https://github.com/zalando/skipper/pkgs/container/skipper

Let's use it here so that the stackset-controller e2e tests over at https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/delivery.yaml#L241 can run against an all arm64 cluster (https://github.com/zalando-incubator/kubernetes-on-aws/pull/5098)