### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - gosimple
   - govet
@@ -12,4 +11,3 @@ linters:
   - staticcheck
   - typecheck
   - unused
-  - varcheck


### PR DESCRIPTION
`deadcode` and `varcheck` are deprecated. They're currenlty unused throughout the code, so no need for replacement.