### PR TITLE
Generate HPA pointing to ingress segments.

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -1339,7 +1339,11 @@ func (c *StackSetController) ReconcileStackResources(ctx context.Context, ssc *c
 		return c.errorEventf(sc.Stack, "FailedManageDeployment", err)
 	}
 
-	err = c.ReconcileStackHPA(ctx, sc.Stack, sc.Resources.HPA, sc.GenerateHPA)
+	hpaGenerator := sc.GenerateHPA
+	if ssc.SupportsSegmentTraffic() {
+		hpaGenerator = sc.GenerateHPAToSegment
+	}
+	err = c.ReconcileStackHPA(ctx, sc.Stack, sc.Resources.HPA, hpaGenerator)
 	if err != nil {
 		return c.errorEventf(sc.Stack, "FailedManageHPA", err)
 	}

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -7986,6 +7986,14 @@ spec:
                                                           format: int32
                                                           type: integer
                                                         path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -8099,14 +8107,6 @@ spec:
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key

--- a/e2e/apply/sample-segment.yaml
+++ b/e2e/apply/sample-segment.yaml
@@ -25,6 +25,8 @@ spec:
         metrics:
         - type: CPU
           averageUtilization: 50
+        - type: Ingress
+          average: 20000m
       podTemplate:
         metadata:
           labels:

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -24,6 +24,8 @@ spec:
         metrics:
         - type: CPU
           averageUtilization: 50
+        - type: Ingress
+          average: 20000m
       podTemplate:
         metadata:
           labels:

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -227,7 +227,25 @@ func (sc *StackContainer) GenerateDeployment() *appsv1.Deployment {
 	return deployment
 }
 
