### PR TITLE
Use a valid app ID for PCS in e2e test

### DIFF
--- a/e2e/apply/sample.yaml
+++ b/e2e/apply/sample.yaml
@@ -3,7 +3,8 @@ kind: StackSet
 metadata:
   name: e2e-deploy-sample
   labels:
-    application: "e2e-deploy-sample"
+    application: "kubernetes"
+    component: "e2e-deploy-sample"
   annotations:
     "stackset-controller.zalando.org/controller": "{{{CONTROLLER_ID}}}"
 spec:
@@ -27,8 +28,7 @@ spec:
           name: e2e-deploy-sample-{{{CDP_BUILD_VERSION}}}-my-pcs
           tokens:
             sample-token:
-              privileges:
-              - com.zalando::foobar.read
+              privileges: []
       autoscaler:
         minReplicas: 2
         maxReplicas: 2
@@ -38,9 +38,6 @@ spec:
         - type: Ingress
           average: 20000m
       podTemplate:
-        metadata:
-          labels:
-            application: "e2e-deploy-sample"
         spec:
           containers:
           - name: skipper


### PR DESCRIPTION
Use a valid appID for PCS e2e test:

![image](https://github.com/user-attachments/assets/eb4be595-352b-4626-8a67-bc0dfbab86b0)
