### PR TITLE
bump go version in github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.23'
+        go-version: '^1.24'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest


### PR DESCRIPTION
Bumps the go version in the github workflows to `1.24`. This fixes the failing github CI pipeline on PRs.