### PR TITLE
Make per-stack hostnames configurable

### DIFF
--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -71,7 +71,7 @@ func main() {
 	kingpin.Flag("enable-configmap-support", "Enable support for ConfigMaps on StackSets.").Default("false").BoolVar(&config.ConfigMapSupportEnabled)
 	kingpin.Flag("enable-secret-support", "Enable support for Secrets on StackSets.").Default("false").BoolVar(&config.SecretSupportEnabled)
 	kingpin.Flag("enable-pcs-support", "Enable support for PlatformCredentialsSet on StackSets.").Default("false").BoolVar(&config.PCSSupportEnabled)
-	kingpin.Flag("enable-per-stack-hostname", "Enable support for per-stack hostnames.").Default("false").BoolVar(&config.PerStackHostnameEnabled)
+	kingpin.Flag("enable-per-stack-hostname", "Enable support for per-stack hostnames.").Default("true").BoolVar(&config.PerStackHostnameEnabled)
 	kingpin.Parse()
 
 	if config.Debug {

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -71,7 +71,7 @@ func main() {
 	kingpin.Flag("enable-configmap-support", "Enable support for ConfigMaps on StackSets.").Default("false").BoolVar(&config.ConfigMapSupportEnabled)
 	kingpin.Flag("enable-secret-support", "Enable support for Secrets on StackSets.").Default("false").BoolVar(&config.SecretSupportEnabled)
 	kingpin.Flag("enable-pcs-support", "Enable support for PlatformCredentialsSet on StackSets.").Default("false").BoolVar(&config.PCSSupportEnabled)
-	kingpin.Flag("enable-per-stack-hostname", "Enable support for per-stack hostnames.").Default("true").BoolVar(&config.PerStackHostnameEnabled)
+	kingpin.Flag("enable-per-stack-hostname", "Enable support for per-stack hostnames.").Default("false").BoolVar(&config.PerStackHostnameEnabled)
 	kingpin.Parse()
 
 	if config.Debug {

--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -47,6 +47,7 @@ var (
 		ConfigMapSupportEnabled     bool
 		SecretSupportEnabled        bool
 		PCSSupportEnabled           bool
+		PerStackHostnameEnabled     bool
 	}
 )
 
@@ -70,6 +71,7 @@ func main() {
 	kingpin.Flag("enable-configmap-support", "Enable support for ConfigMaps on StackSets.").Default("false").BoolVar(&config.ConfigMapSupportEnabled)
 	kingpin.Flag("enable-secret-support", "Enable support for Secrets on StackSets.").Default("false").BoolVar(&config.SecretSupportEnabled)
 	kingpin.Flag("enable-pcs-support", "Enable support for PlatformCredentialsSet on StackSets.").Default("false").BoolVar(&config.PCSSupportEnabled)
+	kingpin.Flag("enable-per-stack-hostname", "Enable support for per-stack hostnames.").Default("false").BoolVar(&config.PerStackHostnameEnabled)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -91,6 +93,7 @@ func main() {
 		ConfigMapSupportEnabled:  config.ConfigMapSupportEnabled,
 		SecretSupportEnabled:     config.SecretSupportEnabled,
 		PcsSupportEnabled:        config.PCSSupportEnabled,
+		PerStackHostnameEnabled:  config.PerStackHostnameEnabled,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/controller/stack_resources.go
+++ b/controller/stack_resources.go
@@ -188,8 +188,8 @@ func (c *StackSetController) ReconcileStackService(ctx context.Context, stack *z
 	return nil
 }
 
-func (c *StackSetController) ReconcileStackIngress(ctx context.Context, stack *zv1.Stack, existing *networking.Ingress, generateUpdated func() (*networking.Ingress, error)) error {
-	ingress, err := generateUpdated()
+func (c *StackSetController) ReconcileStackIngress(ctx context.Context, stack *zv1.Stack, existing *networking.Ingress, generateUpdated func(bool) (*networking.Ingress, error)) error {
+	ingress, err := generateUpdated(c.config.PerStackHostnameEnabled)
 	if err != nil {
 		return err
 	}

--- a/controller/stack_resources_test.go
+++ b/controller/stack_resources_test.go
@@ -788,7 +788,7 @@ func TestReconcileStackIngress(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = env.controller.ReconcileStackIngress(context.Background(), &tc.stack, tc.existing, func() (*networking.Ingress, error) {
+			err = env.controller.ReconcileStackIngress(context.Background(), &tc.stack, tc.existing, func(bool) (*networking.Ingress, error) {
 				return tc.updated, nil
 			})
 			require.NoError(t, err)

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -77,6 +77,7 @@ type StackSetConfig struct {
 	ConfigMapSupportEnabled  bool
 	SecretSupportEnabled     bool
 	PcsSupportEnabled        bool
+	PerStackHostnameEnabled  bool
 }
 
 type stacksetEvent struct {

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -342,15 +342,15 @@ func (sc *StackContainer) stackHostnames(
 	return result.List(), nil
 }
 
-func (sc *StackContainer) GenerateIngress() (*networking.Ingress, error) {
-	return sc.generateIngress(false)
+func (sc *StackContainer) GenerateIngress(perStackHostnameEnabled bool) (*networking.Ingress, error) {
+	return sc.generateIngress(false, perStackHostnameEnabled)
 }
 
-func (sc *StackContainer) GenerateIngressSegment() (
+func (sc *StackContainer) GenerateIngressSegment(perStackHostnameEnabled bool) (
 	*networking.Ingress,
 	error,
 ) {
-	res, err := sc.generateIngress(true)
+	res, err := sc.generateIngress(true, perStackHostnameEnabled)
 	if err != nil || res == nil {
 		return res, err
 	}
@@ -379,11 +379,15 @@ func (sc *StackContainer) GenerateIngressSegment() (
 	return res, nil
 }
 
-func (sc *StackContainer) generateIngress(segment bool) (
+func (sc *StackContainer) generateIngress(segment bool, perStackHostnameEnabled bool) (
 	*networking.Ingress,
 	error,
 ) {
 
+	// If Per-stack Hostnames are disabled, no need to generate per stack ingresses
+	if !perStackHostnameEnabled {
+		return nil, nil
+	}
 	if !sc.HasBackendPort() || sc.ingressSpec == nil {
 		return nil, nil
 	}

--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -384,8 +384,8 @@ func (sc *StackContainer) generateIngress(segment bool, perStackHostnameEnabled 
 	error,
 ) {
 
-	// If Per-stack Hostnames are disabled, no need to generate per stack ingresses
-	if !perStackHostnameEnabled {
+	// If Per-stack Hostnames and segments are disabled, no need to generate per stack ingresses
+	if !perStackHostnameEnabled && !segment {
 		return nil, nil
 	}
 	if !sc.HasBackendPort() || sc.ingressSpec == nil {

--- a/pkg/core/stack_resources_test.go
+++ b/pkg/core/stack_resources_test.go
@@ -322,7 +322,7 @@ func TestStackGenerateIngress(t *testing.T) {
 				backendPort:    &intStrBackendPort,
 				clusterDomains: []string{"example.org"},
 			}
-			ingress, err := c.GenerateIngress()
+			ingress, err := c.GenerateIngress(true)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -461,7 +461,7 @@ func TestStackGenerateIngressSegment(t *testing.T) {
 			segmentUpperLimit: tc.upperLimit,
 			backendPort:       &backendPort,
 		}
-		ingress, err := c.GenerateIngressSegment()
+		ingress, err := c.GenerateIngressSegment(true)
 
 		if (err != nil) != tc.expectError {
 			t.Errorf("expected error: %t , got %v", tc.expectError, err)
@@ -570,7 +570,7 @@ func TestGenerateIngressSegmentWithSyncAnnotations(t *testing.T) {
 			ingressAnnotationsToSync: tc.ingresssAnnotationsToSync,
 			syncAnnotationsInIngress: tc.syncAnnotationsInIngress,
 		}
-		res, _ := c.GenerateIngressSegment()
+		res, _ := c.GenerateIngressSegment(true)
 
 		delete(
 			res.Annotations,


### PR DESCRIPTION
This makes per-stack hostnames configurable in the stackset. 

This allows us to disable support for per-stack hostnames, which is required to solve the problem of duplication of hostnames when a stackset is deployed in multiple namespaces, or multiple clusters in the same account.

The objective is to first be able to disable the support, and then encourage the users that actually rely on this to use `.cluster.local` hostnames instead for their e2e testing.