### PR TITLE
Fix annotation for hostname rps based scaling

### DIFF
--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -318,8 +318,8 @@ func externalRPSMetric(metrics zv1.AutoscalerMetrics, stackname string, weight f
 		},
 	}
 
-	hostKey := fmt.Sprintf("metric-config.%s.requests-per-second/hostnames", name)
-	weightKey := fmt.Sprintf("metric-config.%s.requests-per-second/weight", name)
+	hostKey := fmt.Sprintf("metric-config.external.%s.requests-per-second/hostnames", name)
+	weightKey := fmt.Sprintf("metric-config.external.%s.requests-per-second/weight", name)
 
 	annotations := map[string]string{
 		hostKey:   strings.Join(metrics.RequestsPerSecond.Hostnames, ","),

--- a/pkg/core/autoscaler_test.go
+++ b/pkg/core/autoscaler_test.go
@@ -352,8 +352,8 @@ func TestStackSetController_ReconcileAutoscalersExternalRPS(t *testing.T) {
 		require.Equal(tt, "requests-per-second", externalMetric.External.Metric.Selector.MatchLabels["type"])
 		require.Equal(tt, autoscaling.AverageValueMetricType, externalMetric.External.Target.Type)
 		require.Equal(tt, int64(average), externalMetric.External.Target.AverageValue.Value())
-		require.Equal(tt, expectedHosts, hpa.Annotations["metric-config.stackset-v1-rps.requests-per-second/hostnames"])
-		require.Equal(tt, fmt.Sprintf("%d", int(weight)), hpa.Annotations["metric-config.stackset-v1-rps.requests-per-second/weight"])
+		require.Equal(tt, expectedHosts, hpa.Annotations["metric-config.external.stackset-v1-rps.requests-per-second/hostnames"])
+		require.Equal(tt, fmt.Sprintf("%d", int(weight)), hpa.Annotations["metric-config.external.stackset-v1-rps.requests-per-second/weight"])
 	}
 
 	for _, tc := range []struct {


### PR DESCRIPTION
Follow up to #501 fixing the annotation format for RPS based on hostname scaling. 