### PR TITLE
adapt traffic command to the possibility of missing non-segment routegroup/ingress

### DIFF
--- a/pkg/core/stack_resources.go
+++ b/pkg/core/stack_resources.go
@@ -318,10 +318,10 @@ func (sc *StackContainer) GenerateService() (*v1.Service, error) {
 func (sc *StackContainer) stackHostnames(
 	spec ingressOrRouteGroupSpec,
 	segment bool,
-) ([]string, error) {
+) []string {
 	// The Ingress segment uses the original hostnames
 	if segment {
-		return spec.GetHosts(), nil
+		return spec.GetHosts()
 	}
 	result := sets.NewString()
 
@@ -339,7 +339,7 @@ func (sc *StackContainer) stackHostnames(
 			}
 		}
 	}
-	return result.List(), nil
+	return result.List()
 }
 
 func (sc *StackContainer) GenerateIngress() (*networking.Ingress, error) {
@@ -388,10 +388,7 @@ func (sc *StackContainer) generateIngress(segment bool) (
 		return nil, nil
 	}
 
-	hostnames, err := sc.stackHostnames(sc.ingressSpec, segment)
-	if err != nil {
-		return nil, err
-	}
+	hostnames := sc.stackHostnames(sc.ingressSpec, segment)
 	if len(hostnames) == 0 {
 		return nil, nil
 	}
@@ -481,10 +478,7 @@ func (sc *StackContainer) generateRouteGroup(segment bool) (
 		return nil, nil
 	}
 
-	hostnames, err := sc.stackHostnames(sc.routeGroupSpec, segment)
-	if err != nil {
-		return nil, err
-	}
+	hostnames := sc.stackHostnames(sc.routeGroupSpec, segment)
 	if len(hostnames) == 0 {
 		return nil, nil
 	}

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -875,7 +875,7 @@ func TestStackUpdateFromResources(t *testing.T) {
 		container.ingressSpec = &zv1.StackSetIngressSpec{}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
-		container.Resources.Ingress = ingress(10)
+		container.Resources.Ingress = nil
 		container.Resources.IngressSegment = ingress(11)
 		container.updateFromResources()
 		require.EqualValues(t, true, container.resourcesUpdated)
@@ -923,7 +923,7 @@ func TestStackUpdateFromResources(t *testing.T) {
 		container.routeGroupSpec = &zv1.RouteGroupSpec{}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
-		container.Resources.RouteGroup = routegroup(10)
+		container.Resources.RouteGroup = nil
 		container.Resources.RouteGroupSegment = routegroup(11)
 		container.updateFromResources()
 		require.EqualValues(t, true, container.resourcesUpdated)

--- a/pkg/core/stackset_test.go
+++ b/pkg/core/stackset_test.go
@@ -860,13 +860,25 @@ func TestStackUpdateFromResources(t *testing.T) {
 
 	runTest("ingress isn't considered updated if the generation is different", func(t *testing.T, container *StackContainer) {
 		container.Stack.Generation = 11
-		container.ingressSpec = &zv1.StackSetIngressSpec{}
+		container.ingressSpec = &zv1.StackSetIngressSpec{
+			Hosts: []string{"foo.example.org"},
+		}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
 		container.Resources.Ingress = ingress(10)
 		container.Resources.IngressSegment = ingress(11)
 		container.updateFromResources()
 		require.EqualValues(t, false, container.resourcesUpdated)
+	})
+	runTest("ingress is considered updated if no hostname matches cluster domain", func(t *testing.T, container *StackContainer) {
+		container.Stack.Generation = 11
+		container.ingressSpec = &zv1.StackSetIngressSpec{}
+		container.Resources.Deployment = deployment(11, 5, 5)
+		container.Resources.Service = service(11)
+		container.Resources.Ingress = ingress(10)
+		container.Resources.IngressSegment = ingress(11)
+		container.updateFromResources()
+		require.EqualValues(t, true, container.resourcesUpdated)
 	})
 	runTest("ingress isn't considered updated if it should be gone", func(t *testing.T, container *StackContainer) {
 		container.Stack.Generation = 11
@@ -896,13 +908,25 @@ func TestStackUpdateFromResources(t *testing.T) {
 	})
 	runTest("routegroup isn't considered updated if the generation is different", func(t *testing.T, container *StackContainer) {
 		container.Stack.Generation = 11
-		container.routeGroupSpec = &zv1.RouteGroupSpec{}
+		container.routeGroupSpec = &zv1.RouteGroupSpec{
+			Hosts: []string{"foo.example.org"},
+		}
 		container.Resources.Deployment = deployment(11, 5, 5)
 		container.Resources.Service = service(11)
 		container.Resources.RouteGroup = routegroup(10)
 		container.Resources.RouteGroupSegment = routegroup(11)
 		container.updateFromResources()
 		require.EqualValues(t, false, container.resourcesUpdated)
+	})
+	runTest("routegroup is considered updated if no hostname matches cluster domain", func(t *testing.T, container *StackContainer) {
+		container.Stack.Generation = 11
+		container.routeGroupSpec = &zv1.RouteGroupSpec{}
+		container.Resources.Deployment = deployment(11, 5, 5)
+		container.Resources.Service = service(11)
+		container.Resources.RouteGroup = routegroup(10)
+		container.Resources.RouteGroupSegment = routegroup(11)
+		container.updateFromResources()
+		require.EqualValues(t, true, container.resourcesUpdated)
 	})
 	runTest("routegroup isn't considered updated if it should be gone", func(t *testing.T, container *StackContainer) {
 		container.Stack.Generation = 11

--- a/pkg/core/test_helpers.go
+++ b/pkg/core/test_helpers.go
@@ -22,7 +22,8 @@ type testStackFactory struct {
 func testStack(name string) *testStackFactory {
 	return &testStackFactory{
 		container: &StackContainer{
-			backendPort: &intStrTestPort,
+			clusterDomains: []string{"example.org"},
+			backendPort:    &intStrTestPort,
 			Stack: &zv1.Stack{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name,

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -441,9 +441,12 @@ func (sc *StackContainer) updateFromResources() {
 	if sc.ingressSpec != nil {
 		// the per-stack ingress must either be present and up-to-date, or not present and not expected.
 		// the per-stack ingress is not expected if the stack has no hostnames matching the cluster domain.
-		hostnames := sc.stackHostnames(sc.ingressSpec, false)
-		ingressNotExpected := len(hostnames) == 0
-		ingressUpdated = sc.Resources.Ingress == nil && ingressNotExpected || sc.Resources.Ingress != nil && IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
+		if sc.Resources.Ingress != nil {
+			ingressUpdated = IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
+		} else {
+			hostnames := sc.stackHostnames(sc.ingressSpec, false)
+			ingressUpdated = len(hostnames) == 0
+		}
 		ingressSegmentUpdated = sc.Resources.IngressSegment != nil &&
 			IsResourceUpToDate(sc.Stack, sc.Resources.IngressSegment.ObjectMeta)
 	} else {
@@ -456,9 +459,12 @@ func (sc *StackContainer) updateFromResources() {
 	if sc.routeGroupSpec != nil {
 		// the per-stack route group must either be present and up-to-date, or not present and not expected.
 		// the per-stack route group is not expected if the stack has no hostnames matching the cluster domain.
-		hostnames := sc.stackHostnames(sc.routeGroupSpec, false)
-		routeGroupNotExpected := len(hostnames) == 0
-		routeGroupUpdated = sc.Resources.RouteGroup == nil && routeGroupNotExpected || sc.Resources.RouteGroup != nil && IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
+		if sc.Resources.RouteGroup != nil {
+			routeGroupUpdated = IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
+		} else {
+			hostnames := sc.stackHostnames(sc.routeGroupSpec, false)
+			routeGroupUpdated = len(hostnames) == 0
+		}
 		routeGroupSegmentUpdated = sc.Resources.RouteGroupSegment != nil &&
 			IsResourceUpToDate(
 				sc.Stack,

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -439,8 +439,11 @@ func (sc *StackContainer) updateFromResources() {
 
 	// ingress: ignore if ingress is not set or check if we are up to date
 	if sc.ingressSpec != nil {
+		// the per-stack ingress must either be present and up-to-date, or not present and not expected.
+		// the per-stack ingress is not expected if the stack has no hostnames matching the cluster domain.
 		hostnames := sc.stackHostnames(sc.ingressSpec, false)
-		ingressUpdated = len(hostnames) == 0 || sc.Resources.Ingress != nil && IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
+		ingressNotExpected := len(hostnames) == 0
+		ingressUpdated = sc.Resources.Ingress == nil && ingressNotExpected || sc.Resources.Ingress != nil && IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
 		ingressSegmentUpdated = sc.Resources.IngressSegment != nil &&
 			IsResourceUpToDate(sc.Stack, sc.Resources.IngressSegment.ObjectMeta)
 	} else {
@@ -451,8 +454,11 @@ func (sc *StackContainer) updateFromResources() {
 
 	// routegroup: ignore if routegroup is not set or check if we are up to date
 	if sc.routeGroupSpec != nil {
+		// the per-stack route group must either be present and up-to-date, or not present and not expected.
+		// the per-stack route group is not expected if the stack has no hostnames matching the cluster domain.
 		hostnames := sc.stackHostnames(sc.routeGroupSpec, false)
-		routeGroupUpdated = len(hostnames) == 0 || sc.Resources.RouteGroup != nil && IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
+		routeGroupNotExpected := len(hostnames) == 0
+		routeGroupUpdated = sc.Resources.RouteGroup == nil && routeGroupNotExpected || sc.Resources.RouteGroup != nil && IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
 		routeGroupSegmentUpdated = sc.Resources.RouteGroupSegment != nil &&
 			IsResourceUpToDate(
 				sc.Stack,

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -439,18 +439,20 @@ func (sc *StackContainer) updateFromResources() {
 
 	// ingress: ignore if ingress is not set or check if we are up to date
 	if sc.ingressSpec != nil {
-		ingressUpdated = sc.Resources.Ingress != nil && IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
+		hostnames := sc.stackHostnames(sc.ingressSpec, false)
+		ingressUpdated = len(hostnames) == 0 || sc.Resources.Ingress != nil && IsResourceUpToDate(sc.Stack, sc.Resources.Ingress.ObjectMeta)
 		ingressSegmentUpdated = sc.Resources.IngressSegment != nil &&
 			IsResourceUpToDate(sc.Stack, sc.Resources.IngressSegment.ObjectMeta)
 	} else {
 		// ignore if ingress is not set
 		ingressUpdated = sc.Resources.Ingress == nil
-		ingressSegmentUpdated = sc.Resources.Ingress == nil
+		ingressSegmentUpdated = sc.Resources.IngressSegment == nil
 	}
 
 	// routegroup: ignore if routegroup is not set or check if we are up to date
 	if sc.routeGroupSpec != nil {
-		routeGroupUpdated = sc.Resources.RouteGroup != nil && IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
+		hostnames := sc.stackHostnames(sc.routeGroupSpec, false)
+		routeGroupUpdated = len(hostnames) == 0 || sc.Resources.RouteGroup != nil && IsResourceUpToDate(sc.Stack, sc.Resources.RouteGroup.ObjectMeta)
 		routeGroupSegmentUpdated = sc.Resources.RouteGroupSegment != nil &&
 			IsResourceUpToDate(
 				sc.Stack,
@@ -459,7 +461,7 @@ func (sc *StackContainer) updateFromResources() {
 	} else {
 		// ignore if route group is not set
 		routeGroupUpdated = sc.Resources.RouteGroup == nil
-		routeGroupSegmentUpdated = sc.Resources.RouteGroup == nil
+		routeGroupSegmentUpdated = sc.Resources.RouteGroupSegment == nil
 	}
 
 	// hpa


### PR DESCRIPTION
Follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/9677

When public domains are filtered out on Stacks, like in the PR above, it can happen that individual Stacks don't have any RouteGroup or Ingress (besides the traffic segment). This trips up the traffic switch command as it waits for both the legacy ingress/routegroups as well as the traffic segments to become ready. The former doesn't exist so it never happens and hangs.

This change makes `stackset-controller` consider the RouteGroup "ready" when it wouldn't have any hostnames matching any cluster domains anyway. The respective code for not creating the RouteGroup/Ingress in this case is [here](https://github.com/zalando-incubator/stackset-controller/blob/735edd31a7f352a9cfc5b11ea07908d6886916b1/pkg/core/stack_resources.go#L489). 

Traffic switching these days works entirely via the Traffic Segment RouteGroup/Ingresses, so maybe the old ones shouldn't be considered _at all_ anymore. This is one step in this direction where it ignores them if it doesn't create them in the first place.