### PR TITLE
Ensure annotations map is not nil.

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -265,6 +265,10 @@ func (c *StackSetController) injectSegmentAnnotation(
 		return false
 	}
 
+	if stackSet.Annotations == nil {
+		stackSet.Annotations = make(map[string]string)
+	}
+
 	if stackSet.Annotations[TrafficSegmentsAnnotationKey] == "true" {
 		return false
 	}


### PR DESCRIPTION
End-2end tests in kubernetes-on-aws fail with StackSets without any annotation, becuase the StackSet Controller tries to inject `"stackset-controller.zalando.org/use-traffic-segments"` on a nil map: 

`Encountered a panic while processing a stackset: assignment to entry in nil map\ngoroutine 17341 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x5e\ngithub.com/zalando-incubator/stackset-controller/controller.(*StackSetController).ReconcileStackSet.func1()\n\t/workspace/controller/stackset.go:1388 +0x1c9\npanic({0x17918e0?, 0x1c22d40?})\n\t/usr/local/go/src/runtime/panic.go:770 +0x132\ngithub.com/zalando-incubator/stackset-controller/controller.(*StackSetController).injectSegmentAnnotation(0xc00022f4a0, {0x1c3cd80, 0xc00001bdb0}, 0xc000cc1b08)\n\t/workspace/controller/stackset.go:272`

`unable to reconcile a stackset: panic: assignment to entry in nil map`

This Pull Request ensures the controller will create the affected map when it's nil.