### PR TITLE
Empty structs should not lead to wrong detection

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -459,12 +459,12 @@ func (crs *ConfigurationResourcesSpec) GetName() string {
 
 // IsConfigMap returns true if the ConfigurationResourcesSpec is a ConfigMap.
 func (crs *ConfigurationResourcesSpec) IsConfigMap() bool {
-	return crs.ConfigMapRef != nil
+	return crs.ConfigMapRef != nil && crs.ConfigMapRef.Name != ""
 }
 
 // IsSecret returns true if the ConfigurationResourcesSpec is a Secret.
 func (crs *ConfigurationResourcesSpec) IsSecret() bool {
-	return crs.SecretRef != nil
+	return crs.SecretRef != nil && crs.SecretRef.Name != ""
 }
 
 // StackSpecInternal is the spec part of the Stack, including `ingress` and


### PR DESCRIPTION
Since the latest update of `stackset-controller` the following is treated as a ConfigMap and leads to an error because its name is wrong (`""`).

```
  - configMapRef: {}
    secretRef:
      name: zmon-controller-master-865-secrets
```

```
time="2024-02-19T15:19:01Z" level=error msg="Unable to reconcile stack resources: ConfigurationResource name must be prefixed by Stack name. ConfigurationResource: , Stack: zmon-controller-master-865" controller=stackset namespace=default stack=zmon-controller-master-865 stackset=zmon-controller
```

This and the similar issue of detecting a ConfigMap when it should actually be treated as a Secret are fixed in this PR.

This was introduced in https://github.com/zalando-incubator/stackset-controller/pull/586. With this change we handle all cases.

Subsequent deployments of the already affected StackSets will converge to the desired format where empty structs are omitted but that might take time depending on users rollouts.