### PR TITLE
Add a versioned configmap to the e2e sample stackset

### DIFF
--- a/e2e/apply/sample-segment.yaml
+++ b/e2e/apply/sample-segment.yaml
@@ -59,4 +59,15 @@ spec:
           volumes:
           - name: my-config
             configMap:
-              name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config
+              name: e2e-deploy-sample-segment-{{{CDP_BUILD_VERSION}}}-config
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-deploy-sample-segment-{{{CDP_BUILD_VERSION}}}-config
+  labels:
+    application: "e2e-deploy-sample-segment"
+data:
+  something_is: configured

--- a/e2e/apply/sample-segment.yaml
+++ b/e2e/apply/sample-segment.yaml
@@ -19,6 +19,9 @@ spec:
     spec:
       version: "{{{CDP_BUILD_VERSION}}}"
       replicas: 2
+      configurationResources:
+      - configMapRef:
+          name: e2e-deploy-sample-segment-{{{CDP_BUILD_VERSION}}}-config
       autoscaler:
         minReplicas: 2
         maxReplicas: 2
@@ -49,3 +52,11 @@ spec:
               limits:
                 cpu: 1m
                 memory: 100Mi
+            volumeMounts:
+            - name: my-config
+              mountPath: /etc/my-config
+              readOnly: true
+          volumes:
+          - name: my-config
+            configMap:
+              name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -18,6 +18,9 @@ spec:
     spec:
       version: "{{{CDP_BUILD_VERSION}}}"
       replicas: 2
+      configurationResources:
+      - configMapRef:
+          name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config
       autoscaler:
         minReplicas: 2
         maxReplicas: 2
@@ -48,3 +51,11 @@ spec:
               limits:
                 cpu: 1m
                 memory: 100Mi
+            volumeMounts:
+            - name: my-config
+              mountPath: /etc/my-config
+              readOnly: true
+          volumes:
+          - name: my-config
+            configMap:
+              name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config

--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -59,3 +59,14 @@ spec:
           - name: my-config
             configMap:
               name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-config
+  labels:
+    application: "e2e-deploy-sample"
+data:
+  something_is: configured


### PR DESCRIPTION
This uses a versioned ConfigMap in the sample deployment so we have this covered.