### PR TITLE
crd: require unique hosts

### DIFF
--- a/docs/stack_crd.yaml
+++ b/docs/stack_crd.yaml
@@ -398,7 +398,9 @@ spec:
                   hosts:
                     items:
                       type: string
+                    minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
                       which can be attached to a resource. It's a slimmed down version
@@ -684,9 +686,6 @@ spec:
                                             empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
                                                 properties:
                                                   key:
@@ -7627,7 +7626,9 @@ spec:
                     description: Hosts is the list of hostnames to add to the routegroup.
                     items:
                       type: string
+                    minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                   lbAlgorithm:
                     description: The load balancing algorithm used for the generated
                       per stack backends.

--- a/docs/stackset_crd.yaml
+++ b/docs/stackset_crd.yaml
@@ -78,7 +78,9 @@ spec:
                   hosts:
                     items:
                       type: string
+                    minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
                       which can be attached to a resource. It's a slimmed down version
@@ -192,7 +194,9 @@ spec:
                     description: Hosts is the list of hostnames to add to the routegroup.
                     items:
                       type: string
+                    minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                   lbAlgorithm:
                     description: The load balancing algorithm used for the generated
                       per stack backends.

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -103,8 +103,10 @@ type EmbeddedObjectMeta struct {
 // +k8s:deepcopy-gen=true
 type StackSetIngressSpec struct {
 	EmbeddedObjectMetaWithAnnotations `json:"metadata,omitempty"`
-	Hosts                             []string           `json:"hosts"`
-	BackendPort                       intstr.IntOrString `json:"backendPort"`
+	// +kubebuilder:validation:MinItems=1
+	// +listType=set
+	Hosts       []string           `json:"hosts"`
+	BackendPort intstr.IntOrString `json:"backendPort"`
 
 	// +optional
 	Path string `json:"path"`
@@ -131,6 +133,8 @@ type StackSetExternalIngressSpec struct {
 type RouteGroupSpec struct {
 	EmbeddedObjectMetaWithAnnotations `json:"metadata,omitempty"`
 	// Hosts is the list of hostnames to add to the routegroup.
+	// +kubebuilder:validation:MinItems=1
+	// +listType=set
 	Hosts []string `json:"hosts"`
 	// AdditionalBackends is the list of additional backends to use for
 	// routing.


### PR DESCRIPTION
Require unique non-empty hosts for ingress and routegroup specs.