### PR TITLE
Add RequestsPerSecond type to validation

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -294,6 +294,7 @@ spec:
                           - ZMON
                           - ScalingSchedule
                           - ClusterScalingSchedule
+                          - RequestsPerSecond
                           type: string
                         zmon:
                           description: MetricsZMON specifies the ZMON check which
@@ -1341,14 +1342,6 @@ spec:
                                                   and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1652,6 +1645,14 @@ spec:
                                                   and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -541,6 +541,7 @@ spec:
                                   - ZMON
                                   - ScalingSchedule
                                   - ClusterScalingSchedule
+                                  - RequestsPerSecond
                                   type: string
                                 zmon:
                                   description: MetricsZMON specifies the ZMON check

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -274,7 +274,7 @@ type MetricsRequestsPerSecond struct {
 }
 
 // AutoscalerMetricType is the type of the metric used for scaling.
-// +kubebuilder:validation:Enum=CPU;Memory;AmazonSQS;PodJSON;Ingress;RouteGroup;ZMON;ScalingSchedule;ClusterScalingSchedule
+// +kubebuilder:validation:Enum=CPU;Memory;AmazonSQS;PodJSON;Ingress;RouteGroup;ZMON;ScalingSchedule;ClusterScalingSchedule;RequestsPerSecond
 type AutoscalerMetricType string
 
 const (


### PR DESCRIPTION
Another follow up to #501 adding the `RequestsPerSecond` type in the CRD validation. This is required to avoid the error:

```
The StackSet "x" is invalid: spec.stackTemplate.spec.autoscaler.metrics.type: Unsupported value: "RequestsPerSecond": supported values: "CPU", "Memory", "AmazonSQS", "PodJSON", "Ingress", "RouteGroup", "ZMON", "ScalingSchedule", "ClusterScalingSchedule"
```