### PR TITLE
Add stack weight verification for HPA reconciling

### DIFF
--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -27,24 +27,24 @@ func pint32Equal(p1, p2 *int32) bool {
 // e.g. External RPS metric, this verification provides a way to verify
 // all relevant annotations are actually up to date.
 func areHPAAnnotationsUpToDate(updated, existing *v2.HorizontalPodAutoscaler) bool {
-    if len(updated.Annotations) != len(existing.Annotations) {
-        return false
-    }
+	if len(updated.Annotations) != len(existing.Annotations) {
+		return false
+	}
 
-    for k, v := range updated.Annotations {
-        if k == "stackset-controller.zalando.org/stack-generation" {
-            continue
-        }
+	for k, v := range updated.Annotations {
+		if k == "stackset-controller.zalando.org/stack-generation" {
+			continue
+		}
 
-        existingValue, ok := existing.Annotations[k]
-        if ok && existingValue == v {
-            continue
-        }
+		existingValue, ok := existing.Annotations[k]
+		if ok && existingValue == v {
+			continue
+		}
 
-        return false
-    }
+		return false
+	}
 
-    return true
+	return true
 }
 
 // syncObjectMeta copies metadata elements such as labels or annotations from source to target
@@ -135,7 +135,7 @@ func (c *StackSetController) ReconcileStackHPA(ctx context.Context, stack *zv1.S
 	// Check if we need to update the HPA
 	if core.IsResourceUpToDate(stack, existing.ObjectMeta) &&
 		pint32Equal(existing.Spec.MinReplicas, hpa.Spec.MinReplicas) &&
-        areHPAAnnotationsUpToDate(hpa, existing) {
+		areHPAAnnotationsUpToDate(hpa, existing) {
 		return nil
 	}
 

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -23,10 +23,14 @@ func pint32Equal(p1, p2 *int32) bool {
 	return false
 }
 
+// There are HPA metrics that depend on annotations to work properly,
+// e.g. External RPS metric, this verification provides a way to verify
+// all relevant annotations are actually up to date.
 func areHPAAnnotationsUpToDate(updated, existing *v2.HorizontalPodAutoscaler) bool {
-    // There are HPA metrics that depend on annotations to work properly,
-    // e.g. External RPS metric, this verification provides a way to verify
-    // all relevant annotations are actually up to date.
+    if len(updated.Annotations) != len(existing.Annotations) {
+        return false
+    }
+
     for k, v := range updated.Annotations {
         if k == "stackset-controller.zalando.org/stack-generation" {
             continue

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -33,9 +33,9 @@ var (
 			Generation:      1,
 			OwnerReferences: stacksetOwned(testStackSet).OwnerReferences,
 		},
-        Status: zv1.StackStatus{
-            ActualTrafficWeight: 42.0,
-        },  
+		Status: zv1.StackStatus{
+			ActualTrafficWeight: 42.0,
+		},
 	}
 	updatedTestStack = *baseTestStack.DeepCopy()
 
@@ -397,42 +397,42 @@ func TestReconcileStackHPA(t *testing.T) {
 		},
 	}
 
-    exampleExternalRPSMetric := []autoscaling.MetricSpec{
-        {
-            Type: autoscaling.ExternalMetricSourceType,
-            External: &autoscaling.ExternalMetricSource{
-                Metric: autoscaling.MetricIdentifier{
-                    Name: "foo",
-                    Selector: &metav1.LabelSelector{
-                        MatchLabels: map[string]string{
-                            "type": "requests-per-second",
-                        },
-                    },
-                },
-                Target: autoscaling.MetricTarget{
-                    Type: autoscaling.MetricTargetType("AverageValue"),
-                    AverageValue: resource.NewQuantity(10, resource.DecimalSI),
-                },
-            },
-        },
-    }
+	exampleExternalRPSMetric := []autoscaling.MetricSpec{
+		{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: "foo",
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"type": "requests-per-second",
+						},
+					},
+				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.MetricTargetType("AverageValue"),
+					AverageValue: resource.NewQuantity(10, resource.DecimalSI),
+				},
+			},
+		},
+	}
 
