### PR TITLE
separate public and private domains, allow to choose for stacks

### DIFF
--- a/cmd/stackset-controller/main.go
+++ b/cmd/stackset-controller/main.go
@@ -38,6 +38,8 @@ var (
 		Namespace                   string
 		MetricsAddress              string
 		ClusterDomains              []string
+		ClusterInternalDomains      []string
+		IgnorePublicDomainsOnStacks bool
 		NoTrafficScaledownTTL       time.Duration
 		ControllerID                string
 		BackendWeightsAnnotationKey string
@@ -62,6 +64,8 @@ func main() {
 		Default(defaultReconcileWorkers).IntVar(&config.ReconcileWorkers)
 	kingpin.Flag("backend-weights-key", "Backend weights annotation key the controller will use to set current traffic values").Default(traffic.DefaultBackendWeightsAnnotationKey).StringVar(&config.BackendWeightsAnnotationKey)
 	kingpin.Flag("cluster-domain", "Main domains of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_DOMAIN").Required().StringsVar(&config.ClusterDomains)
+	kingpin.Flag("cluster-internal-domain", "Main internal domains of the cluster, used for generating Stack Ingress hostnames").Envar("CLUSTER_INTERNAL_DOMAIN").StringsVar(&config.ClusterInternalDomains)
+	kingpin.Flag("ignore-public-domains-on-stacks", "If true, only --cluster-internal-domain is considered on Stack Ingresses and RouteGroups").Default("false").BoolVar(&config.IgnorePublicDomainsOnStacks)
 	kingpin.Flag("enable-routegroup-support", "Enable support for RouteGroups on StackSets.").Default("false").BoolVar(&config.RouteGroupSupportEnabled)
 	kingpin.Flag(
 		"sync-ingress-annotation",
@@ -81,6 +85,8 @@ func main() {
 		ControllerID: config.ControllerID,
 
 		ClusterDomains:              config.ClusterDomains,
+		ClusterInternalDomains:      config.ClusterInternalDomains,
+		IgnorePublicDomainsOnStacks: config.IgnorePublicDomainsOnStacks,
 		BackendWeightsAnnotationKey: config.BackendWeightsAnnotationKey,
 		SyncIngressAnnotations:      config.SyncIngressAnnotations,
 

--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -67,6 +67,8 @@ type StackSetConfig struct {
 	ControllerID string
 
 	ClusterDomains              []string
+	ClusterInternalDomains      []string
+	IgnorePublicDomainsOnStacks bool
 	BackendWeightsAnnotationKey string
 	SyncIngressAnnotations      []string
 
@@ -252,6 +254,8 @@ func (c *StackSetController) collectResources(ctx context.Context) (map[types.UI
 			reconciler,
 			c.config.BackendWeightsAnnotationKey,
 			c.config.ClusterDomains,
+			c.config.ClusterInternalDomains,
+			c.config.IgnorePublicDomainsOnStacks,
 			c.config.SyncIngressAnnotations,
 		)
 		stacksets[uid] = stacksetContainer


### PR DESCRIPTION
Alternative for https://github.com/zalando-incubator/stackset-controller/pull/696 so we can compare what the difference is.

It introduces two more flags and should be fully backwards compatible. The first new flag `--cluster-internal-domain` works similar to `--cluster-domain` but tells stackset-controller that it's an internal domain (e.g. `ingress.cluster.local`). By default external and internal domains are both processed (like today) so there's no change when moving a domain from `--cluster-domain` to `--cluster-internal-domain`.

However, the second flag `--ignore-public-domains-on-stacks` can be used to tell stackset-controller to not use public domains for stack hosts. So, once the domains have been split into two separate groups, this flag can be used to change the behaviour.

Below is the intended usage. The first example is the setup on current clusters, the second one will be the setup on legacy clusters and the third one will be the setup for EKS clusters (only difference is the value of the flag).

Imagine a stackset specifying the following ingress section:

```yaml
spec:
  ingress:
    hosts:
    - my-app.teapot.zalan.do
    - my-app.ingress.cluster.local
```

Running stackset-controller with the following configuration will result in the following:

`--cluster-domain teapot.zalan.do --cluster-domain ingress.cluster.local` (current setting)

| main ingress                                        | stack ingress                                             |
|-----------------------------------------------------|-----------------------------------------------------------|
| my-app.teapot.zalan.do my-app.ingress.cluster.local | my-app-v1.teapot.zalan.do my-app-v1.ingress.cluster.local |

That's the current result and backwards compatible.

Then, split cluster domains into a public and private group. There's no change and therefore backwards compatible.

`--cluster-domain teapot.zalan.do --cluster-internal-domain ingress.cluster.local` (future setting for legacy clusters)

| main ingress                                        | stack ingress                                             |
|-----------------------------------------------------|-----------------------------------------------------------|
| my-app.teapot.zalan.do my-app.ingress.cluster.local | my-app-v1.teapot.zalan.do my-app-v1.ingress.cluster.local |

Finally, switch the flip on EKS clusters to skip public domains on Stacks.

`--cluster-domain teapot.zalan.do --cluster-internal-domain ingress.cluster.local --ignore-public-domains-on-stacks` (future setting for EKS clusters)

| main ingress                                        | stack ingress                                             |
|-----------------------------------------------------|-----------------------------------------------------------|
| my-app.teapot.zalan.do my-app.ingress.cluster.local | my-app-v1.ingress.cluster.local                           |

The idea is to run with the public/private split and without `--ignore-public-domains-on-stacks` (false) on legacy clusters. On EKS clusters we would run it with `--ignore-public-domains-on-stacks`.

If the Stackset doesn't make use of the `ingress.cluster.local` domain in its definition, then the results above are the same but with the internal domain (i.e. just the `teapot.zalan.do` DNS names and no DNS name at all for the stack on EKS).