### PR TITLE
shorten subdomain name in stackset hostnames

### DIFF
--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -120,7 +120,7 @@ func requiredEnvar(envar string) string {
 func hostnames(stacksetName string) []string {
 	names := make([]string, 0, len(clusterDomains))
 	for _, domain := range clusterDomains {
-		names = append(names, fmt.Sprintf("%s-%s.%s", namespace, stacksetName, domain))
+		names = append(names, fmt.Sprintf("%s.%s.%s", namespace, stacksetName, domain))
 	}
 	return names
 }


### PR DESCRIPTION
This is needed to conform to subdomain length limit of `57` characters introduced recently that is causing e2e tests to break up. 

The namespace prefix like `d-9owpufu1wutzdgxfdrpytgzw1-` comprises `28` characters which occupy half of this limit. So, splitting the namespace into a subdomain of its own restores the limit to `57` for the stack name alone. This is sufficient to cover the stackset names which can be very long in some tests.