### PR TITLE
Point HPA to segment resource, when ingress versioning is set.

### DIFF
--- a/pkg/core/autoscaler.go
+++ b/pkg/core/autoscaler.go
@@ -122,7 +122,12 @@ func (l autoscalerMetricsList) Less(i, j int) bool {
 	return false
 }
 
-func convertCustomMetrics(stacksetName, stackName, namespace string, metrics autoscalerMetricsList, trafficWeight float64) ([]autoscaling.MetricSpec, map[string]string, error) {
+func convertCustomMetrics(
+	ingressResourceName, stackName, namespace string,
+	metrics autoscalerMetricsList,
+	trafficWeight float64,
+) ([]autoscaling.MetricSpec, map[string]string, error) {
+
 	var resultMetrics []autoscaling.MetricSpec
 	resultAnnotations := make(map[string]string)
 
@@ -140,9 +145,9 @@ func convertCustomMetrics(stacksetName, stackName, namespace string, metrics aut
 		case zv1.PodJSONAutoscalerMetric:
 			generated, annotations, err = podJsonMetric(m)
 		case zv1.IngressAutoscalerMetric:
-			generated, err = ingressMetric(m, stacksetName, stackName)
+			generated, err = ingressMetric(m, ingressResourceName, stackName)
 		case zv1.RouteGroupAutoscalerMetric:
-			generated, err = routegroupMetric(m, stacksetName, stackName)
+			generated, err = routegroupMetric(m, ingressResourceName, stackName)
 		case zv1.ZMONAutoscalerMetric:
 			generated, annotations, err = zmonMetric(m, i, stackName, namespace)
 		case zv1.ScalingScheduleMetric:

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -253,7 +253,21 @@ func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, e
 	result.Spec.MinReplicas = autoscalerSpec.MinReplicas
 	result.Spec.MaxReplicas = autoscalerSpec.MaxReplicas
 
-	metrics, annotations, err := convertCustomMetrics(sc.stacksetName, sc.Name(), sc.Namespace(), autoscalerMetricsList(autoscalerSpec.Metrics), trafficWeight)
+	ingressResourceName := sc.stacksetName
+	if sc.Resources.IngressSegment != nil {
+		ingressResourceName = sc.Resources.IngressSegment.Name
+	}
+	if sc.Resources.RouteGroupSegment != nil {
+		ingressResourceName = sc.Resources.RouteGroupSegment.Name
+	}
+
+	metrics, annotations, err := convertCustomMetrics(
+		ingressResourceName,
+		sc.Name(),
+		sc.Namespace(),
+		autoscalerMetricsList(autoscalerSpec.Metrics),
+		trafficWeight,
+	)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This Pull Request sets the HPA to point either to the ingress/routegroup segment, when a stack has one or both of these resources.

This fixes the issue when an HPA was pointing to a non-existing central ingress resource, when traffic segments is enabled.