### PR TITLE
Rename functions dealing with config/secret refs for clarify

### DIFF
--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -96,7 +96,7 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	t.Parallel()
 
 	stacksetName := "stackset-broken-stacks-with-configmap"
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().ConfigMap().StackGC(1, 30)
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().ConfigMapRef().StackGC(1, 30)
 
 	firstVersion := "v1"
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
@@ -110,7 +110,7 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
 	spec = factory.Create(t, unhealthyVersion)
 	for _, cr := range spec.StackTemplate.Spec.ConfigurationResources {
-		if cr.IsConfigMap() {
+		if cr.IsConfigMapRef() {
 			err := configMapInterface().Delete(context.Background(), cr.GetName(), metav1.DeleteOptions{})
 			require.NoError(t, err)
 		}
@@ -176,7 +176,7 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 	t.Parallel()
 
 	stacksetName := "stackset-broken-stacks-with-secret"
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().Secret().StackGC(1, 30)
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().SecretRef().StackGC(1, 30)
 
 	firstVersion := "v1"
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
@@ -190,7 +190,7 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
 	spec = factory.Create(t, unhealthyVersion)
 	for _, cr := range spec.StackTemplate.Spec.ConfigurationResources {
-		if cr.IsSecret() {
+		if cr.IsSecretRef() {
 			err := secretInterface().Delete(context.Background(), cr.GetName(), metav1.DeleteOptions{})
 			require.NoError(t, err)
 		}

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -306,7 +306,7 @@ func (c *StackSetController) ReconcileStackRouteGroup(ctx context.Context, stack
 	return nil
 }
 
-// ReconcileStackConfigMap will update the named user-provided ConfigMap to be
+// ReconcileStackConfigMapRefs will update the named user-provided ConfigMap to be
 // attached to the Stack by ownerReferences, when a list of Configuration
 // Resources are defined on the Stack template.
 //
@@ -318,14 +318,14 @@ func (c *StackSetController) ReconcileStackRouteGroup(ctx context.Context, stack
 // running resources is also allowed, so the method checks for changes on the
 // ConfigurationResources to ensure all listed ConfigMaps are properly linked
 // to the Stack.
-func (c *StackSetController) ReconcileStackConfigMap(
+func (c *StackSetController) ReconcileStackConfigMapRefs(
 	ctx context.Context,
 	stack *zv1.Stack,
 	existing []*apiv1.ConfigMap,
 	updateObjMeta func(*metav1.ObjectMeta) *metav1.ObjectMeta,
 ) error {
 	for _, rsc := range stack.Spec.ConfigurationResources {
-		if !rsc.IsConfigMap() {
+		if !rsc.IsConfigMapRef() {
 			continue
 		}
 
@@ -368,7 +368,7 @@ func (c *StackSetController) ReconcileStackConfigMap(
 	return nil
 }
 
-// ReconcileStackSecret will update the named user-provided Secret to be
+// ReconcileStackSecretRefs will update the named user-provided Secret to be
 // attached to the Stack by ownerReferences, when a list of Configuration
 // Resources are defined on the Stack template.
 //
@@ -380,14 +380,14 @@ func (c *StackSetController) ReconcileStackConfigMap(
 // running resources is also allowed, so the method checks for changes on the
 // ConfigurationResources to ensure all listed Secrets are properly linked
 // to the Stack.
-func (c *StackSetController) ReconcileStackSecret(
+func (c *StackSetController) ReconcileStackSecretRefs(
 	ctx context.Context,
 	stack *zv1.Stack,
 	existing []*apiv1.Secret,
 	updateObjMeta func(*metav1.ObjectMeta) *metav1.ObjectMeta,
 ) error {
 	for _, rsc := range stack.Spec.ConfigurationResources {
-		if !rsc.IsSecret() {
+		if !rsc.IsSecretRef() {
 			continue
 		}
 

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -957,7 +957,7 @@ func TestReconcileStackRouteGroup(t *testing.T) {
 	}
 }
 
-func TestReconcileStackConfigMap(t *testing.T) {
+func TestReconcileStackConfigMapRefs(t *testing.T) {
 	testConfigMapStack := baseTestStack
 	testConfigMapStack.Spec = zv1.StackSpecInternal{
 		StackSpec: zv1.StackSpec{
@@ -1177,7 +1177,7 @@ func TestReconcileStackConfigMap(t *testing.T) {
 				}
 			}
 
-			err = env.controller.ReconcileStackConfigMap(
+			err = env.controller.ReconcileStackConfigMapRefs(
 				context.Background(), &tc.stack, tc.existing, func(tmp *metav1.ObjectMeta) *metav1.ObjectMeta {
 					return &tc.expected[tmp.Name].ObjectMeta
 				})
@@ -1195,7 +1195,7 @@ func TestReconcileStackConfigMap(t *testing.T) {
 	}
 }
 
-func TestReconcileStackSecret(t *testing.T) {
+func TestReconcileStackSecretRefs(t *testing.T) {
 	testSecretStack := baseTestStack
 	testSecretStack.Spec = zv1.StackSpecInternal{
 		StackSpec: zv1.StackSpec{
@@ -1412,7 +1412,7 @@ func TestReconcileStackSecret(t *testing.T) {
 				}
 			}
 
-			err = env.controller.ReconcileStackSecret(
+			err = env.controller.ReconcileStackSecretRefs(
 				context.Background(), &tc.stack, tc.existing, func(tmp *metav1.ObjectMeta) *metav1.ObjectMeta {
 					return &tc.expected[tmp.Name].ObjectMeta
 				})

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -1321,16 +1321,16 @@ func (c *StackSetController) ReconcileStackResources(ctx context.Context, ssc *c
 	}
 
 	if c.configMapSupportEnabled {
-		err = c.ReconcileStackConfigMap(ctx, sc.Stack, sc.Resources.ConfigMaps, sc.UpdateObjectMeta)
+		err = c.ReconcileStackConfigMapRefs(ctx, sc.Stack, sc.Resources.ConfigMaps, sc.UpdateObjectMeta)
 		if err != nil {
-			return c.errorEventf(sc.Stack, "FailedManageConfigMap", err)
+			return c.errorEventf(sc.Stack, "FailedManageConfigMapRefs", err)
 		}
 	}
 
 	if c.secretSupportEnabled {
-		err := c.ReconcileStackSecret(ctx, sc.Stack, sc.Resources.Secrets, sc.UpdateObjectMeta)
+		err := c.ReconcileStackSecretRefs(ctx, sc.Stack, sc.Resources.Secrets, sc.UpdateObjectMeta)
 		if err != nil {
-			return c.errorEventf(sc.Stack, "FailedManageSecret", err)
+			return c.errorEventf(sc.Stack, "FailedManageSecretRefs", err)
 		}
 	}
 

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -446,24 +446,24 @@ type ConfigurationResourcesSpec struct {
 
 // GetName returns the name of the ConfigurationResourcesSpec.
 func (crs *ConfigurationResourcesSpec) GetName() string {
-	if crs.IsConfigMap() {
+	if crs.IsConfigMapRef() {
 		return crs.ConfigMapRef.Name
 	}
 
-	if crs.IsSecret() {
+	if crs.IsSecretRef() {
 		return crs.SecretRef.Name
 	}
 
 	return ""
 }
 
-// IsConfigMap returns true if the ConfigurationResourcesSpec is a ConfigMap.
-func (crs *ConfigurationResourcesSpec) IsConfigMap() bool {
+// IsConfigMapRef returns true if the ConfigurationResourcesSpec is a ConfigMapRef.
+func (crs *ConfigurationResourcesSpec) IsConfigMapRef() bool {
 	return crs.ConfigMapRef != nil && crs.ConfigMapRef.Name != ""
 }
 
-// IsSecret returns true if the ConfigurationResourcesSpec is a Secret.
-func (crs *ConfigurationResourcesSpec) IsSecret() bool {
+// IsSecretRef returns true if the ConfigurationResourcesSpec is a SecretRef.
+func (crs *ConfigurationResourcesSpec) IsSecretRef() bool {
 	return crs.SecretRef != nil && crs.SecretRef.Name != ""
 }
 


### PR DESCRIPTION
For for [follow-up work on inline ConfigMaps](https://github.com/zalando-incubator/stackset-controller/pull/593/files) I've found it helpful to change some functions dealing with the "reference" implementation to include the "Ref" in their names. This way the corresponding inline functions will be different and it's easier to search for them.