### PR TITLE
Don't prepend TrafficSegment on empty string.

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -7045,6 +7045,20 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -7177,20 +7191,6 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -378,7 +378,7 @@ func (sc *StackContainer) GenerateIngressSegment() (
 		sc.ingressAnnotationsToSync,
 	)
 
-	if predVal, ok := res.Annotations[IngressPredicateKey]; !ok {
+	if predVal, ok := res.Annotations[IngressPredicateKey]; !ok || predVal == "" {
 		res.Annotations = mergeLabels(
 			res.Annotations,
 			map[string]string{IngressPredicateKey: sc.trafficSegment()},

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -434,6 +434,22 @@ func TestStackGenerateIngressSegment(t *testing.T) {
 			expectedPredicate: "TrafficSegment(0.10, 0.30) && Method(\"GET\")",
 			expectedHosts:     []string{"example.teapot.zalan.do"},
 		},
+		{
+			ingressSpec: &zv1.StackSetIngressSpec{
+				EmbeddedObjectMetaWithAnnotations: zv1.EmbeddedObjectMetaWithAnnotations{
+					Annotations: map[string]string{
+						IngressPredicateKey: "",
+					},
+				},
+				Hosts: []string{"example.teapot.zalan.do"},
+			},
+			lowerLimit:        0.1,
+			upperLimit:        0.3,
+			expectNil:         false,
+			expectError:       false,
+			expectedPredicate: "TrafficSegment(0.10, 0.30)",
+			expectedHosts:     []string{"example.teapot.zalan.do"},
+		},
 	} {
 		backendPort := intstr.FromInt(int(80))
 		c := &StackContainer{


### PR DESCRIPTION
When an ingress in a StackSet manifest declares predicates with an empty string (`zalando.org/skipper-predicate: ""`), the StackSet controller generates a syntactically wrong predicate: `"TrafficSegment(0.10, 0.30) && "`.

For the case above, this Pull Request ensures that the StackSet controller does NOT prepend the `TrafficSegment` predicate, but replaces the empty string with the proper `TrafficSegment`.