### PR TITLE
Regenerate CRD based on code

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -266,11 +266,8 @@ spec:
                               items:
                                 type: string
                               type: array
-                            name:
-                              type: string
                           required:
                           - hostnames
-                          - name
                           type: object
                         scalingSchedule:
                           description: MetricsScalingSchedule specifies the ScalingSchedule

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -512,11 +512,8 @@ spec:
                                       items:
                                         type: string
                                       type: array
-                                    name:
-                                      type: string
                                   required:
                                   - hostnames
-                                  - name
                                   type: object
                                 scalingSchedule:
                                   description: MetricsScalingSchedule specifies the


### PR DESCRIPTION
Follow up to #501 to regenerate the CRD based on the latest version of the RPS based implementation.

Without this it's not possible to apply a stackset defining the RPS config as defined in the docs:

```yaml
autoscaler:
  minReplicas: 1
  maxReplicas: 3
  metrics:
  - type: RequestsPerSecond
    average: 30
    requestsPerSecond:
      hostnames: 
        - 'example.com'
        - 'foo.bar.baz'
```

because a `name` is missing which is not used. This is the error you get:

```
error: error validating "fb_rps_stackset.yaml": error validating data: ValidationError(StackSet.spec.stackTemplate.spec.autoscaler.metrics[0].requestsPerSecond): missing required field "name" in org.zalando.v1.StackSet.spec.stackTemplate.spec.autoscaler.metrics.requestsPerSecond; if you choose to ignore these errors, turn validation off with --validate=fals
```