### PR TITLE
add controller id to the logger correctly

### DIFF
--- a/controller/stackset.go
+++ b/controller/stackset.go
@@ -108,8 +108,13 @@ func NewStackSetController(
 		return nil, err
 	}
 
+	controllerID := "stackset"
+	if config.ControllerID != "" {
+		controllerID = config.ControllerID
+	}
+
 	return &StackSetController{
-		logger:          log.WithFields(log.Fields{"controller": "stackset"}),
+		logger:          log.WithFields(log.Fields{"controller": controllerID}),
 		client:          client,
 		config:          config,
 		stacksetEvents:  make(chan stacksetEvent, 1),


### PR DESCRIPTION
The `controller` field in the logs currently has a hardcoded string `stackset`. This isn't helpful when we define the optional `controller-id` CLI parameter and run multiple controllers in a cluster for development/testing. 

This populates the field correctly with the `controllerID` if defined, and falls back to `stackset` as the value when none is provided. 