### PR TITLE
[Draft] Add basic resource templates reconciliation code with stub implementation

### DIFF
--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -42,6 +42,8 @@ var (
 		RouteGroupSupportEnabled    bool
 		IngressSourceSwitchTTL      time.Duration
 		ReconcileWorkers            int
+
+		ResourceTemplatesSupportEnabled bool
 	}
 )
 
@@ -57,6 +59,7 @@ func main() {
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
 	kingpin.Flag("cluster-domain", "Main domains of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_DOMAIN").Required().StringsVar(&config.ClusterDomains)
 	kingpin.Flag("enable-routegroup-support", "Enable support for RouteGroups on StackSets.").Default("false").BoolVar(&config.RouteGroupSupportEnabled)
+	kingpin.Flag("enable-resource-templates-support", "Enable support for ResourceTemplates on Stacks.").Default("false").BoolVar(&config.ResourceTemplatesSupportEnabled)
 	kingpin.Flag("ingress-source-switch-ttl", "The ttl before an ingress source is deleted when replaced with another one e.g. switching from RouteGroup to Ingress or vice versa.").
 		Default(defaultIngressSourceSwitchTTL).DurationVar(&config.IngressSourceSwitchTTL)
 	kingpin.Parse()
@@ -85,6 +88,7 @@ func main() {
 		prometheus.DefaultRegisterer,
 		config.Interval,
 		config.RouteGroupSupportEnabled,
+		config.ResourceTemplatesSupportEnabled,
 		config.IngressSourceSwitchTTL,
 	)
 	if err != nil {

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -318,3 +318,15 @@ func (c *StackSetController) ReconcileStackRouteGroup(ctx context.Context, stack
 		routegroup.Name)
 	return nil
 }
+
+func (c *StackSetController) ReconcileStackResourceTemplates(ctx context.Context, stack *zv1.Stack, existing []zv1.ResourceTemplate, generateUpdated func() ([]zv1.ResourceTemplate, error)) error {
+	resourceTemplates, err := generateUpdated()
+	if err != nil {
+		return err
+	}
+
+	// TODO
+	_ = resourceTemplates
+
+	return nil
+}

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -57,7 +57,7 @@ func NewTestEnvironment() *testEnvironment {
 		rgClient:  rgfake.NewSimpleClientset(),
 	}
 
-	controller, err := NewStackSetController(client, "", 10, "", nil, prometheus.NewPedanticRegistry(), time.Minute, true, time.Minute)
+	controller, err := NewStackSetController(client, "", 10, "", nil, prometheus.NewPedanticRegistry(), time.Minute, true, true, time.Minute)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -420,6 +420,47 @@ func (sc *StackContainer) GenerateRouteGroup() (*rgv1.RouteGroup, error) {
 	return result, nil
 }
 
+func (sc *StackContainer) GenerateResourceTemplates() ([]zv1.ResourceTemplate, error) {
+	for _, rt := range sc.Resources.ResourceTemplates {
+		// TODO
+		if rt.ConfigMap != nil {
+			// inline configmap
+			for k, v := range rt.ConfigMap {
+				fmt.Println(k, v)
+			}
+
+			continue
+		}
+
+		// TODO
+		if rt.ConfigMapRef.Name != "" {
+			// reference configmap
+			fmt.Println(rt.ConfigMapRef.Name)
+
+			continue
+		}
+
+		// TODO
+		if rt.SecretRef.Name != "" {
+			// reference secret
+			fmt.Println(rt.SecretRef.Name)
+
+			continue
+		}
+
+		// TODO
+		if rt.PlatformCredentialsSetRef.Name != "" {
+			// reference platformCredentialsSet
+			fmt.Println(rt.PlatformCredentialsSetRef.Name)
+
+			continue
+		}
+	}
+
+	// TODO
+	return nil, nil
+}
+
 func (sc *StackContainer) GenerateStackStatus() *zv1.StackStatus {
 	prescaling := zv1.PrescalingStatus{}
 	if sc.prescalingActive {

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -186,6 +186,8 @@ type StackResources struct {
 	Service    *v1.Service
 	Ingress    *networking.Ingress
 	RouteGroup *rgv1.RouteGroup
+
+	ResourceTemplates []zv1.ResourceTemplate
 }
 
 func NewContainer(stackset *zv1.StackSet, reconciler TrafficReconciler, backendWeightsAnnotationKey string, clusterDomains []string) *StackSetContainer {
@@ -385,6 +387,38 @@ func (sc *StackContainer) overrideParentResources() error {
 
 func (sc *StackContainer) updateFromResources() {
 	sc.stackReplicas = effectiveReplicas(sc.Stack.Spec.StackSpec.Replicas)
+
+	// Example usage
+	for _, rt := range sc.Stack.Spec.ResourceTemplates {
+		if rt.ConfigMap != nil {
+			// inline configmap
+			for k, v := range rt.ConfigMap {
+				fmt.Println(k, v)
+			}
+
+			continue
+		}
+		if rt.ConfigMapRef.Name != "" {
+			// reference configmap
+			fmt.Println(rt.ConfigMapRef.Name)
+
+			continue
+		}
+
+		if rt.SecretRef.Name != "" {
+			// reference secret
+			fmt.Println(rt.SecretRef.Name)
+
+			continue
+		}
+
+		if rt.PlatformCredentialsSetRef.Name != "" {
+			// reference platformCredentialsSet
+			fmt.Println(rt.PlatformCredentialsSetRef.Name)
+
+			continue
+		}
+	}
 
 	var deploymentUpdated, serviceUpdated, ingressUpdated, routeGroupUpdated, hpaUpdated bool
 


### PR DESCRIPTION
Part 2) of https://github.com/zalando-incubator/stackset-controller/pull/520.

Splitting up the ResourceTemplate PR into smaller parts to make slow progress.

Adding a stub implementation for processing resource templates.

TODO: add some stub test cases