### PR TITLE
Reference Secrets for per stack versioning

### DIFF
--- a/cmd/e2e/README.md
+++ b/cmd/e2e/README.md
@@ -32,7 +32,7 @@ watch -n 10 "kubectl get -n foo stackset,stack,ing,ep,deployment"
 kubectl delete namespace foo; kubectl create namespace foo
 make
 ./build/stackset-controller --apiserver=http://127.0.0.1:8001 \
---enable-configmap-support --enable-routegroup-support \
+--enable-configmap-support --enable-secret-support --enable-routegroup-support \
 --enable-traffic-segments --annotated-traffic-segments \
 --sync-ingress-annotation=example.org/i-haz-synchronize \
 --sync-ingress-annotation=teapot.org/the-best --controller-id=foo \

--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -171,3 +171,83 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	}
 
 }
+
+func TestBrokenStackWithSecrets(t *testing.T) {
+	t.Parallel()
+
+	stacksetName := "stackset-broken-stacks-with-secret"
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().Secret().StackGC(1, 30)
+
+	firstVersion := "v1"
+	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
+	spec := factory.Create(t, firstVersion)
+	err := createStackSet(stacksetName, 0, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, firstVersion)
+	require.NoError(t, err)
+
+	unhealthyVersion := "v2"
+	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
+	spec = factory.Create(t, unhealthyVersion)
+	for _, cr := range spec.StackTemplate.Spec.ConfigurationResources {
+		if cr.SecretRef.Name != "" {
+			err := secretInterface().Delete(context.Background(), cr.SecretRef.Name, metav1.DeleteOptions{})
+			require.NoError(t, err)
+		}
+	}
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, unhealthyVersion)
+	require.NoError(t, err)
+
+	_, err = waitForIngress(t, stacksetName)
+	require.NoError(t, err)
+
+	initialWeights := map[string]float64{firstStack: 100}
+	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, initialWeights, nil).await()
+	require.NoError(t, err)
+
+	// Switch traffic to the second stack, this should fail
+	desiredWeights := map[string]float64{unhealthyStack: 100}
+	err = setDesiredTrafficWeightsStackset(stacksetName, desiredWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, desiredWeights, nil).await()
+	require.Error(t, err)
+
+	// Create a healthy stack
+	healthyVersion := "v3"
+	healthyStack := fmt.Sprintf("%s-%s", stacksetName, healthyVersion)
+	spec = factory.Create(t, healthyVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, healthyVersion)
+	require.NoError(t, err)
+
+	healthyWeights := map[string]float64{healthyStack: 100}
+	err = setDesiredTrafficWeightsStackset(stacksetName, healthyWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, healthyWeights, nil).await()
+	require.NoError(t, err)
+
+	// Create another healthy stack so we can test GC
+	finalVersion := "v4"
+	finalStack := fmt.Sprintf("%s-%s", stacksetName, finalVersion)
+	spec = factory.Create(t, finalVersion)
+	err = updateStackset(stacksetName, spec)
+	require.NoError(t, err)
+	_, err = waitForStack(t, stacksetName, finalVersion)
+	require.NoError(t, err)
+
+	finalWeights := map[string]float64{finalStack: 100}
+	err = setDesiredTrafficWeightsStackset(stacksetName, finalWeights)
+	require.NoError(t, err)
+	err = trafficWeightsUpdatedStackset(t, stacksetName, weightKindActual, finalWeights, nil).await()
+	require.NoError(t, err)
+
+	// Check that the unhealthy stack was deleted
+	for _, stack := range []string{unhealthyStack, firstStack} {
+		err := resourceDeleted(t, "stack", stack, stackInterface()).withTimeout(time.Second * 60).await()
+		require.NoError(t, err)
+	}
+
+}

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -101,6 +101,10 @@ func configMapInterface() corev1typed.ConfigMapInterface {
 	return kubernetesClient.CoreV1().ConfigMaps(namespace)
 }
 
