### PR TITLE
all: fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ behavior for the `StackSet`:
 
 * [How To's](/docs/howtos.md)
 
-### Kubernetes Compatibilty
+### Kubernetes Compatibility
 
 The StackSet controller works with Kubernetes `>=v1.23`.
 

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -101,7 +101,7 @@ one port of the containers must have the same name or port number as the
 ### Configure custom service ports
 
 In some cases you want to expose multiple ports in your service. For this use
-case it's posible to define the service ports on the `StackSet`.
+case it's possible to define the service ports on the `StackSet`.
 
 ```yaml
 apiVersion: zalando.org/v1
@@ -207,7 +207,7 @@ autoscaler:
 Here the stackset would be scaled based on the length of the Amazon SQS Queue size so that there are no more
 than 30 items in the queue per pod. Also the autoscaler tries to keep the CPU usage below 80% in the pods by
 scaling. If multiple metrics are specified then the HPA calculates the number of pods required per metrics
-and uses the higest recommendation.
+and uses the highest recommendation.
 
 JSON metrics exposed by the pods are also supported. Here's an example where the pods expose metrics in
 JSON format on the `/metrics` endpoint on port 9090. The key for the metrics should be specified as well.
@@ -326,7 +326,7 @@ spec:
 The pre scaling works as follows:
 
 1. User directs/increases traffic to a stack.
-2. Before the stack gets any traffic it will caculate a prescale value `n` of
+2. Before the stack gets any traffic it will calculate a prescale value `n` of
    replicas based on the sum of all stacks currently getting traffic.
 3. The HPA of the stack will get the `MinReplicas` value set equal to the
    prescale value calculated in 2.

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -120,7 +120,7 @@ func (o *StackIngressRouteGroupOverrides) IsEnabled() bool {
 	return *o.Enabled
 }
 
-// StackSetIngressSpec is the ingress defintion of an StackSet. This
+// StackSetIngressSpec is the ingress definition of an StackSet. This
 // includes ingress annotations and a list of hostnames.
 // +k8s:deepcopy-gen=true
 type StackSetIngressSpec struct {

--- a/pkg/core/stackset.go
+++ b/pkg/core/stackset.go
@@ -116,7 +116,7 @@ func (ssc *StackSetContainer) MarkExpiredStacks() {
 		return
 	}
 
-	// sort condidates by when they last had traffic.
+	// sort candidates by when they last had traffic.
 	sort.Slice(gcCandidates, func(i, j int) bool {
 		// First check if NoTrafficSince is set. If not, fall back to the creation timestamp
 		iTime := gcCandidates[i].noTrafficSince

--- a/pkg/core/traffic.go
+++ b/pkg/core/traffic.go
@@ -73,7 +73,7 @@ func normalizeWeights(backendWeights map[string]float64) {
 //
 // The function assumes that the weights are already normalized to a sum of
 // 100.
-// It's using the "Largets Remainder Method" for rounding:
+// It's using the "Largest Remainder Method" for rounding:
 // https://en.wikipedia.org/wiki/Largest_remainder_method
 func roundWeights(weights map[string]float64) {
 	type backendWeight struct {

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -23,10 +23,10 @@ const (
 )
 
 // StackSetContainer is a container for storing the full state of a StackSet
-// including the sub-resources which are part of the StackSet. It respresents a
+// including the sub-resources which are part of the StackSet. It represents a
 // snapshot of the resources currently in the Cluster. This includes an
 // optional Ingress resource as well as the current Traffic distribution. It
-// also contains a set of StackContainers which respresents the full state of
+// also contains a set of StackContainers which represents the full state of
 // the individual Stacks part of the StackSet.
 type StackSetContainer struct {
 	StackSet *zv1.StackSet
@@ -140,7 +140,7 @@ func (sc *StackContainer) HasTraffic() bool {
 }
 
 func (sc *StackContainer) IsReady() bool {
-	// Calculate minmum required replicas for the Deployment to be considered ready
+	// Calculate minimum required replicas for the Deployment to be considered ready
 	minRequiredReplicas := int32(math.Ceil(float64(sc.deploymentReplicas) * sc.minReadyPercent))
 
 	// Stacks are considered ready when all subresources have been updated


### PR DESCRIPTION
```
codespell --skip .git | less
```

See https://github.com/codespell-project/codespell