### PR TITLE
Make forward compatible with pre-scale

### DIFF
--- a/pkg/core/test_helpers.go
+++ b/pkg/core/test_helpers.go
@@ -99,6 +99,14 @@ func (f *testStackFactory) pendingRemoval() *testStackFactory {
 	return f
 }
 
+func (f *testStackFactory) trafficForward() *testStackFactory {
+	if f.container.Stack.Annotations == nil {
+		f.container.Stack.Annotations = map[string]string{}
+	}
+	f.container.Stack.Annotations[forwardBackendAnnotation] = forwardBackendName
+	return f
+}
+
 func (f *testStackFactory) prescaling(replicas int32, desiredTrafficWeight float64, lastTrafficIncrease time.Time) *testStackFactory {
 	f.container.prescalingActive = true
 	f.container.prescalingReplicas = replicas

--- a/pkg/core/traffic_prescaling.go
+++ b/pkg/core/traffic_prescaling.go
@@ -41,6 +41,13 @@ func (r PrescalingTrafficReconciler) Reconcile(stacks map[string]*StackContainer
 
 	// Prescale stacks if needed
 	for _, stack := range stacks {
+		// Stacks configured to forward traffic to another cluster don't
+		// have a deployment of their own, so prescaling doesn't apply
+		// to them.
+		if stack.TrafficForward() {
+			continue
+		}
+
 		// If traffic needs to be increased
 		if stack.desiredTrafficWeight > stack.actualTrafficWeight {
 			// If prescaling is not active, or desired weight changed since the last prescaling attempt, update
@@ -86,7 +93,11 @@ func (r PrescalingTrafficReconciler) Reconcile(stacks map[string]*StackContainer
 	actualWeights := make(map[string]float64, len(stacks))
 	for stackName, stack := range stacks {
 		// Check if we're increasing traffic but the stack is not ready
-		if stack.desiredTrafficWeight > stack.actualTrafficWeight {
+		if stack.desiredTrafficWeight > stack.actualTrafficWeight && !stack.TrafficForward() {
+			// Stacks configured to forward traffic to another cluster
+			// don't have a deployment of their own here, so replica
+			// based readiness/prescaling checks don't apply to them
+			// (see stack.IsReady() for the same exception).
 			var desiredReplicas = stack.deploymentReplicas
 			if stack.prescalingActive {
 				desiredReplicas = stack.prescalingReplicas

--- a/pkg/core/traffic_test.go
+++ b/pkg/core/traffic_test.go
@@ -874,6 +874,21 @@ func TestTrafficSwitchPrescaling(t *testing.T) {
 			},
 			expectedError: "stacks not ready: foo-v1, foo-v3",
 		},
+		{
+			name: "forwarded stacks are not subject to prescaling readiness checks",
+			stacks: map[types.UID]*StackContainer{
+				"foo-v1": testStack("foo-v1").traffic(0, 100).ready(3).stack(),
+				"foo-v2": testStack("foo-v2").traffic(100, 0).trafficForward().stack(),
+			},
+			expectedDesiredWeights: map[string]float64{
+				"foo-v1": 0,
+				"foo-v2": 100,
+			},
+			expectedActualWeights: map[string]float64{
+				"foo-v1": 0,
+				"foo-v2": 100,
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := StackSetContainer{


### PR DESCRIPTION
This fixes a bug where forward (#716, #721)  in combination with `alpha.stackset-controller.zalando.org/prescale-stacks` would not work and switching traffic to a forwarded stack would get stuck because the "virtual" stack was not ready.

The solution is to not check for readiness of the underlying deployment, as there is no underlying deployment when the stack is marked for forwarding.