### PR TITLE
Allow more control over configured versioned resources for more flexible test cases

### DIFF
--- a/cmd/e2e/broken_stack_test.go
+++ b/cmd/e2e/broken_stack_test.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -96,10 +94,14 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	t.Parallel()
 
 	stacksetName := "stackset-broken-stacks-with-configmap"
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().ConfigMapRef().StackGC(1, 30)
-
 	firstVersion := "v1"
+
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
+
+	configMapName := fmt.Sprintf("%s-configmap", firstStack)
+	createConfigMap(t, configMapName)
+
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedConfigMap(configMapName).StackGC(1, 30)
 	spec := factory.Create(t, firstVersion)
 	err := createStackSet(stacksetName, 0, spec)
 	require.NoError(t, err)
@@ -108,13 +110,11 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 
 	unhealthyVersion := "v2"
 	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
+
+	configMapName = fmt.Sprintf("%s-configmap", unhealthyStack)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedConfigMap(configMapName).StackGC(1, 30)
 	spec = factory.Create(t, unhealthyVersion)
-	for _, cr := range spec.StackTemplate.Spec.ConfigurationResources {
-		if cr.IsConfigMapRef() {
-			err := configMapInterface().Delete(context.Background(), cr.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
-		}
-	}
 	err = updateStackset(stacksetName, spec)
 	require.NoError(t, err)
 	_, err = waitForStack(t, stacksetName, unhealthyVersion)
@@ -137,6 +137,11 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	// Create a healthy stack
 	healthyVersion := "v3"
 	healthyStack := fmt.Sprintf("%s-%s", stacksetName, healthyVersion)
+
+	configMapName = fmt.Sprintf("%s-configmap", healthyStack)
+	createConfigMap(t, configMapName)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedConfigMap(configMapName).StackGC(1, 30)
 	spec = factory.Create(t, healthyVersion)
 	err = updateStackset(stacksetName, spec)
 	require.NoError(t, err)
@@ -152,6 +157,11 @@ func TestBrokenStackWithConfigMaps(t *testing.T) {
 	// Create another healthy stack so we can test GC
 	finalVersion := "v4"
 	finalStack := fmt.Sprintf("%s-%s", stacksetName, finalVersion)
+
+	configMapName = fmt.Sprintf("%s-configmap", finalStack)
+	createConfigMap(t, configMapName)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedConfigMap(configMapName).StackGC(1, 30)
 	spec = factory.Create(t, finalVersion)
 	err = updateStackset(stacksetName, spec)
 	require.NoError(t, err)
@@ -176,9 +186,12 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 	t.Parallel()
 
 	stacksetName := "stackset-broken-stacks-with-secret"
-	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().SecretRef().StackGC(1, 30)
-
 	firstVersion := "v1"
+
+	secretName := fmt.Sprintf("%s-%s-secret", stacksetName, firstVersion)
+	createSecret(t, secretName)
+
+	factory := NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedSecret(secretName).StackGC(1, 30)
 	firstStack := fmt.Sprintf("%s-%s", stacksetName, firstVersion)
 	spec := factory.Create(t, firstVersion)
 	err := createStackSet(stacksetName, 0, spec)
@@ -187,14 +200,12 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	unhealthyVersion := "v2"
+
+	secretName = fmt.Sprintf("%s-%s-secret", stacksetName, unhealthyVersion)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedSecret(secretName).StackGC(1, 30)
 	unhealthyStack := fmt.Sprintf("%s-%s", stacksetName, unhealthyVersion)
 	spec = factory.Create(t, unhealthyVersion)
-	for _, cr := range spec.StackTemplate.Spec.ConfigurationResources {
-		if cr.IsSecretRef() {
-			err := secretInterface().Delete(context.Background(), cr.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
-		}
-	}
 	err = updateStackset(stacksetName, spec)
 	require.NoError(t, err)
 	_, err = waitForStack(t, stacksetName, unhealthyVersion)
@@ -216,6 +227,11 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 
 	// Create a healthy stack
 	healthyVersion := "v3"
+
+	secretName = fmt.Sprintf("%s-%s-secret", stacksetName, healthyVersion)
+	createSecret(t, secretName)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedSecret(secretName).StackGC(1, 30)
 	healthyStack := fmt.Sprintf("%s-%s", stacksetName, healthyVersion)
 	spec = factory.Create(t, healthyVersion)
 	err = updateStackset(stacksetName, spec)
@@ -231,6 +247,11 @@ func TestBrokenStackWithSecrets(t *testing.T) {
 
 	// Create another healthy stack so we can test GC
 	finalVersion := "v4"
+
+	secretName = fmt.Sprintf("%s-%s-secret", stacksetName, finalVersion)
+	createSecret(t, secretName)
+
+	factory = NewTestStacksetSpecFactory(stacksetName).Ingress().AddReferencedSecret(secretName).StackGC(1, 30)
 	finalStack := fmt.Sprintf("%s-%s", stacksetName, finalVersion)
 	spec = factory.Create(t, finalVersion)
 	err = updateStackset(stacksetName, spec)

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	"github.com/zalando-incubator/stackset-controller/controller"
 	zv1 "github.com/zalando-incubator/stackset-controller/pkg/apis/zalando.org/v1"
@@ -589,6 +590,32 @@ func setDesiredTrafficWeightsStackset(stacksetName string, weights map[string]fl
 		}
 		return err
 	}
+}
+
+func createConfigMap(t *testing.T, name string) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+	_, err := configMapInterface().Create(context.Background(), configMap, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func createSecret(t *testing.T, name string) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+	_, err := secretInterface().Create(context.Background(), secret, metav1.CreateOptions{})
+	require.NoError(t, err)
 }
 
 func pint32(i int32) *int32 {


### PR DESCRIPTION
This came out while working on https://github.com/zalando-incubator/stackset-controller/pull/599

This replaces the specific fields `configMapRef` and `secretRef` that were used to attach a versioned resource to a StackSet with the more granular functions:
* `AddReferencedConfigMap`/`AddReferencedSecret` which add an entry for the given resource under StackSet's `configurationResources` section
* `volumes` which hold the configured volumes for the StackSet. (There's no dedicated accessor function for volumes because it's not needed here.)

Both functions can be used in a straight-forward way to build-up a StackSet into a particular state for testing, i.e. having certain versioned resources in this case.

The author of the test case is still required to **actually create** the referenced versioned resource similar to how users would do it via CDP (see `createConfigMap` and `createSecret` helper functions for that). This is to keep the test close to reality and allow for testing certain failure scenarios, for example when a reference is defined in the StackSet but the referenced resource doesn't exist which can easily happen in reality. This is obviously debatable as it _yet again_ makes writing test cases more error-prone but I didn't want to throw too many things together at this stage.