### PR TITLE
fix cpu metric in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ spec:
         minReplicas: 3
         maxReplicas: 10
         metrics:
-        - type: cpu
+        - type: CPU
           averageUtilization: 50
       # full Pod template.
       podTemplate:
@@ -134,7 +134,7 @@ spec:
     minReplicas: 3
     maxReplicas: 10
     metrics:
-    - type: cpu
+    - type: CPU
       averageUtilization: 50
   podTemplate:
     spec:


### PR DESCRIPTION
This needs to be uppercase, using `cpu` lowercase results in:

```
spec.stackTemplate.spec.autoscaler.metrics.type: Unsupported value: "cpu": supported values: "CPU", "Memory", "AmazonSQS", "PodJSON", "Ingress", "RouteGroup", "ZMON", "ScalingSchedule", "ClusterScalingSchedule"
```