### PR TITLE
Fix order of metrics in autoscaling test

### DIFF
--- a/cmd/e2e/configure_hpa_test.go
+++ b/cmd/e2e/configure_hpa_test.go
@@ -15,8 +15,8 @@ func TestConfigureAutoscaling(t *testing.T) {
 	var stabilizationWindow int32 = 60
 	metrics := []zv1.AutoscalerMetrics{
 		makeCPUAutoscalerMetrics(50),
-		makeExternalAutoscalerMetrics("test", "eu-central-1", 10),
-		makeObjectAutoscalerMetrics(20),
+		makeAmazonSQSAutoscalerMetrics("test", "eu-central-1", 10),
+		makeIngressAutoscalerMetrics(20),
 	}
 	require.Len(t, metrics, 3)
 

--- a/cmd/e2e/generated_autoscaler_test.go
+++ b/cmd/e2e/generated_autoscaler_test.go
@@ -54,13 +54,24 @@ func TestGenerateAutoscaler(t *testing.T) {
 	require.EqualValues(t, 1, *hpa.Spec.MinReplicas)
 	require.EqualValues(t, 10, hpa.Spec.MaxReplicas)
 	require.Len(t, hpa.Spec.Metrics, 3)
-	metric1 := hpa.Spec.Metrics[0]
-	require.EqualValues(t, metric1.Type, v2.ExternalMetricSourceType)
-	require.EqualValues(t, metric1.External.Target.AverageValue.Value(), 10)
-	metric2 := hpa.Spec.Metrics[1]
-	require.EqualValues(t, v2.ResourceMetricSourceType, metric2.Type)
-	require.EqualValues(t, 50, *metric2.Resource.Target.AverageUtilization)
-	metric3 := hpa.Spec.Metrics[2]
-	require.EqualValues(t, v2.ObjectMetricSourceType, metric3.Type)
-	require.EqualValues(t, 20, metric3.Object.Target.AverageValue.Value())
+
+	// we intentionally don't care about the order of the metrics because
+	// it's not guaranteed in Kubernetes versions below v1.28
+	// See https://github.com/zalando-incubator/stackset-controller/pull/591#issuecomment-1959751276
+	metricTypes := map[v2.MetricSourceType]int64{
+		v2.ExternalMetricSourceType: 10,
+		v2.ResourceMetricSourceType: 50,
+		v2.ObjectMetricSourceType:   20,
+	}
+
+	for _, metric := range hpa.Spec.Metrics {
+		switch metric.Type {
+		case v2.ExternalMetricSourceType:
+			require.EqualValues(t, metricTypes[metric.Type], metric.External.Target.AverageValue.Value())
+		case v2.ResourceMetricSourceType:
+			require.EqualValues(t, metricTypes[metric.Type], *metric.Resource.Target.AverageUtilization)
+		case v2.ObjectMetricSourceType:
+			require.EqualValues(t, metricTypes[metric.Type], metric.Object.Target.AverageValue.Value())
+		}
+	}
 }


### PR DESCRIPTION
When generating an HPA from the `autoscaler` config we sort the metrics based on [some heuristic](https://github.com/zalando-incubator/stackset-controller/blob/5e8d42ca5d32ecfe938fed43e8a19de527254f07/pkg/core/autoscaler.go#L60-L63) to have a consistent naming for metrics.

In the e2e test the order in which we check the metrics does not match.

~This issue only shows up in e2e tests in Kubernetes v1.28 which I don't quite understand, as I would think it would be broken in earlier versions as well :shrug: This should be a general fix none the less.~ This is an issue with Kubernetes below v1.28 See https://github.com/zalando-incubator/stackset-controller/pull/591#issuecomment-1959751276