### PR TITLE
Prevent scaling up stacks without traffic

### DIFF
--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -223,6 +223,10 @@ func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, e
 		return nil, nil
 	}
 
+	if sc.ScaledDown() {
+		return nil, nil
+	}
+
 	result := &autoscaling.HorizontalPodAutoscaler{
 		ObjectMeta: sc.resourceMeta(),
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -895,6 +895,7 @@ func TestGenerateHPA(t *testing.T) {
 		autoscaler          *zv1.Autoscaler
 		expectedMinReplicas *int32
 		expectedMaxReplicas int32
+		noTrafficSince      time.Time
 		expectedMetrics     []autoscaling.MetricSpec
 		expectedBehavior    *autoscaling.HorizontalPodAutoscalerBehavior
 	}{
@@ -928,6 +929,24 @@ func TestGenerateHPA(t *testing.T) {
 			},
 			expectedBehavior: exampleBehavior,
 		},
+		{
+			name: "HPA when stack scaled down",
+			autoscaler: &zv1.Autoscaler{
+				MinReplicas: &min,
+				MaxReplicas: max,
+
+				Metrics: []zv1.AutoscalerMetrics{
+					{
+						Type:               zv1.CPUAutoscalerMetric,
+						AverageUtilization: &utilization,
+					},
+				},
+				Behavior: exampleBehavior,
+			},
+			noTrafficSince:   time.Now().Add(-time.Hour),
+			expectedMetrics:  nil,
+			expectedBehavior: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			podTemplate := zv1.PodTemplateSpec{
@@ -955,14 +974,20 @@ func TestGenerateHPA(t *testing.T) {
 						},
 					},
 				},
+				noTrafficSince: tc.noTrafficSince,
+				scaledownTTL:   time.Minute,
 			}
 
 			hpa, err := autoscalerContainer.GenerateHPA()
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedMinReplicas, hpa.Spec.MinReplicas)
-			require.Equal(t, tc.expectedMaxReplicas, hpa.Spec.MaxReplicas)
-			require.Equal(t, tc.expectedMetrics, hpa.Spec.Metrics)
-			require.Equal(t, tc.expectedBehavior, hpa.Spec.Behavior)
+			if tc.expectedBehavior == nil {
+				require.Nil(t, hpa)
+			} else {
+				require.Equal(t, tc.expectedMinReplicas, hpa.Spec.MinReplicas)
+				require.Equal(t, tc.expectedMaxReplicas, hpa.Spec.MaxReplicas)
+				require.Equal(t, tc.expectedMetrics, hpa.Spec.Metrics)
+				require.Equal(t, tc.expectedBehavior, hpa.Spec.Behavior)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Remove the HPA when a stack is scaled down and create it again if it scales up, this way we avoid scaling a downscaled stack and other components like kube-metrics-adapter also doesn't need to do work calculating metrics of an HPA which is not actually in use.

https://github.bus.zalan.do/teapot/issues/issues/3482