-    externalRPSHPAObjMeta := baseTestStackOwned.DeepCopy()
-    for k, v := range map[string]string{
+	externalRPSHPAObjMeta := baseTestStackOwned.DeepCopy()
+	for k, v := range map[string]string{
 		"metric-config.external.foo.requests-per-second/hostnames": "just.testing.com",
-        "metric-config.external.foo.requests-per-second/weight": "42",
-    }{
-        externalRPSHPAObjMeta.Annotations[k] = v 
-    }
-    externalRPSHPAObjMetaUpdated := baseTestStackOwned.DeepCopy()
-    for k, v := range map[string]string{
+		"metric-config.external.foo.requests-per-second/weight":    "42",
+	} {
+		externalRPSHPAObjMeta.Annotations[k] = v
+	}
+	externalRPSHPAObjMetaUpdated := baseTestStackOwned.DeepCopy()
+	for k, v := range map[string]string{
 		"metric-config.external.foo.requests-per-second/hostnames": "just.testing.com",
-        "metric-config.external.foo.requests-per-second/weight": "100",
-    }{
-        externalRPSHPAObjMetaUpdated.Annotations[k] = v 
-    }
-    externalRPSHPAStack := baseTestStack.DeepCopy()
-    externalRPSHPAStack.Status.ActualTrafficWeight = 100
+		"metric-config.external.foo.requests-per-second/weight":    "100",
+	} {
+		externalRPSHPAObjMetaUpdated.Annotations[k] = v
+	}
+	externalRPSHPAStack := baseTestStack.DeepCopy()
+	externalRPSHPAStack.Status.ActualTrafficWeight = 100
 
 	for _, tc := range []struct {
 		name     string

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -33,6 +33,9 @@ var (
 			Generation:      1,
 			OwnerReferences: stacksetOwned(testStackSet).OwnerReferences,
 		},
+        Status: zv1.StackStatus{
+            ActualTrafficWeight: 42.0,
+        },  
 	}
 	updatedTestStack = *baseTestStack.DeepCopy()
 
@@ -364,6 +367,7 @@ func TestReconcileStackHPA(t *testing.T) {
 			},
 		},
 	}
+
 	exampleUpdatedResource := resource.MustParse("20m")
 	exampleUpdatedMetrics := []autoscaling.MetricSpec{
 		{
@@ -392,6 +396,43 @@ func TestReconcileStackHPA(t *testing.T) {
 			},
 		},
 	}
+
+    exampleExternalRPSMetric := []autoscaling.MetricSpec{
+        {
+            Type: autoscaling.ExternalMetricSourceType,
+            External: &autoscaling.ExternalMetricSource{
+                Metric: autoscaling.MetricIdentifier{
+                    Name: "foo",
+                    Selector: &metav1.LabelSelector{
+                        MatchLabels: map[string]string{
+                            "type": "requests-per-second",
+                        },
+                    },
+                },
+                Target: autoscaling.MetricTarget{
+                    Type: autoscaling.MetricTargetType("AverageValue"),
+                    AverageValue: resource.NewQuantity(10, resource.DecimalSI),
+                },
+            },
+        },
+    }
+
+    externalRPSHPAObjMeta := baseTestStackOwned.DeepCopy()
+    for k, v := range map[string]string{
+		"metric-config.external.foo.requests-per-second/hostnames": "just.testing.com",
+        "metric-config.external.foo.requests-per-second/weight": "42",
+    }{
+        externalRPSHPAObjMeta.Annotations[k] = v 
+    }
+    externalRPSHPAObjMetaUpdated := baseTestStackOwned.DeepCopy()
+    for k, v := range map[string]string{
+		"metric-config.external.foo.requests-per-second/hostnames": "just.testing.com",
+        "metric-config.external.foo.requests-per-second/weight": "100",
+    }{
+        externalRPSHPAObjMetaUpdated.Annotations[k] = v 
+    }
+    externalRPSHPAStack := baseTestStack.DeepCopy()
+    externalRPSHPAStack.Status.ActualTrafficWeight = 100
 
 	for _, tc := range []struct {
 		name     string
@@ -459,6 +500,34 @@ func TestReconcileStackHPA(t *testing.T) {
 					MinReplicas: &exampleMinReplicas,
 					MaxReplicas: 7,
 					Metrics:     exampleUpdatedMetrics,
+				},
+			},
+		},
+		{
+			name:  "HPA is updated if stack weight changes",
+			stack: *externalRPSHPAStack,
+			existing: &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: *externalRPSHPAObjMeta,
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MinReplicas: &exampleMinReplicas,
+					MaxReplicas: 5,
+					Metrics:     exampleExternalRPSMetric,
+				},
+			},
+			updated: &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: *externalRPSHPAObjMetaUpdated,
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MinReplicas: &exampleMinReplicas,
+					MaxReplicas: 5,
+					Metrics:     exampleExternalRPSMetric,
+				},
+			},
+			expected: &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: *externalRPSHPAObjMetaUpdated,
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MinReplicas: &exampleMinReplicas,
+					MaxReplicas: 5,
+					Metrics:     exampleExternalRPSMetric,
 				},
 			},
 		},


### PR DESCRIPTION
This PR introduces a new check to make weight changes to External RPS HPA automatically during traffic switch. Now when traffic switching using stackset weights the weight change trigger the update of the HPA that will take in consideration the new weight of the stack. Before only stack generation was considered, which would not be updated in Status and annotation changes.