### PR TITLE
Ensures map exists before updating.

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -422,6 +422,10 @@ func updateStackSetWithAnnotations(
 		// Keep the desired traffic
 		spec.Traffic = stackSet.Spec.Traffic
 		stackSet.Spec = spec
+
+		if stackSet.Annotations == nil {
+			stackSet.Annotations = make(map[string]string)
+		}
 		for k, v := range annotations {
 			stackSet.Annotations[k] = v
 		}


### PR DESCRIPTION
Fixes a panic on end-2end testing detected in kubernetes-on-aws [end-2-end](https://sunrise.zalando.net/cdp/gh/zalando-incubator/kubernetes-on-aws/l-2oiccy5z8b8ctzjejheew7aozq/steps/4/logs) tests.

```
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 68 [running]:
testing.tRunner.func1.2({0x15b6160, 0x19ca000})
	/usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1634 +0x377
panic({0x15b6160?, 0x19ca000?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/zalando-incubator/stackset-controller/cmd/e2e.updateStackSetWithAnnotations({_, _}, {0xc00035a230, 0x0, 0x0, {0xc0002aa3a0, 0xc000a945c8}, {{0x0}, {{0xc000a945cc, 0x0, ...}, ...}}, ...}, ...)
	/go/pkg/mod/github.com/zalando-incubator/stackset-controller@v1.4.44/cmd/e2e/test_utils.go:426 +0x234
github.com/zalando-incubator/stackset-controller/cmd/e2e.TestShallowStackSetConvertToSegmentIngress(0xc00025d860)
	/go/pkg/mod/github.com/zalando-incubator/stackset-controller@v1.4.44/cmd/e2e/ingress_source_switch_test.go:216 +0x36e
testing.tRunner(0xc00025d860, 0x1887fa0)
	/usr/local/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1742 +0x390
``` 