+func secretInterface() corev1typed.SecretInterface {
+	return kubernetesClient.CoreV1().Secrets(namespace)
+}
+
 func requiredEnvar(envar string) string {
 	namespace := os.Getenv(envar)
 	if namespace == "" {

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -488,6 +488,14 @@ func waitForConfigMap(t *testing.T, configMapName string) (*corev1.ConfigMap, er
 	return configMapInterface().Get(context.Background(), configMapName, metav1.GetOptions{})
 }
 
+func waitForSecret(t *testing.T, secretName string) (*corev1.Secret, error) {
+	err := resourceCreated(t, "secret", secretName, secretInterface()).await()
+	if err != nil {
+		return nil, err
+	}
+	return secretInterface().Get(context.Background(), secretName, metav1.GetOptions{})
+}
+
 func waitForUpdatedRouteGroup(t *testing.T, name string, oldTimestamp string) (*rgv1.RouteGroup, error) {
 	err := newAwaiter(t, fmt.Sprintf("updated RouteGroup %s", name)).withPoll(func() (bool, error) {
 		rg, err := routegroupInterface().Get(context.Background(), name, metav1.GetOptions{})

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -48,6 +48,7 @@ var (
 		IngressSourceSwitchTTL      time.Duration
 		ReconcileWorkers            int
 		ConfigMapSupportEnabled     bool
+		SecretSupportEnabled        bool
 	}
 )
 
@@ -79,6 +80,7 @@ func main() {
 	kingpin.Flag("ingress-source-switch-ttl", "The ttl before an ingress source is deleted when replaced with another one e.g. switching from RouteGroup to Ingress or vice versa.").
 		Default(defaultIngressSourceSwitchTTL).DurationVar(&config.IngressSourceSwitchTTL)
 	kingpin.Flag("enable-configmap-support", "Enable support for ConfigMaps on StackSets.").Default("false").BoolVar(&config.ConfigMapSupportEnabled)
+	kingpin.Flag("enable-secret-support", "Enable support for Secrets on StackSets.").Default("false").BoolVar(&config.SecretSupportEnabled)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -110,6 +112,7 @@ func main() {
 		config.AnnotatedTrafficSegments,
 		config.SyncIngressAnnotations,
 		config.ConfigMapSupportEnabled,
+		config.SecretSupportEnabled,
 		config.IngressSourceSwitchTTL,
 	)
 	if err != nil {

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -382,7 +382,7 @@ func (c *StackSetController) ReconcileStackConfigMap(
 		}
 		rscName := rsc.ConfigMapRef.Name
 
-		if err := validateConfigurationResourcesNames(stack); err != nil {
+		if err := validateConfigurationResourceName(stack.Name, rscName); err != nil {
 			return err
 		}
 
@@ -453,7 +453,7 @@ func (c *StackSetController) ReconcileStackSecret(
 		}
 		rscName := rsc.SecretRef.Name
 
-		if err := validateConfigurationResourcesNames(stack); err != nil {
+		if err := validateConfigurationResourceName(stack.Name, rscName); err != nil {
 			return err
 		}
 

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -382,7 +382,7 @@ func (c *StackSetController) ReconcileStackConfigMap(
 		}
 		rscName := rsc.ConfigMapRef.Name
 
-		if err := validateConfigurationResourceNames(stack); err != nil {
+		if err := validateConfigurationResourcesNames(stack); err != nil {
 			return err
 		}
 
@@ -453,7 +453,7 @@ func (c *StackSetController) ReconcileStackSecret(
 		}
 		rscName := rsc.SecretRef.Name
 
-		if err := validateConfigurationResourceNames(stack); err != nil {
+		if err := validateConfigurationResourcesNames(stack); err != nil {
 			return err
 		}
 

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -33,8 +33,8 @@ func syncObjectMeta(target, source metav1.Object) {
 	target.SetAnnotations(source.GetAnnotations())
 }
 
-// equalResourceList compares existing Resources with list of
-// ConfigurationResources to be created for Stack
+// equalConfigMapList compares existing ConfigMaps with list of ConfigMaps
+// defined under ConfigurationResources to be assigned to Stack
 func equalConfigMapList(
 	existing []*apiv1.ConfigMap,
 	defined []zv1.ConfigurationResourcesSpec,
@@ -54,6 +54,8 @@ func equalConfigMapList(
 	return reflect.DeepEqual(existingName, crName)
 }
 
+// equalSecretList compares existing Secrets with list of Secrets
+// defined under ConfigurationResources to be assigned to Stack
 func equalSecretList(
 	existing []*apiv1.Secret,
 	defined []zv1.ConfigurationResourcesSpec,
@@ -419,6 +421,18 @@ func (c *StackSetController) ReconcileStackConfigMap(
 	return nil
 }
 
+// ReconcileStackSecret will update the named user-provided Secret to be
+// attached to the Stack by ownerReferences, when a list of Configuration
+// Resources are defined on the Stack template.
+//
+// The provided Secret name must be prefixed by the Stack name.
+// eg: Stack: myapp-v1 Secret: myapp-v1-my-secret
+//
+// User update of running versioned Secrets is not encouraged but is allowed
+// on consideration of emergency needs. Similarly, addition of Secrets to
+// running resources is also allowed, so the method checks for changes on the
+// ConfigurationResources to ensure all listed Secrets are properly linked
+// to the Stack.
 func (c *StackSetController) ReconcileStackSecret(
 	ctx context.Context,
 	stack *zv1.Stack,

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -324,10 +324,6 @@ func (c *StackSetController) ReconcileStackConfigMap(
 	existing []*apiv1.ConfigMap,
 	updateObjMeta func(*metav1.ObjectMeta) *metav1.ObjectMeta,
 ) error {
-	if stack.Spec.ConfigurationResources == nil {
-		return nil
-	}
-
 	for _, rsc := range stack.Spec.ConfigurationResources {
 		if rsc.ConfigMapRef.Name == "" {
 			continue
@@ -391,10 +387,6 @@ func (c *StackSetController) ReconcileStackSecret(
 	existing []*apiv1.Secret,
 	updateObjMeta func(*metav1.ObjectMeta) *metav1.ObjectMeta,
 ) error {
-	if stack.Spec.ConfigurationResources == nil {
-		return nil
-	}
-
 	for _, rsc := range stack.Spec.ConfigurationResources {
 		if rsc.SecretRef.Name == "" {
 			continue

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -1155,17 +1155,19 @@ func TestReconcileStackConfigMap(t *testing.T) {
 			err = env.CreateStacks(context.Background(), []zv1.Stack{tc.stack})
 			require.NoError(t, err)
 
-			if tc.template != nil {
-				for _, i := range tc.template {
-					err = env.CreateConfigMaps(context.Background(), []v1.ConfigMap{*i})
+			// Create case's existing resources
+			if tc.existing != nil {
+				for _, existing := range tc.existing {
+					err = env.CreateConfigMaps(context.Background(), []v1.ConfigMap{*existing})
 					require.NoError(t, err)
 				}
 			}
 
-			if tc.existing != nil {
-				for _, existing := range tc.existing {
-					err = env.CreateConfigMaps(context.Background(), []v1.ConfigMap{*existing})
-					for _, template := range tc.template {
+			// Create case's template resources
+			if tc.template != nil {
+				for _, template := range tc.template {
+					err = env.CreateConfigMaps(context.Background(), []v1.ConfigMap{*template})
+					for _, existing := range tc.existing {
 						if existing.Name == template.Name {
 							require.Error(t, err)
 						} else {
@@ -1181,7 +1183,7 @@ func TestReconcileStackConfigMap(t *testing.T) {
 				})
 			require.NoError(t, err)
 
-			// Versioned ConfigMap exists as expected
+			// Versioned ConfigMaps exist as expected
 			for _, expected := range tc.expected {
 				versioned, err := env.client.CoreV1().ConfigMaps(tc.stack.Namespace).Get(
 					context.Background(), expected.Name, metav1.GetOptions{})
@@ -1388,17 +1390,19 @@ func TestReconcileStackSecret(t *testing.T) {
 			err = env.CreateStacks(context.Background(), []zv1.Stack{tc.stack})
 			require.NoError(t, err)
 
-			if tc.template != nil {
-				for _, i := range tc.template {
-					err = env.CreateSecrets(context.Background(), []v1.Secret{*i})
+			// Create case's existing resources
+			if tc.existing != nil {
+				for _, existing := range tc.existing {
+					err = env.CreateSecrets(context.Background(), []v1.Secret{*existing})
 					require.NoError(t, err)
 				}
 			}
 
-			if tc.existing != nil {
-				for _, existing := range tc.existing {
-					err = env.CreateSecrets(context.Background(), []v1.Secret{*existing})
-					for _, template := range tc.template {
+			// Create case's template resources
+			if tc.template != nil {
+				for _, template := range tc.template {
+					err = env.CreateSecrets(context.Background(), []v1.Secret{*template})
+					for _, existing := range tc.existing {
 						if existing.Name == template.Name {
 							require.Error(t, err)
 						} else {
@@ -1414,7 +1418,7 @@ func TestReconcileStackSecret(t *testing.T) {
 				})
 			require.NoError(t, err)
 
-			// Versioned Secret exists as expected
+			// Versioned Secrets exist as expected
 			for _, expected := range tc.expected {
 				versioned, err := env.client.CoreV1().Secrets(tc.stack.Namespace).Get(
 					context.Background(), expected.Name, metav1.GetOptions{})

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -45,8 +45,6 @@ const (
 	defaultResetMinReplicasDelay = 10 * time.Minute
 )
 
-var configurationResourceNameError = "ConfigurationResource name must be prefixed by Stack name. ConfigurationResource: %s, Stack: %s"
-
 // StackSetController is the main controller. It watches for changes to
 // stackset resources and starts and maintains other controllers per
 // stackset resource.
@@ -1513,9 +1511,7 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 			rscName = rsc.SecretRef.Name
 		}
 
-		if !strings.HasPrefix(rscName, stack.Name) {
-			return fmt.Errorf(configurationResourceNameError, rscName, stack.Name)
-		}
+		return validateConfigurationResourceName(stack.Name, rscName)
 	}
 	return nil
 }
@@ -1524,7 +1520,8 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 // name is not prefixed by Stack name.
 func validateConfigurationResourceName(stack string, rsc string) error {
 	if !strings.HasPrefix(rsc, stack) {
-		return fmt.Errorf(configurationResourceNameError, rsc, stack)
+		return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name."+
+			"ConfigurationResource: %s, Stack: %s", rsc, stack)
 	}
 	return nil
 }

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -45,6 +45,8 @@ const (
 	defaultResetMinReplicasDelay = 10 * time.Minute
 )
 
+var configurationResourceNameError = "ConfigurationResource name must be prefixed by Stack name. ConfigurationResource: %s, Stack: %s"
+
 // StackSetController is the main controller. It watches for changes to
 // stackset resources and starts and maintains other controllers per
 // stackset resource.
@@ -1511,7 +1513,9 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 			rscName = rsc.SecretRef.Name
 		}
 
-		return validateConfigurationResourceName(stack.Name, rscName)
+		if !strings.HasPrefix(rscName, stack.Name) {
+			return fmt.Errorf(configurationResourceNameError, rscName, stack.Name)
+		}
 	}
 	return nil
 }
@@ -1520,8 +1524,7 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 // name is not prefixed by Stack name.
 func validateConfigurationResourceName(stack string, rsc string) error {
 	if !strings.HasPrefix(rsc, stack) {
-		return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name."+
-			"ConfigurationResource: %s, Stack: %s", rsc, stack)
+		return fmt.Errorf(configurationResourceNameError, rsc, stack)
 	}
 	return nil
 }

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -45,6 +45,8 @@ const (
 	defaultResetMinReplicasDelay = 10 * time.Minute
 )
 
+var configurationResourceNameError = "ConfigurationResource name must be prefixed by Stack name. ConfigurationResource: %s, Stack: %s"
+
 // StackSetController is the main controller. It watches for changes to
 // stackset resources and starts and maintains other controllers per
 // stackset resource.
@@ -1512,8 +1514,7 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 		}
 
 		if !strings.HasPrefix(rscName, stack.Name) {
-			return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name. "+
-				"ConfigurationResource: %s, Stack: %s", rscName, stack.Name)
+			return fmt.Errorf(configurationResourceNameError, rscName, stack.Name)
 		}
 	}
 	return nil
@@ -1523,8 +1524,7 @@ func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 // name is not prefixed by Stack name.
 func validateConfigurationResourceName(stack string, rsc string) error {
 	if !strings.HasPrefix(rsc, stack) {
-		return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name. "+
-			"ConfigurationResource: %s, Stack: %s", rsc, stack)
+		return fmt.Errorf(configurationResourceNameError, rsc, stack)
 	}
 	return nil
 }

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -781,7 +781,7 @@ func (c *StackSetController) CreateCurrentStack(ctx context.Context, ssc *core.S
 
 	if c.configMapSupportEnabled || c.secretSupportEnabled {
 		// ensure that ConfigurationResources are prefixed by Stack name.
-		if err := validateConfigurationResourceNames(newStack.Stack); err != nil {
+		if err := validateConfigurationResourcesNames(newStack.Stack); err != nil {
 			return err
 		}
 	}
@@ -1498,11 +1498,11 @@ func resourceReadyTime(timestamp time.Time, ttl time.Duration) bool {
 	return false
 }
 
-// validateConfigurationResourceNames returns an error if any ConfigurationResource
+// validateConfigurationResourcesNames returns an error if any ConfigurationResource
 // name is not prefixed by Stack name.
-func validateConfigurationResourceNames(stack *zv1.Stack) error {
-	var rscName string
+func validateConfigurationResourcesNames(stack *zv1.Stack) error {
 	for _, rsc := range stack.Spec.ConfigurationResources {
+		var rscName string
 		if rsc.ConfigMapRef.Name != "" {
 			rscName = rsc.ConfigMapRef.Name
 		}

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -781,7 +781,7 @@ func (c *StackSetController) CreateCurrentStack(ctx context.Context, ssc *core.S
 
 	if c.configMapSupportEnabled || c.secretSupportEnabled {
 		// ensure that ConfigurationResources are prefixed by Stack name.
-		if err := validateConfigurationResourcesNames(newStack.Stack); err != nil {
+		if err := validateAllConfigurationResourcesNames(newStack.Stack); err != nil {
 			return err
 		}
 	}
@@ -1500,7 +1500,7 @@ func resourceReadyTime(timestamp time.Time, ttl time.Duration) bool {
 
 // validateConfigurationResourcesNames returns an error if any ConfigurationResource
 // name is not prefixed by Stack name.
-func validateConfigurationResourcesNames(stack *zv1.Stack) error {
+func validateAllConfigurationResourcesNames(stack *zv1.Stack) error {
 	for _, rsc := range stack.Spec.ConfigurationResources {
 		var rscName string
 		if rsc.ConfigMapRef.Name != "" {
@@ -1515,6 +1515,16 @@ func validateConfigurationResourcesNames(stack *zv1.Stack) error {
 			return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name. "+
 				"ConfigurationResource: %s, Stack: %s", rscName, stack.Name)
 		}
+	}
+	return nil
+}
+
+// validateConfigurationResourceName returns an error if specific resource
+// name is not prefixed by Stack name.
+func validateConfigurationResourceName(stack string, rsc string) error {
+	if !strings.HasPrefix(rsc, stack) {
+		return fmt.Errorf("ConfigurationResource name must be prefixed by Stack name. "+
+			"ConfigurationResource: %s, Stack: %s", rsc, stack)
 	}
 	return nil
 }

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -66,6 +66,7 @@ func TestCollectResources(t *testing.T) {
 		services    []v1.Service
 		hpas        []autoscaling.HorizontalPodAutoscaler
 		configmaps  []v1.ConfigMap
+		secrets     []v1.Secret
 		expected    map[types.UID]*core.StackSetContainer
 	}{
 		{
@@ -211,6 +212,11 @@ func TestCollectResources(t *testing.T) {
 				{ObjectMeta: testOrphanMeta},          // owned by unknown stack
 				{ObjectMeta: testUnownedA1Meta},       // same name, but not owned by a stack
 			},
+			secrets: []v1.Secret{
+				{ObjectMeta: stackOwned(testStackA2)}, // stack owned
+				{ObjectMeta: testOrphanMeta},          // owned by unknown stack
+				{ObjectMeta: testUnownedA1Meta},       // same name, but not owned by a stack
+			},
 			expected: map[types.UID]*core.StackSetContainer{
 				testStacksetA.UID: {
 					StackSet: &testStacksetA,
@@ -227,6 +233,7 @@ func TestCollectResources(t *testing.T) {
 								Ingress:    &networking.Ingress{ObjectMeta: stackOwned(testStackA2)},
 								RouteGroup: &rgv1.RouteGroup{ObjectMeta: stackOwned(testStackA2)},
 								ConfigMaps: []*v1.ConfigMap{{ObjectMeta: stackOwned(testStackA2)}},
+								Secrets:    []*v1.Secret{{ObjectMeta: stackOwned(testStackA2)}},
 							},
 						},
 					},
@@ -307,6 +314,9 @@ func TestCollectResources(t *testing.T) {
 			require.NoError(t, err)
 
 			err = env.CreateConfigMaps(context.Background(), tc.configmaps)
+			require.NoError(t, err)
+
+			err = env.CreateSecrets(context.Background(), tc.secrets)
 			require.NoError(t, err)
 
 			resources, err := env.controller.collectResources(context.Background())

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -72,6 +72,7 @@ func NewTestEnvironment() *testEnvironment {
 		true,
 		[]string{},
 		true,
+		true,
 		time.Minute,
 	)
 
@@ -165,6 +166,16 @@ func (f *testEnvironment) CreateHPAs(ctx context.Context, hpas []autoscaling.Hor
 func (f *testEnvironment) CreateConfigMaps(ctx context.Context, configMaps []v1.ConfigMap) error {
 	for _, configMap := range configMaps {
 		_, err := f.client.CoreV1().ConfigMaps(configMap.Namespace).Create(ctx, &configMap, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *testEnvironment) CreateSecrets(ctx context.Context, secrets []v1.Secret) error {
+	for _, secret := range secrets {
+		_, err := f.client.CoreV1().Secrets(secret.Namespace).Create(ctx, &secret, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}

--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -356,7 +356,15 @@ spec:
                     the config resources to be created
                   properties:
                     configMapRef:
-                      description: ConfigMap to be versioned for Stack
+                      description: ConfigMap to be owned by Stack
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    secretRef:
+                      description: Secret to be owned by Stack
                       properties:
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -603,7 +603,16 @@ spec:
                             to defined the config resources to be created
                           properties:
                             configMapRef:
-                              description: ConfigMap to be versioned for Stack
+                              description: ConfigMap to be owned by Stack
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: Secret to be owned by Stack
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/e2e/apply/deployment.yaml
+++ b/e2e/apply/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           - "--cluster-domain={{{CLUSTER_DOMAIN}}}"
           - "--cluster-domain={{{CLUSTER_DOMAIN_INTERNAL}}}"
           - "--enable-configmap-support"
+          - "--enable-secret-support"
           - "--enable-routegroup-support"
           - "--enable-traffic-segments"
           - "--annotated-traffic-segments"

--- a/e2e/apply/rbac.yaml
+++ b/e2e/apply/rbac.yaml
@@ -93,6 +93,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - get

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -437,8 +437,11 @@ type StackSpec struct {
 // ConfigurationResourcesSpec makes it possible to defined the config resources to be created
 // +k8s:deepcopy-gen=true
 type ConfigurationResourcesSpec struct {
-	// ConfigMap to be versioned for Stack
+	// ConfigMap to be owned by Stack
 	ConfigMapRef v1.LocalObjectReference `json:"configMapRef,omitempty"`
+
+	// Secret to be owned by Stack
+	SecretRef v1.LocalObjectReference `json:"secretRef,omitempty"`
 }
 
 // StackSpecInternal is the spec part of the Stack, including `ingress` and

--- a/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
@@ -122,6 +122,7 @@ func (in *AutoscalerMetrics) DeepCopy() *AutoscalerMetrics {
 func (in *ConfigurationResourcesSpec) DeepCopyInto(out *ConfigurationResourcesSpec) {
 	*out = *in
 	out.ConfigMapRef = in.ConfigMapRef
+	out.SecretRef = in.SecretRef
 	return
 }
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -210,6 +210,7 @@ type StackResources struct {
 	RouteGroup        *rgv1.RouteGroup
 	RouteGroupSegment *rgv1.RouteGroup
 	ConfigMaps        []*v1.ConfigMap
+	Secrets           []*v1.Secret
 }
 
 func NewContainer(stackset *zv1.StackSet, reconciler TrafficReconciler, backendWeightsAnnotationKey string, clusterDomains []string) *StackSetContainer {


### PR DESCRIPTION
Following the [Reference ConfigMap for per stack versioning](https://github.com/zalando-incubator/stackset-controller/pull/520) and [Revised adaptation of ConfigMap per Stack](https://github.com/zalando-incubator/stackset-controller/pull/550), this Pull Request implements **Secrets versioned by reference**.

The expected behaviour is that given a **Secret** named in the `<stack-name>-<secret-name>` pattern is defined on `stackTemplate.configurationResources.secretRef`, Stackset Controller identifies the deployed **Secret** and updates it with the **Stack** info on `ownerReferences`. 