### PR TITLE
Isolate permissions of e2e stackset-controller to its own namespace to avoid clashes

### DIFF
--- a/e2e/apply/rbac.yaml
+++ b/e2e/apply/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: stackset-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: stackset-controller
 rules:
@@ -103,14 +103,13 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: stackset-controller-e2e
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: stackset-controller
 subjects:
 - kind: ServiceAccount
   name: stackset-controller
-  namespace: {{{NAMESPACE}}}


### PR DESCRIPTION
Since introducing the [`--namespace` flag](https://github.com/zalando-incubator/stackset-controller/pull/566) and running e2e tests with it, we can reduce stackset-controller's permissions to a single namespace as well.

This is less subtle than it seems to be as this allows for _correctly_ running multiple stackset-controller e2e test runs in parallel (i.e. in different concurrent PRs). We did this before but it was flawed because some resources, such as the [`ClusterRole`](https://github.com/zalando-incubator/stackset-controller/blob/c9410526ba568e2ec8e9fc7bddad8895ceff4f4b/e2e/apply/rbac.yaml#L8-L10), were shared between different open PRs and therefore would overwrite each other, leading to unpredictable results when changed.

By isolating every e2e run into a separate namespace, we'll avoid running into any of these problems.