-func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, error) {
+func (sc *StackContainer) GenerateHPAToSegment() (
+	*autoscaling.HorizontalPodAutoscaler,
+	error,
+) {
+	return sc.generateHPA(true)
+}
+
+func (sc *StackContainer) GenerateHPA() (
+	*autoscaling.HorizontalPodAutoscaler,
+	error,
+) {
+	return sc.generateHPA(false)
+
+}
+
+func (sc *StackContainer) generateHPA(toSegment bool) (
+	*autoscaling.HorizontalPodAutoscaler,
+	error,
+) {
 	autoscalerSpec := sc.Stack.Spec.StackSpec.Autoscaler
 	trafficWeight := sc.actualTrafficWeight
 
@@ -254,11 +272,8 @@ func (sc *StackContainer) GenerateHPA() (*autoscaling.HorizontalPodAutoscaler, e
 	result.Spec.MaxReplicas = autoscalerSpec.MaxReplicas
 
 	ingressResourceName := sc.stacksetName
-	if sc.Resources.IngressSegment != nil {
-		ingressResourceName = sc.Resources.IngressSegment.Name
-	}
-	if sc.Resources.RouteGroupSegment != nil {
-		ingressResourceName = sc.Resources.RouteGroupSegment.Name
+	if toSegment {
+		ingressResourceName = sc.Name() + SegmentSuffix
 	}
 
 	metrics, annotations, err := convertCustomMetrics(

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -1408,34 +1408,23 @@ func TestGenerateHPA(t *testing.T) {
 func TestGenerateHPAToSegment(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
-		minReplicas int32
-		maxReplicas int32
 		metricType  zv1.AutoscalerMetricType
-		metricValue int64
 		expectedRef string
 	}{
 		{
 			name:        "HPA metric points to ingress segment",
-			minReplicas: 1,
-			maxReplicas: 2,
 			metricType:  zv1.IngressAutoscalerMetric,
-			metricValue: 20,
 			expectedRef: "foo-v1-traffic-segment",
 		},
 		{
 			name:        "HPA metric points to routeGroup segment",
-			minReplicas: 1,
-			maxReplicas: 2,
 			metricType:  zv1.RouteGroupAutoscalerMetric,
-			metricValue: 20,
 			expectedRef: "foo-v1-traffic-segment",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metricValue := resource.NewQuantity(
-				tc.metricValue,
-				resource.DecimalSI,
-			)
+			metricValue := resource.NewQuantity(20, resource.DecimalSI)
+			var minReplicas int32 = 1
 
 			autoScalerContainer := &StackContainer{
 				Stack: &zv1.Stack{
@@ -1458,8 +1447,8 @@ func TestGenerateHPAToSegment(t *testing.T) {
 								},
 							},
 							Autoscaler: &zv1.Autoscaler{
-								MinReplicas: &tc.minReplicas,
-								MaxReplicas: tc.maxReplicas,
+								MinReplicas: &minReplicas,
+								MaxReplicas: 2,
 								Metrics: []zv1.AutoscalerMetrics{
 									{
 										Type:    tc.metricType,

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -1330,7 +1330,6 @@ func TestGenerateHPA(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
 		autoscaler          *zv1.Autoscaler
-		resources           StackResources
 		expectedMinReplicas *int32
 		expectedMaxReplicas int32
 		expectedMetrics     []autoscaling.MetricSpec
@@ -1349,122 +1348,6 @@ func TestGenerateHPA(t *testing.T) {
 					},
 				},
 				Behavior: exampleBehavior,
-			},
-			expectedMinReplicas: &min,
-			expectedMaxReplicas: max,
-			expectedMetrics: []autoscaling.MetricSpec{
-				{
-					Type: autoscaling.ResourceMetricSourceType,
-					Resource: &autoscaling.ResourceMetricSource{
-						Name: v1.ResourceCPU,
-						Target: autoscaling.MetricTarget{
-							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: &utilization,
-						},
-					},
-				},
-			},
-			expectedBehavior: exampleBehavior,
-		},
-		{
-			name: "HPA in a Stack with ingress segment",
-			autoscaler: &zv1.Autoscaler{
-				MinReplicas: &min,
-				MaxReplicas: max,
-
-				Metrics: []zv1.AutoscalerMetrics{
-					{
-						Type:               zv1.CPUAutoscalerMetric,
-						AverageUtilization: &utilization,
-					},
-				},
-				Behavior: exampleBehavior,
-			},
-			resources: StackResources{
-				IngressSegment: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "stack-traffic-segment",
-					},
-				},
-			},
-			expectedMinReplicas: &min,
-			expectedMaxReplicas: max,
-			expectedMetrics: []autoscaling.MetricSpec{
-				{
-					Type: autoscaling.ResourceMetricSourceType,
-					Resource: &autoscaling.ResourceMetricSource{
-						Name: v1.ResourceCPU,
-						Target: autoscaling.MetricTarget{
-							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: &utilization,
-						},
-					},
-				},
-			},
-			expectedBehavior: exampleBehavior,
-		},
-		{
-			name: "HPA in a Stack with routegroup segment",
-			autoscaler: &zv1.Autoscaler{
-				MinReplicas: &min,
-				MaxReplicas: max,
-
-				Metrics: []zv1.AutoscalerMetrics{
-					{
-						Type:               zv1.CPUAutoscalerMetric,
-						AverageUtilization: &utilization,
-					},
-				},
-				Behavior: exampleBehavior,
-			},
-			resources: StackResources{
-				RouteGroupSegment: &rgv1.RouteGroup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "stack-traffic-segment",
-					},
-				},
-			},
-			expectedMinReplicas: &min,
-			expectedMaxReplicas: max,
-			expectedMetrics: []autoscaling.MetricSpec{
-				{
-					Type: autoscaling.ResourceMetricSourceType,
-					Resource: &autoscaling.ResourceMetricSource{
-						Name: v1.ResourceCPU,
-						Target: autoscaling.MetricTarget{
-							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: &utilization,
-						},
-					},
-				},
-			},
-			expectedBehavior: exampleBehavior,
-		},
-		{
-			name: "HPA in a Stack with both routegroup and ingress segment",
-			autoscaler: &zv1.Autoscaler{
-				MinReplicas: &min,
-				MaxReplicas: max,
-
-				Metrics: []zv1.AutoscalerMetrics{
-					{
-						Type:               zv1.CPUAutoscalerMetric,
-						AverageUtilization: &utilization,
-					},
-				},
-				Behavior: exampleBehavior,
-			},
-			resources: StackResources{
-				IngressSegment: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "stack-traffic-segment",
-					},
-				},
-				RouteGroupSegment: &rgv1.RouteGroup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "stack-traffic-segment",
-					},
-				},
 			},
 			expectedMinReplicas: &min,
 			expectedMaxReplicas: max,
@@ -1509,7 +1392,6 @@ func TestGenerateHPA(t *testing.T) {
 						},
 					},
 				},
-				Resources: tc.resources,
 			}
 
 			hpa, err := autoscalerContainer.GenerateHPA()

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -15,6 +15,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -1400,6 +1401,85 @@ func TestGenerateHPA(t *testing.T) {
 			require.Equal(t, tc.expectedMaxReplicas, hpa.Spec.MaxReplicas)
 			require.Equal(t, tc.expectedMetrics, hpa.Spec.Metrics)
 			require.Equal(t, tc.expectedBehavior, hpa.Spec.Behavior)
+		})
+	}
+}
+
+func TestGenerateHPAToSegment(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		minReplicas int32
+		maxReplicas int32
+		metricType  zv1.AutoscalerMetricType
+		metricValue int64
+		expectedRef string
+	}{
+		{
+			name:        "HPA metric points to ingress segment",
+			minReplicas: 1,
+			maxReplicas: 2,
+			metricType:  zv1.IngressAutoscalerMetric,
+			metricValue: 20,
+			expectedRef: "foo-v1-traffic-segment",
+		},
+		{
+			name:        "HPA metric points to routeGroup segment",
+			minReplicas: 1,
+			maxReplicas: 2,
+			metricType:  zv1.RouteGroupAutoscalerMetric,
+			metricValue: 20,
+			expectedRef: "foo-v1-traffic-segment",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			metricValue := resource.NewQuantity(
+				tc.metricValue,
+				resource.DecimalSI,
+			)
+
+			autoScalerContainer := &StackContainer{
+				Stack: &zv1.Stack{
+					ObjectMeta: testStackMeta,
+					Spec: zv1.StackSpecInternal{
+						StackSpec: zv1.StackSpec{
+							PodTemplate: zv1.PodTemplateSpec{
+								EmbeddedObjectMeta: zv1.EmbeddedObjectMeta{
+									Labels: map[string]string{
+										"pod-label": "pod-foo",
+									},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "foo",
+											Image: "ghcr.io/zalando/skipper:latest",
+										},
+									},
+								},
+							},
+							Autoscaler: &zv1.Autoscaler{
+								MinReplicas: &tc.minReplicas,
+								MaxReplicas: tc.maxReplicas,
+								Metrics: []zv1.AutoscalerMetrics{
+									{
+										Type:    tc.metricType,
+										Average: metricValue,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			hpa, err := autoScalerContainer.GenerateHPAToSegment()
+			require.NoError(t, err)
+			require.NotEmpty(t, hpa.Spec.Metrics)
+			require.Equal(
+				t,
+				tc.expectedRef,
+				hpa.Spec.Metrics[0].Object.DescribedObject.Name,
+			)
 		})
 	}
 }


### PR DESCRIPTION
The fix in https://github.com/zalando-incubator/stackset-controller/pull/585 didn't work, because when the controller generates HPAs for the first time, the `Resources` in `StackContainer` are empty.

This Pull Requests updates generation of HPAs for a StackSet with enabled segments. I also updated the end-2-end test setup to include an Ingress based metri in tha autoscaler.