### PR TITLE
Delete central ingress/routegroup when StackSet has no Stacks.

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -382,6 +382,14 @@ func createStackSetWithAnnotations(
 	return err
 }
 
+func deleteStack(stackName string) error {
+	return stackInterface().Delete(
+		context.Background(),
+		stackName,
+		metav1.DeleteOptions{},
+	)
+}
+
 func stacksetExists(stacksetName string) bool {
 	_, err := stacksetInterface().Get(context.Background(), stacksetName, metav1.GetOptions{})
 	return err == nil

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -1144,6 +1144,22 @@ func (c *StackSetController) convertToTrafficSegments(
 		}
 	}
 
+	if len(ssc.StackContainers) == 0 {
+		c.logger.Infof(
+			"No stacks found for StackSet %s, safe to delete central "+
+			"ingress/routegroup",
+			ssc.StackSet.Name,
+		)
+
+		// If we don't have any stacks, we can delete the central ingress
+		// resources
+		oldEnough := metav1.NewTime(
+			time.Now().Add(-c.ingressSourceSwitchTTL-time.Minute),
+		)
+		ingTimestamp = &oldEnough
+		rgTimestamp = &oldEnough
+	}
+
 	if ingTimestamp != nil && ssc.Ingress != nil {
 		if !resourceReadyTime(ingTimestamp.Time, c.ingressSourceSwitchTTL) {
 			c.logger.Infof(


### PR DESCRIPTION
Whan converting to versioned ingress, the StackSet controller won't delete the central ingress of a "shallow" StackSet - a StzackSet with no Stacks . This Pull Request ensures that controller also deletes the central ingress of shallow StackSets an completes the conversion.

The converted StackSet won't have _any_ ingress/routegroup. But since there are no backends, this is not a problem.