### PR TITLE
[1/3] Add test suite dedicated for configuration resources

### DIFF
--- a/cmd/e2e/configuration_resources_test.go
+++ b/cmd/e2e/configuration_resources_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -26,10 +25,9 @@ func (suite *ConfigurationResourcesTestSuite) SetupTest() {
 	suite.stacksetName = "stackset-cr"
 	suite.stackVersion = "v1"
 
-	// TODO: The cleanup should be done automatically but without being too magical
-	suite.cleanUpStackSet(suite.stacksetName)
-
 	suite.stacksetSpecFactory = NewTestStacksetSpecFactory(suite.stacksetName)
+
+	_ = deleteStackset(suite.stacksetName)
 }
 
 // TestReferencedConfigMaps tests that ConfigMaps referenced in the StackSet spec are owned by the Stack.
@@ -100,13 +98,4 @@ func (suite *ConfigurationResourcesTestSuite) TestReferencedSecrets() {
 			UID:        stack.UID,
 		},
 	}, secret.OwnerReferences)
-}
-
-//
-// HELPER FUNCTIONS
-//
-
-// cleanUpStackSet deletes the StackSet with the given name.
-func (suite *ConfigurationResourcesTestSuite) cleanUpStackSet(name string) {
-	_ = stacksetInterface().Delete(context.Background(), name, metav1.DeleteOptions{})
 }

--- a/cmd/e2e/configuration_resources_test.go
+++ b/cmd/e2e/configuration_resources_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/zalando-incubator/stackset-controller/pkg/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConfigurationResources(t *testing.T) {
+	suite.Run(t, new(ConfigurationResourcesTestSuite))
+}
+
+type ConfigurationResourcesTestSuite struct {
+	suite.Suite
+
+	stacksetSpecFactory *TestStacksetSpecFactory
+
+	stacksetName string
+	stackVersion string
+}
+
+func (suite *ConfigurationResourcesTestSuite) SetupTest() {
+	suite.stacksetName = "stackset-cr"
+	suite.stackVersion = "v1"
+
+	// TODO: The cleanup should be done automatically but without being too magical
+	suite.cleanUpStackSet(suite.stacksetName)
+
+	suite.stacksetSpecFactory = NewTestStacksetSpecFactory(suite.stacksetName)
+}
+
+// TestReferencedConfigMaps tests that ConfigMaps referenced in the StackSet spec are owned by the Stack.
+func (suite *ConfigurationResourcesTestSuite) TestReferencedConfigMaps() {
+	// Create a ConfigMap in the cluster following the naming convention
+	configMapName := "stackset-cr-v1-my-configmap"
+	createConfigMap(suite.T(), configMapName)
+
+	// Add the ConfigMap reference to the StackSet spec
+	suite.stacksetSpecFactory.AddReferencedConfigMap(configMapName)
+
+	// Generate the StackSet spec
+	stacksetSpec := suite.stacksetSpecFactory.Create(suite.T(), suite.stackVersion)
+
+	// Create the StackSet in the cluster
+	err := createStackSet(suite.stacksetName, 0, stacksetSpec)
+	suite.Require().NoError(err)
+
+	// Wait for the first Stack to be created
+	stack, err := waitForStack(suite.T(), suite.stacksetName, suite.stackVersion)
+	suite.Require().NoError(err)
+
+	// Fetch the latest version of the ConfigMap
+	configMap, err := waitForConfigMap(suite.T(), configMapName)
+	suite.Require().NoError(err)
+
+	// Ensure that the ConfigMap is owned by the Stack
+	suite.Equal([]metav1.OwnerReference{
+		{
+			APIVersion: core.APIVersion,
+			Kind:       core.KindStack,
+			Name:       stack.Name,
+			UID:        stack.UID,
+		},
+	}, configMap.OwnerReferences)
+}
+
+// TestReferencedSecrets tests that Secrets referenced in the StackSet spec are owned by the Stack.
+func (suite *ConfigurationResourcesTestSuite) TestReferencedSecrets() {
+	// Create a Secret in the cluster following the naming convention
+	secretName := "stackset-cr-v1-my-secret"
+	createSecret(suite.T(), secretName)
+
+	// Add the Secret reference to the StackSet spec
+	suite.stacksetSpecFactory.AddReferencedSecret(secretName)
+
+	// Generate the StackSet spec
+	stacksetSpec := suite.stacksetSpecFactory.Create(suite.T(), suite.stackVersion)
+
+	// Create the StackSet in the cluster
+	err := createStackSet(suite.stacksetName, 0, stacksetSpec)
+	suite.Require().NoError(err)
+
+	// Wait for the first Stack to be created
+	stack, err := waitForStack(suite.T(), suite.stacksetName, suite.stackVersion)
+	suite.Require().NoError(err)
+
+	// Fetch the latest version of the Secret
+	secret, err := waitForSecret(suite.T(), secretName)
+	suite.Require().NoError(err)
+
+	// Ensure that the Secret is owned by the Stack
+	suite.Equal([]metav1.OwnerReference{
+		{
+			APIVersion: core.APIVersion,
+			Kind:       core.KindStack,
+			Name:       stack.Name,
+			UID:        stack.UID,
+		},
+	}, secret.OwnerReferences)
+}
+
+//
+// HELPER FUNCTIONS
+//
+
+// cleanUpStackSet deletes the StackSet with the given name.
+func (suite *ConfigurationResourcesTestSuite) cleanUpStackSet(name string) {
+	_ = stacksetInterface().Delete(context.Background(), name, metav1.DeleteOptions{})
+}

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -383,6 +383,14 @@ func createStackSetWithAnnotations(
 	return err
 }
 
+func deleteStackset(stacksetName string) error {
+	return stacksetInterface().Delete(
+		context.Background(),
+		stacksetName,
+		metav1.DeleteOptions{},
+	)
+}
+
 func deleteStack(stackName string) error {
 	return stackInterface().Delete(
 		context.Background(),


### PR DESCRIPTION
Separate test suite to focus on versioned configuration resources where we don't need to care (as much) about all that other stuff that StackSets can have.

The rewrite of the existing tests using the new methods to make sure everything still works was done in https://github.com/zalando-incubator/stackset-controller/pull/606. Some of these could be removed as the behaviour is tested in this new suite as well but we can also leave them.

Please also see the follow up PRs that are based on this one:
- [[2/3] Add Inline Solution for ConfigMaps](https://github.com/zalando-incubator/stackset-controller/pull/593)
- [[3/3] Add e2e test case for Inline ConfigMap](https://github.com/zalando-incubator/stackset-controller/pull/595)