### PR TITLE
Wait for ownerReferences to appear on the resources

### DIFF
--- a/cmd/e2e/configuration_resources_test.go
+++ b/cmd/e2e/configuration_resources_test.go
@@ -53,19 +53,21 @@ func (suite *ConfigurationResourcesTestSuite) TestReferencedConfigMaps() {
 	stack, err := waitForStack(suite.T(), suite.stacksetName, suite.stackVersion)
 	suite.Require().NoError(err)
 
-	// Fetch the latest version of the ConfigMap
-	configMap, err := waitForConfigMap(suite.T(), configMapName)
+	// Ensure that the ConfigMap exists in the cluster
+	_, err = waitForConfigMap(suite.T(), configMapName)
 	suite.Require().NoError(err)
 
 	// Ensure that the ConfigMap is owned by the Stack
-	suite.Equal([]metav1.OwnerReference{
+	ownerReferences := []metav1.OwnerReference{
 		{
 			APIVersion: core.APIVersion,
 			Kind:       core.KindStack,
 			Name:       stack.Name,
 			UID:        stack.UID,
 		},
-	}, configMap.OwnerReferences)
+	}
+	err = waitForConfigMapOwnerReferences(suite.T(), configMapName, ownerReferences).await()
+	suite.Require().NoError(err)
 }
 
 // TestReferencedSecrets tests that Secrets referenced in the StackSet spec are owned by the Stack.
@@ -88,19 +90,21 @@ func (suite *ConfigurationResourcesTestSuite) TestReferencedSecrets() {
 	stack, err := waitForStack(suite.T(), suite.stacksetName, suite.stackVersion)
 	suite.Require().NoError(err)
 
-	// Fetch the latest version of the Secret
-	secret, err := waitForSecret(suite.T(), secretName)
+	// Ensure that the Secret exists in the cluster
+	_, err = waitForSecret(suite.T(), secretName)
 	suite.Require().NoError(err)
 
 	// Ensure that the Secret is owned by the Stack
-	suite.Equal([]metav1.OwnerReference{
+	ownerReferences := []metav1.OwnerReference{
 		{
 			APIVersion: core.APIVersion,
 			Kind:       core.KindStack,
 			Name:       stack.Name,
 			UID:        stack.UID,
 		},
-	}, secret.OwnerReferences)
+	}
+	err = waitForSecretOwnerReferences(suite.T(), secretName, ownerReferences).await()
+	suite.Require().NoError(err)
 }
 
 // TestGeneratedPCS tests that PlatformCredentialsSets defined in the StackSet are

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -495,7 +495,7 @@ func waitForConfigMapOwnerReferences(t *testing.T, configMapName string, expecte
 		if !reflect.DeepEqual(expectedOwnerReferences, configMap.OwnerReferences) {
 			return true, fmt.Errorf("%s: actual ownerReferences: %+v, expected: %+v, diff:\n%v", configMapName, configMap.OwnerReferences, expectedOwnerReferences, cmp.Diff(configMap.OwnerReferences, expectedOwnerReferences))
 		}
-		return true, nil
+		return false, nil
 	})
 }
 
@@ -516,7 +516,7 @@ func waitForSecretOwnerReferences(t *testing.T, secretName string, expectedOwner
 		if !reflect.DeepEqual(expectedOwnerReferences, secret.OwnerReferences) {
 			return true, fmt.Errorf("%s: actual ownerReferences: %+v, expected: %+v, diff:\n%v", secretName, secret.OwnerReferences, expectedOwnerReferences, cmp.Diff(secret.OwnerReferences, expectedOwnerReferences))
 		}
-		return true, nil
+		return false, nil
 	})
 }
 


### PR DESCRIPTION
For https://github.bus.zalan.do/teapot/issues/issues/3622

We check referenced versioned ConfigMaps and Secrets for their ownerReferences. However, we need to allow `stackset-controller` a little bit of time to process them. Typically resources are _created_ by `stackset-controller` so that upon waiting for them they are already in their final state. This is not the case for referenced configuration resources which exist prior to processing, so we need to delay the check a bit. Note that inline PlatformCredentialsSets don't need it because they are created by `stackset-controller`.