### PR TITLE
Enable traffic segments on annotated StackSets only with --annotated-traffic-segments.

### DIFF
--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -66,11 +67,15 @@ func main() {
 	kingpin.Flag("enable-routegroup-support", "Enable support for RouteGroups on StackSets.").Default("false").BoolVar(&config.RouteGroupSupportEnabled)
 	kingpin.Flag(
 		"enable-traffic-segments",
-		"Enable support for traffic segments.",
+		"Support traffic segments by default. "+
+			"Ignored when also setting --annotated-traffic-segments.",
 	).Default("false").BoolVar(&config.TrafficSegmentsEnabled)
 	kingpin.Flag(
 		"annotated-traffic-segments",
-		"Only support traffic segments when annotated. Requires --enable-traffic-segments.",
+		fmt.Sprintf(
+			"Support traffic segments annotated with %q.",
+			controller.TrafficSegmentsAnnotationKey,
+		),
 	).Default("false").BoolVar(&config.AnnotatedTrafficSegments)
 	kingpin.Flag(
 		"sync-ingress-annotation",

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -249,11 +249,11 @@ func (c *StackSetController) injectSegmentAnnotation(
 	ctx context.Context,
 	stackSet *zv1.StackSet,
 ) bool {
-	if !c.trafficSegmentsEnabled {
+	if c.annotatedTrafficSegments {
 		return false
 	}
 
-	if c.annotatedTrafficSegments {
+	if !c.trafficSegmentsEnabled {
 		return false
 	}
 
@@ -310,13 +310,14 @@ func (c *StackSetController) collectResources(ctx context.Context) (map[types.UI
 		}
 
 		stacksetContainer := core.NewContainer(&stackset, reconciler, c.backendWeightsAnnotationKey, c.clusterDomains)
-		if c.trafficSegmentsEnabled &&
-			stackset.Annotations[TrafficSegmentsAnnotationKey] == "true" {
+		if c.trafficSegmentsEnabled || c.annotatedTrafficSegments {
 
-			stacksetContainer.EnableSegmentTraffic()
-			stacksetContainer.SynchronizeIngressAnnotations(
-				c.syncIngressAnnotations,
-			)
+			if stackset.Annotations[TrafficSegmentsAnnotationKey] == "true" {
+				stacksetContainer.EnableSegmentTraffic()
+				stacksetContainer.SynchronizeIngressAnnotations(
+					c.syncIngressAnnotations,
+				)
+			}
 		}
 		stacksets[uid] = stacksetContainer
 	}

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -328,7 +328,9 @@ func TestSegmentEnablement(t *testing.T) {
 				testStackset("foo", "default", "123"),
 				testStacksetAnnotatedSegment("bar", "default", "456"),
 			},
-			segmentsEnabled: map[types.UID]bool{"123": false, "456": false},
+			annotatedTrafficSegments: false,
+			trafficSegmentsEnabled:   false,
+			segmentsEnabled:          map[types.UID]bool{"123": false, "456": false},
 		},
 		{
 			stacksets: []zv1.StackSet{
@@ -336,6 +338,7 @@ func TestSegmentEnablement(t *testing.T) {
 				testStacksetAnnotatedSegment("bar", "default", "0AB"),
 			},
 			annotatedTrafficSegments: true,
+			trafficSegmentsEnabled:   false,
 			segmentsEnabled:          map[types.UID]bool{"789": false, "0AB": true},
 		},
 		{
@@ -343,8 +346,9 @@ func TestSegmentEnablement(t *testing.T) {
 				testStackset("foo", "default", "CDE"),
 				testStacksetAnnotatedSegment("bar", "default", "FGH"),
 			},
-			trafficSegmentsEnabled: true,
-			segmentsEnabled:        map[types.UID]bool{"CDE": false, "FGH": true},
+			annotatedTrafficSegments: false,
+			trafficSegmentsEnabled:   true,
+			segmentsEnabled:          map[types.UID]bool{"CDE": false, "FGH": true},
 		},
 		{
 			stacksets: []zv1.StackSet{

--- a/controller/stackset_test.go
+++ b/controller/stackset_test.go
@@ -318,10 +318,10 @@ func TestCollectResources(t *testing.T) {
 
 func TestSegmentEnablement(t *testing.T) {
 	for _, tc := range []struct {
-		stacksets []zv1.StackSet
+		stacksets                []zv1.StackSet
 		annotatedTrafficSegments bool
-		trafficSegmentsEnabled bool
-		segmentsEnabled map[types.UID]bool
+		trafficSegmentsEnabled   bool
+		segmentsEnabled          map[types.UID]bool
 	}{
 		{
 			stacksets: []zv1.StackSet{
@@ -336,7 +336,7 @@ func TestSegmentEnablement(t *testing.T) {
 				testStacksetAnnotatedSegment("bar", "default", "0AB"),
 			},
 			annotatedTrafficSegments: true,
-			segmentsEnabled: map[types.UID]bool{"789": false, "0AB": true},
+			segmentsEnabled:          map[types.UID]bool{"789": false, "0AB": true},
 		},
 		{
 			stacksets: []zv1.StackSet{
@@ -344,7 +344,7 @@ func TestSegmentEnablement(t *testing.T) {
 				testStacksetAnnotatedSegment("bar", "default", "FGH"),
 			},
 			trafficSegmentsEnabled: true,
-			segmentsEnabled: map[types.UID]bool{"CDE": false, "FGH": true},
+			segmentsEnabled:        map[types.UID]bool{"CDE": false, "FGH": true},
 		},
 		{
 			stacksets: []zv1.StackSet{
@@ -352,10 +352,10 @@ func TestSegmentEnablement(t *testing.T) {
 				testStacksetAnnotatedSegment("bar", "default", "LMN"),
 			},
 			annotatedTrafficSegments: true,
-			trafficSegmentsEnabled: true,
-			segmentsEnabled: map[types.UID]bool{"IJK": false, "LMN": true},
+			trafficSegmentsEnabled:   true,
+			segmentsEnabled:          map[types.UID]bool{"IJK": false, "LMN": true},
 		},
-	}{
+	} {
 		env := NewTestEnvironment()
 		env.controller.annotatedTrafficSegments = tc.annotatedTrafficSegments
 		env.controller.trafficSegmentsEnabled = tc.trafficSegmentsEnabled

--- a/controller/test_helpers.go
+++ b/controller/test_helpers.go
@@ -182,6 +182,12 @@ func testStackset(name, namespace string, uid types.UID) zv1.StackSet {
 	}
 }
 
+func testStacksetAnnotatedSegment(name, namespace string, uid types.UID) zv1.StackSet {
+	res := testStackset(name, namespace, uid)
+	res.Annotations = map[string]string{TrafficSegmentsAnnotationKey: "true"}
+	return res
+}
+
 func testStack(name, namespace string, uid types.UID, ownerStack zv1.StackSet) zv1.Stack {
 	return zv1.Stack{
 		TypeMeta: metav1.TypeMeta{

--- a/e2e/apply/deployment.yaml
+++ b/e2e/apply/deployment.yaml
@@ -29,7 +29,6 @@ spec:
           - "--cluster-domain={{{CLUSTER_DOMAIN_INTERNAL}}}"
           - "--enable-configmap-support"
           - "--enable-routegroup-support"
-          - "--enable-traffic-segments"
           - "--annotated-traffic-segments"
           - "--sync-ingress-annotation=example.org/i-haz-synchronize"
           - "--sync-ingress-annotation=teapot.org/the-best"

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*
@@ -16,5 +17,7 @@ limitations under the License.
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools
 
-import _ "k8s.io/code-generator"
-import _ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+import (
+	_ "k8s.io/code-generator"
+	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+)

--- a/pkg/core/conversion.go
+++ b/pkg/core/conversion.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	autoscaling "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 )

--- a/pkg/core/generated.conversion.go
+++ b/pkg/core/generated.conversion.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-	"k8s.io/api/autoscaling/v2beta1"
 	autoscaling "k8s.io/api/autoscaling/v2"
+	"k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/apimachinery/pkg/conversion"
 )
 

--- a/pkg/core/helpers.go
+++ b/pkg/core/helpers.go
@@ -31,9 +31,7 @@ func mergeLabels(labelMaps ...map[string]string) map[string]string {
 // syncAnnotations synchronizes the given "dest" map with the key/pair values
 // from "src". The function removes all keys from "dest" that are not present in
 // "src", but specified in "annotationsToSync".
-func syncAnnotations(dest, src map[string]string, annotationsToSync []string) (
-	map[string]string,
-) {
+func syncAnnotations(dest, src map[string]string, annotationsToSync []string) map[string]string {
 	res := mergeLabels(dest, src)
 
 	for _, k := range annotationsToSync {

--- a/pkg/core/helpers_test.go
+++ b/pkg/core/helpers_test.go
@@ -67,36 +67,36 @@ func TestSyncAnnotations(t *testing.T) {
 	}
 }
 
-func TestGetKeyValues(t * testing.T) {
+func TestGetKeyValues(t *testing.T) {
 	for _, tc := range []struct {
-		keys []string
+		keys        []string
 		annotations map[string]string
-		expected map[string]string
+		expected    map[string]string
 	}{
 		{
-			keys: []string{"a"},
+			keys:        []string{"a"},
 			annotations: map[string]string{"a": "1", "b": "2"},
-			expected: map[string]string{"a": "1"},
+			expected:    map[string]string{"a": "1"},
 		},
 		{
-			keys: []string{"a", "b"},
+			keys:        []string{"a", "b"},
 			annotations: map[string]string{"a": "1", "b": "2"},
-			expected: map[string]string{"a": "1", "b": "2"},
+			expected:    map[string]string{"a": "1", "b": "2"},
 		},
 		{
-			keys: []string{},
+			keys:        []string{},
 			annotations: map[string]string{"a": "1", "b": "2"},
-			expected: map[string]string{},
+			expected:    map[string]string{},
 		},
 		{
-			keys: []string{"c"},
+			keys:        []string{"c"},
 			annotations: map[string]string{"a": "1", "b": "2"},
-			expected: map[string]string{},
+			expected:    map[string]string{},
 		},
 		{
-			keys: []string{"a", "c"},
+			keys:        []string{"a", "c"},
 			annotations: map[string]string{"a": "1", "b": "2"},
-			expected: map[string]string{"a": "1"},
+			expected:    map[string]string{"a": "1"},
 		},
 	} {
 		res := getKeyValues(tc.keys, tc.annotations)

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -486,26 +486,26 @@ func TestStackGenerateIngressSegment(t *testing.T) {
 
 func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 	for _, tc := range []struct {
-		ingressSpec       *zv1.StackSetIngressSpec
-		ingresssAnnotationsToSync	[]string
-		syncAnnotationsInIngress map[string]string
-		expected map[string]string
+		ingressSpec               *zv1.StackSetIngressSpec
+		ingresssAnnotationsToSync []string
+		syncAnnotationsInIngress  map[string]string
+		expected                  map[string]string
 	}{
 		{
 			ingressSpec: &zv1.StackSetIngressSpec{
 				Hosts: []string{"example.teapot.zalan.do"},
 			},
 			ingresssAnnotationsToSync: []string{},
-			syncAnnotationsInIngress: map[string]string{},
-			expected: map[string]string{},
+			syncAnnotationsInIngress:  map[string]string{},
+			expected:                  map[string]string{},
 		},
 		{
 			ingressSpec: &zv1.StackSetIngressSpec{
 				Hosts: []string{"example.teapot.zalan.do"},
 			},
 			ingresssAnnotationsToSync: []string{"aSync"},
-			syncAnnotationsInIngress: map[string]string{"aSync": "1Sync"},
-			expected: map[string]string{"aSync": "1Sync"},
+			syncAnnotationsInIngress:  map[string]string{"aSync": "1Sync"},
+			expected:                  map[string]string{"aSync": "1Sync"},
 		},
 		{
 			ingressSpec: &zv1.StackSetIngressSpec{
@@ -517,8 +517,8 @@ func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 				},
 			},
 			ingresssAnnotationsToSync: []string{"aSync"},
-			syncAnnotationsInIngress: map[string]string{"aSync": "1Sync"},
-			expected: map[string]string{"a": "1", "aSync": "1Sync"},
+			syncAnnotationsInIngress:  map[string]string{"aSync": "1Sync"},
+			expected:                  map[string]string{"a": "1", "aSync": "1Sync"},
 		},
 		{
 			ingressSpec: &zv1.StackSetIngressSpec{
@@ -528,8 +528,8 @@ func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 				},
 			},
 			ingresssAnnotationsToSync: []string{"aSync"},
-			syncAnnotationsInIngress: map[string]string{},
-			expected: map[string]string{},
+			syncAnnotationsInIngress:  map[string]string{},
+			expected:                  map[string]string{},
 		},
 		{
 			ingressSpec: &zv1.StackSetIngressSpec{
@@ -539,17 +539,17 @@ func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 				},
 			},
 			ingresssAnnotationsToSync: []string{"aSync"},
-			syncAnnotationsInIngress: map[string]string{},
-			expected: map[string]string{"a": "1"},
+			syncAnnotationsInIngress:  map[string]string{},
+			expected:                  map[string]string{"a": "1"},
 		},
-	}{
+	} {
 		backendPort := intstr.FromInt(int(80))
 		c := &StackContainer{
 			Stack: &zv1.Stack{
 				ObjectMeta: testStackMeta,
 			},
-			ingressSpec:       tc.ingressSpec,
-			backendPort:       &backendPort,
+			ingressSpec:              tc.ingressSpec,
+			backendPort:              &backendPort,
 			ingressAnnotationsToSync: tc.ingresssAnnotationsToSync,
 			syncAnnotationsInIngress: tc.syncAnnotationsInIngress,
 		}
@@ -572,8 +572,8 @@ func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 
 func TestStackGenerateRouteGroup(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		routeGroupSpec *zv1.RouteGroupSpec
+		name                string
+		routeGroupSpec      *zv1.RouteGroupSpec
 		expectDisabled      bool
 		expectError         bool
 		expectedAnnotations map[string]string
@@ -833,28 +833,28 @@ func TestStackGenerateRouteGroupSegment(t *testing.T) {
 }
 func TestGenerateRouteGroupSegmentWithSyncAnnotations(t *testing.T) {
 	for _, tc := range []struct {
-		rgSpec       *zv1.RouteGroupSpec
-		ingresssAnnotationsToSync	[]string
+		rgSpec                      *zv1.RouteGroupSpec
+		ingresssAnnotationsToSync   []string
 		syncAnnotationsInRouteGroup map[string]string
-		expected map[string]string
+		expected                    map[string]string
 	}{
 		{
 			rgSpec: &zv1.RouteGroupSpec{
 				Hosts:  []string{"example.teapot.zalan.do"},
 				Routes: []rgv1.RouteGroupRouteSpec{{}},
 			},
-			ingresssAnnotationsToSync: []string{},
+			ingresssAnnotationsToSync:   []string{},
 			syncAnnotationsInRouteGroup: map[string]string{},
-			expected: map[string]string{},
+			expected:                    map[string]string{},
 		},
 		{
 			rgSpec: &zv1.RouteGroupSpec{
 				Hosts:  []string{"example.teapot.zalan.do"},
 				Routes: []rgv1.RouteGroupRouteSpec{{}},
 			},
-			ingresssAnnotationsToSync: []string{"aSync"},
+			ingresssAnnotationsToSync:   []string{"aSync"},
 			syncAnnotationsInRouteGroup: map[string]string{"aSync": "1Sync"},
-			expected: map[string]string{"aSync": "1Sync"},
+			expected:                    map[string]string{"aSync": "1Sync"},
 		},
 		{
 			rgSpec: &zv1.RouteGroupSpec{
@@ -864,9 +864,9 @@ func TestGenerateRouteGroupSegmentWithSyncAnnotations(t *testing.T) {
 				Hosts:  []string{"example.teapot.zalan.do"},
 				Routes: []rgv1.RouteGroupRouteSpec{{}},
 			},
-			ingresssAnnotationsToSync: []string{"aSync"},
+			ingresssAnnotationsToSync:   []string{"aSync"},
 			syncAnnotationsInRouteGroup: map[string]string{"aSync": "1Sync"},
-			expected: map[string]string{"a": "1", "aSync": "1Sync"},
+			expected:                    map[string]string{"a": "1", "aSync": "1Sync"},
 		},
 		{
 			rgSpec: &zv1.RouteGroupSpec{
@@ -876,9 +876,9 @@ func TestGenerateRouteGroupSegmentWithSyncAnnotations(t *testing.T) {
 				Hosts:  []string{"example.teapot.zalan.do"},
 				Routes: []rgv1.RouteGroupRouteSpec{{}},
 			},
-			ingresssAnnotationsToSync: []string{"aSync"},
+			ingresssAnnotationsToSync:   []string{"aSync"},
 			syncAnnotationsInRouteGroup: map[string]string{},
-			expected: map[string]string{},
+			expected:                    map[string]string{},
 		},
 		{
 			rgSpec: &zv1.RouteGroupSpec{
@@ -888,19 +888,19 @@ func TestGenerateRouteGroupSegmentWithSyncAnnotations(t *testing.T) {
 				Hosts:  []string{"example.teapot.zalan.do"},
 				Routes: []rgv1.RouteGroupRouteSpec{{}},
 			},
-			ingresssAnnotationsToSync: []string{"aSync"},
+			ingresssAnnotationsToSync:   []string{"aSync"},
 			syncAnnotationsInRouteGroup: map[string]string{},
-			expected: map[string]string{"a": "1"},
+			expected:                    map[string]string{"a": "1"},
 		},
-	}{
+	} {
 		backendPort := intstr.FromInt(int(80))
 		c := &StackContainer{
 			Stack: &zv1.Stack{
 				ObjectMeta: testStackMeta,
 			},
-			routeGroupSpec:   tc.rgSpec,
-			backendPort:       &backendPort,
-			ingressAnnotationsToSync: tc.ingresssAnnotationsToSync,
+			routeGroupSpec:              tc.rgSpec,
+			backendPort:                 &backendPort,
+			ingressAnnotationsToSync:    tc.ingresssAnnotationsToSync,
 			syncAnnotationsInRouteGroup: tc.syncAnnotationsInRouteGroup,
 		}
 		res, _ := c.GenerateRouteGroupSegment()

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -409,7 +409,7 @@ func TestStackSetUpdateFromResourcesPopulatesIngress(t *testing.T) {
 		expectedIngress *zv1.StackSetIngressSpec
 	}{
 		{
-			name: "no ingress",
+			name:            "no ingress",
 			expectedIngress: nil,
 		},
 		{
@@ -483,7 +483,7 @@ func TestStackSetUpdateFromResourcesPopulatesBackendPort(t *testing.T) {
 				"v1": {
 					Stack: &zv1.Stack{
 						Spec: zv1.StackSpecInternal{
-							Ingress: tc.spec.Ingress,
+							Ingress:         tc.spec.Ingress,
 							ExternalIngress: tc.spec.ExternalIngress,
 						},
 					},
@@ -546,7 +546,7 @@ func TestStackSetUpdateFromResourcesScaleDown(t *testing.T) {
 				"v1": {
 					Stack: &zv1.Stack{
 						Spec: zv1.StackSpecInternal{
-							Ingress: tc.ingress,
+							Ingress:         tc.ingress,
 							ExternalIngress: tc.externalIngress,
 						},
 					},
@@ -592,11 +592,11 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 	t *testing.T,
 ) {
 	for _, tc := range []struct {
-		ingressAnnotationsToSync []string
-		stackSet zv1.StackSetSpec
-		ingress 	  *zv1.StackSetIngressSpec
-		expectedAnnotationsToSync    		  []string
-		expectedSyncAnnotationsInIngress map[string]string
+		ingressAnnotationsToSync            []string
+		stackSet                            zv1.StackSetSpec
+		ingress                             *zv1.StackSetIngressSpec
+		expectedAnnotationsToSync           []string
+		expectedSyncAnnotationsInIngress    map[string]string
 		expectedSyncAnnotationsInRouteGroup map[string]string
 	}{
 		{
@@ -606,7 +606,7 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 					EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
 						Annotations: map[string]string{
 							"aSync": "1Sync",
-							"a": "1",
+							"a":     "1",
 						},
 					},
 					BackendPort: intstr.FromInt(8080),
@@ -628,8 +628,8 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 					BackendPort: intstr.FromInt(8080),
 				},
 			},
-			expectedAnnotationsToSync: []string{"aSync"},
-			expectedSyncAnnotationsInIngress: map[string]string{},
+			expectedAnnotationsToSync:           []string{"aSync"},
+			expectedSyncAnnotationsInIngress:    map[string]string{},
 			expectedSyncAnnotationsInRouteGroup: map[string]string{},
 		},
 		{
@@ -639,15 +639,15 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 					EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
 						Annotations: map[string]string{
 							"aSync": "1Sync",
-							"a": "1",
+							"a":     "1",
 						},
 					},
-					Hosts:  []string{"example.teapot.zalan.do"},
-					Routes: []rgv1.RouteGroupRouteSpec{{}},
+					Hosts:       []string{"example.teapot.zalan.do"},
+					Routes:      []rgv1.RouteGroupRouteSpec{{}},
 					BackendPort: 8080,
 				},
 			},
-			expectedAnnotationsToSync: []string{"aSync"},
+			expectedAnnotationsToSync:        []string{"aSync"},
 			expectedSyncAnnotationsInIngress: map[string]string{},
 			expectedSyncAnnotationsInRouteGroup: map[string]string{
 				"aSync": "1Sync",
@@ -660,7 +660,7 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 					EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
 						Annotations: map[string]string{
 							"aSync": "1Sync",
-							"a": "1",
+							"a":     "1",
 						},
 					},
 					BackendPort: intstr.FromInt(8080),
@@ -669,11 +669,11 @@ func TestStackSetUpdateFromResourcesSynchronizedIngressAnnotations(
 					EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
 						Annotations: map[string]string{
 							"aSync": "1Sync",
-							"a": "1",
+							"a":     "1",
 						},
 					},
-					Hosts:  []string{"example.teapot.zalan.do"},
-					Routes: []rgv1.RouteGroupRouteSpec{{}},
+					Hosts:       []string{"example.teapot.zalan.do"},
+					Routes:      []rgv1.RouteGroupRouteSpec{{}},
 					BackendPort: 8080,
 				},
 			},


### PR DESCRIPTION
Right now to enable traffic segments via annotation we need to set both `--enable-traffic-segments` and `--annotated-traffic-segments`. This can be dangerous, because it is very easy to set first `--enable-traffic-segments` which would trigger migration to traffic segments of _all_ StackSets.

With this Pull Request you will only need to set `--annotated-traffic-segments` to enable traffic segments via annotations. I this way, we only need to set this flag in the corresponding migration stages.

Additionally, this PR formats the code with `goimports`.